### PR TITLE
feat(modloader): 插件命令前缀支持

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-app"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/adapter/pyproject.toml
+++ b/packages/adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-adapter"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/chat/pyproject.toml
+++ b/packages/chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-chat"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-contracts"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 description = "Cross-module domain models and port interfaces for NeoBot"
 readme = "README.md"
 authors = [

--- a/packages/memory/pyproject.toml
+++ b/packages/memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-memory"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/modloader/README.md
+++ b/packages/modloader/README.md
@@ -45,6 +45,20 @@ async def ping(args: str | None, reply: Reply):
 
 用户发送 `/ping hello` 时，`args` 会得到 `"hello"`。
 
+插件可通过 `Plugin(command_prefix="#")` 为全部命令设置固定前缀。若插件配置模型包含
+`command_prefix` 字段，加载时经过校验的配置值会自动覆盖该默认值：
+
+```python
+class Config(BaseModel):
+    command_prefix: str = "/"
+
+
+plugin = Plugin("ping", config=Config)
+```
+
+单个命令仍可用 `@plugin.command("ping", prefix="!")` 覆盖插件全局前缀。
+空字符串表示无前缀；前缀不能包含空白字符。
+
 ## 消息链
 
 处理器可以注入标准化后的 `Message` 对象。它会优先从 `event["message"]` 读取 OneBot 消息链；如果没有消息链，才使用 `raw_message` 作为纯文本兜底。

--- a/packages/modloader/pyproject.toml
+++ b/packages/modloader/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-modloader"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/modloader/src/neobot_modloader/command_dsl.py
+++ b/packages/modloader/src/neobot_modloader/command_dsl.py
@@ -41,15 +41,17 @@ class MessagePattern:
         *,
         command: bool = False,
         aliases: tuple[str, ...] = (),
+        prefix: str = "/",
     ) -> None:
         self.pattern = (pattern or "").strip()
         self.command = command
         self.aliases = tuple(aliases)
         self.elements = _parse_pattern(self.pattern)
+        self.prefix = _validate_command_prefix(prefix) if command else prefix
         if self.command:
             if not self.elements or self.elements[0].kind != "literal":
                 raise PatternError("command pattern must start with a command name")
-            self.command_name = self.elements[0].value.lstrip("/")
+            self.command_name = self.elements[0].value.removeprefix(self.prefix)
             self.body = self.elements[1:]
         else:
             self.command_name = ""
@@ -66,23 +68,23 @@ class MessagePattern:
     @property
     def usage(self) -> str:
         return (
-            f"/{self.pattern}"
-            if self.command and not self.pattern.startswith("/")
+            f"{self.prefix}{self.pattern}"
+            if self.command and not self.pattern.startswith(self.prefix)
             else self.pattern
         )
 
     def match(self, message: Message) -> PatternMatch:
         tokens = _message_tokens(message)
         if self.command:
-            command_index = _find_command(tokens)
+            command_index = _find_command(tokens, self.prefix)
             if command_index is None:
                 return PatternMatch(False, {}, command_matched=False)
             raw = tokens[command_index]
             assert isinstance(raw, str)
-            command_name = raw.lstrip("/")
+            command_name = raw.removeprefix(self.prefix)
             allowed = {
                 self.command_name.lower(),
-                *(alias.lower().lstrip("/") for alias in self.aliases),
+                *(alias.removeprefix(self.prefix).lower() for alias in self.aliases),
             }
             if command_name.lower() not in allowed:
                 return PatternMatch(False, {}, command_matched=False)
@@ -214,11 +216,21 @@ def _split_text(value: str) -> list[str]:
         return value.split()
 
 
-def _find_command(tokens: list[str | MessageSegment]) -> int | None:
+def _find_command(
+    tokens: list[str | MessageSegment], prefix: str = "/"
+) -> int | None:
     for index, token in enumerate(tokens):
-        if isinstance(token, str) and token.startswith("/") and len(token) > 1:
+        if isinstance(token, str) and token.startswith(prefix) and len(token) > len(prefix):
             return index
     return None
+
+
+def _validate_command_prefix(prefix: str) -> str:
+    if not isinstance(prefix, str):
+        raise PatternError("command prefix must be a string")
+    if any(char.isspace() for char in prefix):
+        raise PatternError("command prefix cannot contain whitespace")
+    return prefix
 
 
 def _match_elements(

--- a/packages/modloader/src/neobot_modloader/plugin.py
+++ b/packages/modloader/src/neobot_modloader/plugin.py
@@ -39,6 +39,7 @@ class Plugin:
         usage: str = "",
         author: str = "",
         config: type[BaseModel] | None = None,
+        command_prefix: str = "/",
         dependencies: Sequence[str] = (),
         priority: int = 0,
         min_neobot_version: str | None = None,
@@ -50,6 +51,9 @@ class Plugin:
         self.usage = usage
         self.author = author
         self.config_model = config
+        self.command_prefix = MessagePattern(
+            "_prefix_validation", command=True, prefix=command_prefix
+        ).prefix
         self.dependencies = tuple(dependencies)
         self.priority = int(priority)
         self.min_neobot_version = min_neobot_version
@@ -98,6 +102,7 @@ class Plugin:
         self,
         pattern: str,
         *,
+        prefix: str | None = None,
         aliases: Sequence[str] | None = None,
         priority: int = 10,
         block: bool = True,
@@ -110,7 +115,12 @@ class Plugin:
         not parse is treated as unhandled: it neither runs the handler nor
         applies this registration's block settings.
         """
-        compiled = MessagePattern(pattern, command=True, aliases=tuple(aliases or ()))
+        compiled = MessagePattern(
+            pattern,
+            command=True,
+            aliases=tuple(aliases or ()),
+            prefix=prefix if prefix is not None else self.command_prefix,
+        )
         validate_parse_error(parse_error)
 
         def decorate(handler: Handler) -> Handler:
@@ -124,6 +134,7 @@ class Plugin:
                     block_ai_reply=False,
                     timeout=timeout,
                     parse_error=parse_error,
+                    command_prefix=prefix,
                 )
             )
             return handler
@@ -342,6 +353,7 @@ class Plugin:
         )
         await self._bind_databases()
         if not self._bound:
+            self._apply_command_prefix()
             # 订阅、Tool、SKILL.md 和 Agent 只绑定一次；reload/stop 会由 manager 清理旧绑定。
             bind_handlers(self, self._registrations, context)
             await bind_tools(self, self._tool_registrations, context)
@@ -350,6 +362,33 @@ class Plugin:
             self._bound = True
         for handler in self._load_handlers:
             await self._call_lifecycle(handler)
+
+    def _apply_command_prefix(self) -> None:
+        prefix = self.command_prefix
+        configured = getattr(self._config, "command_prefix", None)
+        if configured is not None:
+            prefix = MessagePattern(
+                "_prefix_validation", command=True, prefix=configured
+            ).prefix
+        for registration in self._registrations:
+            if registration.kind != "command" or registration.command_prefix is not None:
+                continue
+            old_prefix = registration.pattern.prefix
+            pattern = registration.pattern.pattern
+            if old_prefix and pattern.startswith(old_prefix):
+                pattern = pattern.removeprefix(old_prefix)
+            aliases = tuple(
+                alias.removeprefix(old_prefix)
+                if old_prefix and alias.startswith(old_prefix)
+                else alias
+                for alias in registration.pattern.aliases
+            )
+            registration.pattern = MessagePattern(
+                pattern,
+                command=True,
+                aliases=aliases,
+                prefix=prefix,
+            )
 
     async def _bind_databases(self) -> None:
         if not self._databases:

--- a/packages/modloader/src/neobot_modloader/plugins/registration.py
+++ b/packages/modloader/src/neobot_modloader/plugins/registration.py
@@ -32,6 +32,7 @@ class HandlerRegistration:
     endswith: str | None = None
     fullmatch: str | None = None
     rule: Callable[[dict[str, Any]], Any] | None = None
+    command_prefix: str | None = None
 
 
 @dataclass(slots=True)

--- a/packages/modloader/tests/test_command_dsl.py
+++ b/packages/modloader/tests/test_command_dsl.py
@@ -19,6 +19,44 @@ class CommandDslTest(unittest.TestCase):
         self.assertTrue(missing.matched)
         self.assertIsNone(missing.values["city"])
 
+    def test_command_custom_prefix(self) -> None:
+        pattern = MessagePattern("签到", command=True, prefix="#")
+
+        self.assertEqual(pattern.usage, "#签到")
+        self.assertTrue(pattern.match(Message({"raw_message": "#签到"})).matched)
+        self.assertFalse(pattern.match(Message({"raw_message": "/签到"})).matched)
+        self.assertFalse(pattern.match(Message({"raw_message": "签到"})).matched)
+
+    def test_command_custom_prefix_with_args_and_alias(self) -> None:
+        pattern = MessagePattern(
+            "出售 <target:str>", command=True, prefix="!", aliases=("sell",)
+        )
+
+        result = pattern.match(Message({"raw_message": "!出售 鲫鱼"}))
+        self.assertTrue(result.matched)
+        self.assertEqual(result.values["target"], "鲫鱼")
+        self.assertTrue(pattern.match(Message({"raw_message": "!sell 草鱼"})).matched)
+        self.assertFalse(pattern.match(Message({"raw_message": "/出售 鲫鱼"})).matched)
+
+    def test_command_default_prefix_unchanged(self) -> None:
+        pattern = MessagePattern("签到", command=True)
+
+        self.assertEqual(pattern.usage, "/签到")
+        self.assertTrue(pattern.match(Message({"raw_message": "/签到"})).matched)
+        self.assertFalse(pattern.match(Message({"raw_message": "#签到"})).matched)
+
+    def test_command_allows_empty_prefix(self) -> None:
+        pattern = MessagePattern("签到", command=True, prefix="")
+
+        self.assertEqual(pattern.usage, "签到")
+        self.assertTrue(pattern.match(Message({"raw_message": "签到"})).matched)
+        self.assertFalse(pattern.match(Message({"raw_message": "/签到"})).matched)
+        self.assertFalse(pattern.match(Message({"raw_message": "你好 签到"})).matched)
+
+    def test_command_rejects_whitespace_prefix(self) -> None:
+        with self.assertRaises(PatternError):
+            MessagePattern("签到", command=True, prefix="bot ")
+
     def test_command_coerces_basic_types(self) -> None:
         pattern = MessagePattern("debug <enabled:bool> <count:int> <ratio:float>", command=True)
 

--- a/packages/modloader/tests/test_integration.py
+++ b/packages/modloader/tests/test_integration.py
@@ -441,6 +441,111 @@ class IntegrationTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(self.mock_adapter.send.call_args.args[1], "pong")
 
+    async def test_e2e_global_command_prefix_from_config(self) -> None:
+        self._write_pkg(
+            "prefixed",
+            textwrap.dedent(
+                """\
+                from pydantic import BaseModel
+                from neobot_modloader import Plugin, Reply
+
+                class Config(BaseModel):
+                    command_prefix: str = "/"
+
+                plugin = Plugin("prefixed", config=Config)
+
+                @plugin.command("ping")
+                async def ping(reply: Reply):
+                    await reply.send("pong")
+                """
+            ),
+            manifest='name = "prefixed"\n[config]\ncommand_prefix = "#"\n',
+        )
+
+        self.runtime.load_all()
+        await self.runtime.load_registered()
+        await self.runtime.start_all()
+        slash = await self._dispatch(
+            {"post_type": "message", "message_type": "private", "user_id": 1, "raw_message": "/ping"}
+        )
+        custom = await self._dispatch(
+            {"post_type": "message", "message_type": "private", "user_id": 1, "raw_message": "#ping"}
+        )
+
+        self.assertFalse(slash.consumed)
+        self.assertTrue(custom.consumed)
+        self.assertEqual(self.mock_adapter.send.call_args.args[1], "pong")
+
+    async def test_e2e_command_prefix_override_wins(self) -> None:
+        self._write_pkg(
+            "prefixed",
+            textwrap.dedent(
+                """\
+                from pydantic import BaseModel
+                from neobot_modloader import Plugin, Reply
+
+                class Config(BaseModel):
+                    command_prefix: str = "#"
+
+                plugin = Plugin("prefixed", config=Config)
+
+                @plugin.command("ping", prefix="!")
+                async def ping(reply: Reply):
+                    await reply.send("pong")
+                """
+            ),
+            manifest='name = "prefixed"\n[config]\ncommand_prefix = "#"\n',
+        )
+
+        self.runtime.load_all()
+        await self.runtime.load_registered()
+        await self.runtime.start_all()
+        global_prefix = await self._dispatch(
+            {"post_type": "message", "message_type": "private", "user_id": 1, "raw_message": "#ping"}
+        )
+        override = await self._dispatch(
+            {"post_type": "message", "message_type": "private", "user_id": 1, "raw_message": "!ping"}
+        )
+
+        self.assertFalse(global_prefix.consumed)
+        self.assertTrue(override.consumed)
+        self.assertEqual(self.mock_adapter.send.call_args.args[1], "pong")
+
+    async def test_e2e_global_prefix_normalizes_prefixed_pattern_and_alias(self) -> None:
+        self._write_pkg(
+            "prefixed",
+            textwrap.dedent(
+                """\
+                from pydantic import BaseModel
+                from neobot_modloader import Plugin, Reply
+
+                class Config(BaseModel):
+                    command_prefix: str = "#"
+
+                plugin = Plugin("prefixed", config=Config)
+
+                @plugin.command("/ping", aliases=("/p",))
+                async def ping(reply: Reply):
+                    await reply.send("pong")
+                """
+            ),
+            manifest='name = "prefixed"\n[config]\ncommand_prefix = "#"\n',
+        )
+
+        self.runtime.load_all()
+        await self.runtime.load_registered()
+        await self.runtime.start_all()
+        command = await self._dispatch(
+            {"post_type": "message", "message_type": "private", "user_id": 1, "raw_message": "#ping"}
+        )
+        alias = await self._dispatch(
+            {"post_type": "message", "message_type": "private", "user_id": 1, "raw_message": "#p"}
+        )
+
+        self.assertTrue(command.consumed)
+        self.assertTrue(alias.consumed)
+        self.assertEqual(self.mock_adapter.send.call_count, 2)
+
     async def test_e2e_agent_handler_registration(self) -> None:
         self._write_pkg(
             "helper",

--- a/packages/storage/pyproject.toml
+++ b/packages/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-storage"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 description = "Storage layer for NeoBot — SQLAlchemy + Alembic"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 description = "a QQ LLM Bot "
 requires-python = ">=3.13"
 authors = [


### PR DESCRIPTION
## 变更

modloader 插件命令前缀支持：

- `Plugin(command_prefix="/")` 插件级默认前缀；配置模型含 `command_prefix` 字段时，加载阶段以校验后的配置值自动覆盖（无需逐命令指定）
- `@plugin.command(..., prefix="!")` 保留单命令覆盖
- 空前缀合法：命令直接以消息首个文本 token 匹配（如 `签到`）
- 前缀不能包含空白字符
- MessagePattern 匹配/usage 均按前缀归一化；对已带前缀的 pattern/别名自动规范化，避免双前缀

## 测试

- `test_command_dsl.py`：自定义/多字符/空前缀、参数与别名、非法前缀
- `test_integration.py`：配置注入全局前缀、单命令覆盖、预置前缀归一化（端到端）

`pytest packages/modloader/tests`：456 passed, 4 skipped

## 版本

1.0.0-alpha.14 → 1.0.0-alpha.15
