### PR TITLE
fix(pypi): 修复 Linux 依赖安装

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "pikepdf>=9.0",
     "playwright>=1.55.0",
     "pypdf>=6.7",
-    "pywin32>=310",
     "python-docx>=1.1.0",
     "python-dotenv>=1.2.2",
     "readability-lxml>=0.8.0",
@@ -42,7 +41,6 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0",
     "tomlkit",
     "trafilatura>=2.0.0",
-    "union",
     "lunarcalendar>=0.0.9",
     "xlsxwriter>=3.2",
 ]


### PR DESCRIPTION
## 问题

neobot-app 无条件声明了仅支持 Windows 的 pywin32，导致 Linux 安装无法正确解析依赖；同时未使用的 union 会传递引入要求 Python <3.13 的 flytekit，与项目要求的 Python 3.13 冲突。

## 修改

- 移除未使用的 pywin32 直接依赖
- 移除未使用的 union 及其冲突的传递依赖链
- 保留 drissionpage>=4.1，确保浏览器模块自动安装

仓库全量搜索确认没有代码导入 pywin32 提供的模块。现有 Windows 功能使用标准库 winreg、ctypes.wintypes 和 msvcrt，不依赖 pywin32。

## 验证

- uv run pytest: 1595 passed, 4 skipped
- uv run ruff check app/src app/tests packages: passed
- uv pip check: all installed packages are compatible
- uv build --package neobot-app: passed
- wheel METADATA 保留 Requires-Dist: drissionpage>=4.1，不再包含 pywin32、union