### PR TITLE
chore: bump versions to 1.0.0-alpha.16

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-app"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/adapter/pyproject.toml
+++ b/packages/adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-adapter"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/chat/pyproject.toml
+++ b/packages/chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-chat"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-contracts"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 description = "Cross-module domain models and port interfaces for NeoBot"
 readme = "README.md"
 authors = [

--- a/packages/memory/pyproject.toml
+++ b/packages/memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-memory"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/modloader/pyproject.toml
+++ b/packages/modloader/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-modloader"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/storage/pyproject.toml
+++ b/packages/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-storage"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 description = "Storage layer for NeoBot — SQLAlchemy + Alembic"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 description = "a QQ LLM Bot "
 requires-python = ">=3.13"
 authors = [


### PR DESCRIPTION
## 修改

- 将 NeoBot 根项目及 7 个工作区包版本统一提升至 1.0.0-alpha.16
- 保持独立参考项目 reference/plugin-htmlkit 的版本不变

## 验证

- uv lock --check: passed
- uv build --all-packages: passed
- 成功生成 7 组 1.0.0a16 wheel 和 sdist 发布产物