### PR TITLE
fix(browser): 兼容新版 Playwright

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-app"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/app/src/neobot_app/bootstrap/_runtime.py
+++ b/app/src/neobot_app/bootstrap/_runtime.py
@@ -24,15 +24,14 @@ def _auto_install_chromium() -> bool:
 
     logger = LoguruLoggerFactory().get_logger("app.bootstrap")
     try:
-        from playwright._impl._driver import compute_driver_executable, get_driver_dir
         import subprocess
+        import sys
 
-        driver_path = get_driver_dir()
-        driver_exe = compute_driver_executable()
-        cli = Path(driver_path) / driver_exe
+        __import__("playwright")
+
         logger.info("未检测到浏览器，正在自动下载 Chromium（约 150MB）…")
         result = subprocess.run(
-            [str(cli), "install", "chromium"],
+            [sys.executable, "-m", "playwright", "install", "chromium"],
             capture_output=True, timeout=300,
         )
         if result.returncode == 0:
@@ -44,7 +43,7 @@ def _auto_install_chromium() -> bool:
     except ImportError:
         logger.info(
             "playwright 未安装，跳过自动下载。"
-            "如需浏览器功能请: pip install playwright && playwright install chromium"
+            "如需浏览器功能请: pip install playwright && python -m playwright install chromium"
         )
         return False
     except Exception as exc:

--- a/app/src/neobot_app/browser/agent_browser/manager.py
+++ b/app/src/neobot_app/browser/agent_browser/manager.py
@@ -89,7 +89,9 @@ def _playwright_chromium_path() -> str:
     if _WINDOWS:
         candidates = list((home / "AppData" / "Local" / "ms-playwright").glob("chromium-*/chrome-win/chrome.exe"))
     elif platform.system() == "Linux":
-        candidates = list((home / ".cache" / "ms-playwright").glob("chromium-*/chrome-linux/chrome"))
+        browser_cache = home / ".cache" / "ms-playwright"
+        candidates = list(browser_cache.glob("chromium-*/chrome-linux/chrome"))
+        candidates.extend(browser_cache.glob("chromium-*/chrome-linux64/chrome"))
     elif platform.system() == "Darwin":
         candidates = list((home / "Library" / "Caches" / "ms-playwright").glob("chromium-*/chrome-mac/Chromium.app/Contents/MacOS/Chromium"))
     else:

--- a/app/src/neobot_app/cli.py
+++ b/app/src/neobot_app/cli.py
@@ -6,7 +6,6 @@ import argparse
 import asyncio
 import signal
 import sys
-from pathlib import Path
 
 from neobot_app.bootstrap import create_application
 from neobot_app.config.loader.manager import ConfigLoadError
@@ -160,7 +159,7 @@ def cmd_install_browser(args: argparse.Namespace) -> None:
     print("需要安装 playwright: pip install playwright")
     print()
     try:
-        from playwright._impl._driver import compute_driver_executable, get_driver_dir
+        __import__("playwright")
     except ImportError:
         print("请先安装 playwright: pip install playwright")
         print("或通过 CHROME_PATH 环境变量指定已安装的浏览器路径。")
@@ -168,11 +167,8 @@ def cmd_install_browser(args: argparse.Namespace) -> None:
 
     try:
         import subprocess
-        driver_path = get_driver_dir()
-        driver_exe = compute_driver_executable()
-        cli = Path(driver_path) / driver_exe
         result = subprocess.run(
-            [str(cli), "install", "chromium"],
+            [sys.executable, "-m", "playwright", "install", "chromium"],
             capture_output=False, text=True,
         )
         if result.returncode != 0:

--- a/app/tests/modules/browser/test_manager.py
+++ b/app/tests/modules/browser/test_manager.py
@@ -13,7 +13,9 @@ import asyncio
 import base64
 import builtins
 import gc
+import subprocess
 import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -21,6 +23,7 @@ from DrissionPage.errors import PageDisconnectedError
 
 from neobot_app.browser.agent_browser import manager as manager_module
 from neobot_app.browser.agent_browser.manager import BrowserManager
+from neobot_app.bootstrap._runtime import _auto_install_chromium
 
 
 @pytest.fixture(autouse=True)
@@ -52,6 +55,44 @@ class _BrokenPage:
 
 class _HealthyPage:
     url = "https://example.test/healthy"
+
+
+def test_playwright_chromium_path_supports_linux_chrome_linux64(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """新版 Playwright 的 chrome-linux64 目录应能被自动检测。"""
+    chromium = (
+        tmp_path
+        / ".cache"
+        / "ms-playwright"
+        / "chromium-1234"
+        / "chrome-linux64"
+        / "chrome"
+    )
+    chromium.parent.mkdir(parents=True)
+    chromium.touch()
+
+    monkeypatch.setattr(manager_module, "_WINDOWS", False)
+    monkeypatch.setattr(manager_module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(manager_module.Path, "home", classmethod(lambda cls: tmp_path))
+
+    assert manager_module._playwright_chromium_path() == str(chromium)
+
+
+def test_auto_install_chromium_uses_current_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """自动安装应走公开模块入口，避免依赖 Playwright 私有 API。"""
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert _auto_install_chromium() is True
+    assert commands == [[sys.executable, "-m", "playwright", "install", "chromium"]]
 
 
 async def _async_noop(self) -> None:

--- a/packages/adapter/pyproject.toml
+++ b/packages/adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-adapter"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/chat/pyproject.toml
+++ b/packages/chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-chat"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-contracts"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 description = "Cross-module domain models and port interfaces for NeoBot"
 readme = "README.md"
 authors = [

--- a/packages/memory/pyproject.toml
+++ b/packages/memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-memory"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/modloader/pyproject.toml
+++ b/packages/modloader/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-modloader"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/storage/pyproject.toml
+++ b/packages/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-storage"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 description = "Storage layer for NeoBot — SQLAlchemy + Alembic"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 description = "a QQ LLM Bot "
 requires-python = ">=3.13"
 authors = [


### PR DESCRIPTION
## 问题

Playwright 1.62 已移除私有 API get_driver_dir。NeoBot 导入该 API 失败后将其误判为 Playwright 未安装，即使服务器已安装 Playwright 和 Chromium 仍会跳过浏览器初始化。

新版 Linux Chromium 还可能安装在 chrome-linux64/chrome，而现有检测仅识别 chrome-linux/chrome。

## 修改

- 改用当前 Python 的公开模块入口执行 python -m playwright install chromium
- CLI 安装浏览器命令同步移除 Playwright 私有 API
- Linux 路径检测兼容 chrome-linux64/chrome
- 新增自动安装命令和新版 Linux 路径回归测试
- 将 NeoBot 工作区版本统一提升到 1.0.0-alpha.17

## 验证

- uv run pytest: 1597 passed, 4 skipped
- Ruff: passed
- uv build --all-packages: passed
- 成功生成 7 组 1.0.0a17 wheel 和 sdist 发布产物