### PR TITLE
fix(logging): 移除心跳日志输出

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-app"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.18"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/app/src/neobot_app/runtime/lifecycle_handler.py
+++ b/app/src/neobot_app/runtime/lifecycle_handler.py
@@ -11,6 +11,14 @@ class LifecycleHandler:
     async def handle(self, ctx: EventContext) -> None:
         event = ctx.raw_event
         meta_event_type = event.get("meta_event_type", "未知")
+        if meta_event_type == "heartbeat":
+            status = event.get("status")
+            if isinstance(status, dict) and (
+                status.get("online") is False or status.get("good") is False
+            ):
+                self._logger.warning(f"心跳状态异常: {status}")
+            return
+
         sub_type = event.get("sub_type", "")
         label = f"{meta_event_type}" + (f".{sub_type}" if sub_type else "")
         details: list[str] = []

--- a/app/tests/modules/runtime/test_lifecycle_handler.py
+++ b/app/tests/modules/runtime/test_lifecycle_handler.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from neobot_app.runtime.event_context import EventContext
+from neobot_app.runtime.lifecycle_handler import LifecycleHandler
+
+
+@pytest.mark.asyncio
+async def test_normal_heartbeat_is_not_logged() -> None:
+    logger = MagicMock()
+    handler = LifecycleHandler(logger=logger)
+
+    await handler.handle(
+        EventContext(
+            {
+                "post_type": "meta_event",
+                "meta_event_type": "heartbeat",
+                "interval": 3000,
+                "status": {"online": True, "good": True},
+            }
+        )
+    )
+
+    logger.info.assert_not_called()
+    logger.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_abnormal_heartbeat_logs_warning() -> None:
+    logger = MagicMock()
+    handler = LifecycleHandler(logger=logger)
+    status = {"online": False, "good": False}
+
+    await handler.handle(
+        EventContext(
+            {
+                "post_type": "meta_event",
+                "meta_event_type": "heartbeat",
+                "status": status,
+            }
+        )
+    )
+
+    logger.info.assert_not_called()
+    logger.warning.assert_called_once_with(f"心跳状态异常: {status}")
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_event_remains_logged() -> None:
+    logger = MagicMock()
+    handler = LifecycleHandler(logger=logger)
+
+    await handler.handle(
+        EventContext(
+            {
+                "post_type": "meta_event",
+                "meta_event_type": "lifecycle",
+                "sub_type": "connect",
+                "self_id": 123,
+            }
+        )
+    )
+
+    logger.info.assert_called_once_with(
+        "收到元事件[lifecycle.connect] self_id=123"
+    )

--- a/packages/adapter/pyproject.toml
+++ b/packages/adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-adapter"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.18"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/chat/pyproject.toml
+++ b/packages/chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-chat"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.18"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-contracts"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.18"
 description = "Cross-module domain models and port interfaces for NeoBot"
 readme = "README.md"
 authors = [

--- a/packages/memory/pyproject.toml
+++ b/packages/memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-memory"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.18"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/modloader/pyproject.toml
+++ b/packages/modloader/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-modloader"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.18"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/storage/pyproject.toml
+++ b/packages/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot-storage"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.18"
 description = "Storage layer for NeoBot — SQLAlchemy + Alembic"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neobot"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.18"
 description = "a QQ LLM Bot "
 requires-python = ">=3.13"
 authors = [


### PR DESCRIPTION
## 修改

- 正常 heartbeat 元事件不再每 3 秒输出 info 日志
- 心跳状态明确为 online=false 或 good=false 时输出 warning
- 保留适配器已有的未上报心跳超时告警
- 增加正常心跳、异常状态和 lifecycle 日志回归测试
- 将 NeoBot 工作区版本统一提升至 1.0.0-alpha.18

## 验证

- 全量测试: 1600 passed, 4 skipped
- 针对性测试: 19 passed
- Ruff: passed
- uv build --all-packages: passed
- 成功生成 7 组 1.0.0a18 wheel 和 sdist 发布产物