### PR TITLE
fix: 修复安全、可靠性与并发问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+# 每次推送到 main / 每个 PR：先跑静态检查，再跑测试。
+# 浏览器 / 网络 / 真实 LLM 用例依赖外部环境，默认排除（本地可用 -m 单独运行）。
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: 测试与静态检查
+    runs-on: ubuntu-latest
+    steps:
+      - name: 检出仓库
+        uses: actions/checkout@v7
+
+      - name: 安装 uv
+        uses: astral-sh/setup-uv@v10.0.1
+
+      - name: 安装依赖（全部工作区包 + dev 组）
+        run: uv sync --all-packages
+
+      - name: ruff（阻断）
+        run: uv run ruff check .
+
+      - name: 测试（阻断；排除 browser / network / slow / llm）
+        run: uv run pytest -m "not browser and not network and not slow and not llm"
+
+      # 存量类型错误约 500+，先只暴露不阻断；清理到可接受规模后再摘掉
+      # continue-on-error。
+      - name: mypy（暂不阻断）
+        continue-on-error: true
+        run: uv run mypy app/src packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 
 # 每次推送到 main / 每个 PR：先跑静态检查，再跑测试。
-# 浏览器 / 网络 / 真实 LLM 用例依赖外部环境，默认排除（本地可用 -m 单独运行）。
+# browser / network / slow / llm 四个标记用于隔离依赖外部环境的用例；当前仓库里
+# 只有 browser 有实际用例，新增真实网络/真实 LLM 用例时请务必打上对应标记，
+# 否则它们会进入 CI 默认集合（--strict-markers 会拦下拼错的标记名）。
 on:
   push:
     branches: [main]
@@ -25,16 +27,18 @@ jobs:
       - name: 安装 uv
         uses: astral-sh/setup-uv@v10.0.1
 
-      - name: 安装依赖（全部工作区包 + dev 组）
-        run: uv sync --all-packages
+      - name: 安装依赖（全部工作区包 + dev 组，严格用锁文件）
+        run: uv sync --all-packages --locked
 
       - name: ruff（阻断）
         run: uv run ruff check .
 
+      # --strict-markers：标记写错（例如把 network 打成 netwrok）会直接失败，
+      # 而不是让用例静默落进默认运行集合。
       - name: 测试（阻断；排除 browser / network / slow / llm）
-        run: uv run pytest -m "not browser and not network and not slow and not llm"
+        run: uv run pytest --strict-markers -m "not browser and not network and not slow and not llm"
 
-      # 存量类型错误约 500+，先只暴露不阻断；清理到可接受规模后再摘掉
+      # 存量类型错误约 820 条，先只暴露不阻断；清理到可接受规模后再摘掉
       # continue-on-error。
       - name: mypy（暂不阻断）
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -127,8 +127,7 @@ node_modules/
 # 临时提交信息
 .commit-msg-*.tmp
 
-# uv lock file
-uv.lock
+# 说明：uv.lock 需要提交（7 包工作区没有锁文件会导致每次构建解析出不同依赖）。
 /test/reports/
 /Reference/
 /TODO/

--- a/app/src/neobot_app/agent_tools/lsp.py
+++ b/app/src/neobot_app/agent_tools/lsp.py
@@ -239,8 +239,20 @@ class LspTools:
                 raise ValueError("Invalid deployment LSP server configuration")
             # Resolve the executable before entering any owner-controlled cwd.
             # Otherwise a planted workspace executable could shadow a PATH name.
+            #
+            # ⚠️ 不要改回 str(Path(executable).resolve()) / os.path.realpath()。
+            # 绝对化但**不**解析符号链接：Linux/macOS 上 .venv/bin/python 是指向
+            # 基础解释器的符号链接，resolve() 会穿透它，子进程于是用基础
+            # 解释器启动——而启动参数带 -I（隔离模式），既看不到 venv 的
+            # site-packages 也不认 PYTHONPATH，pylsp 就装在那个 venv 里，结果是
+            # LSP 永远起不来（lsp_protocol_error: Language server failed or
+            # returned an invalid response），且只在 Linux/macOS 复现。
+            # 回归防护见 test_lsp.py::test_deployment_executable_through_link_keeps_link_path
+            # 与 test_lsp_defaults.py（CI 是 ubuntu-latest，改错会立刻红）。
+            # abspath 只做路径规范化；对 PATH 里的命令（如 pyright）同样更安全：
+            # 不穿透 shim/链接，交给它自己的启动逻辑。
             executable = shutil.which(command[0]) or command[0]
-            configured_command = [str(Path(executable).resolve()), *command[1:]]
+            configured_command = [os.path.abspath(executable), *command[1:]]
             self._servers[extension.lower()] = (configured_command, language)
         self._timeout = timeout_seconds
         self._max_servers = max_servers

--- a/app/src/neobot_app/agent_tools/lsp_defaults.py
+++ b/app/src/neobot_app/agent_tools/lsp_defaults.py
@@ -22,6 +22,10 @@ def default_python_lsp_servers() -> dict[str, dict[str, Any]]:
     cannot shadow the installed server. A frozen executable is *not* Python; it
     re-enters only the dedicated stdio worker, never ``Bot.exe -m pylsp``.
     """
+    # ⚠️ sys.executable 在 Linux/macOS 上可能是符号链接（uv / pyenv / 系统
+    # python3 建的 venv 都如此）：这里必须原样使用，下游（LspTools、部署配置
+    # 解析）也不得用 Path.resolve()/realpath() 解析它——穿透到基础解释器后
+    # 子进程看不到 venv 的 site-packages，pylsp 起不来。详见 lsp.py 中的说明。
     command = (
         [sys.executable, PYTHON_LSP_WORKER_FLAG]
         if getattr(sys, "frozen", False)

--- a/app/src/neobot_app/assembly/adapter.py
+++ b/app/src/neobot_app/assembly/adapter.py
@@ -49,6 +49,9 @@ def _settings_from_config(config: Any = None) -> AdapterSettings:
         bot_name=str(getattr(bot_cfg, "nick_name", "Neo Bot") or "Neo Bot"),
         reverse_ws_host=str(getattr(adapter_cfg, "reverse_ws_host", "") or ""),
         reverse_ws_port=int(getattr(adapter_cfg, "reverse_ws_port", 0) or 0),
+        reverse_ws_access_token=str(
+            getattr(adapter_cfg, "reverse_ws_access_token", "") or ""
+        ),
     )
     return _apply_env_overrides(settings)
 
@@ -79,6 +82,11 @@ def _apply_env_overrides(settings: AdapterSettings) -> AdapterSettings:
         values["reverse_ws_host"] = reverse_host
     if reverse_port:
         values["reverse_ws_port"] = int(reverse_port)
+    # 反向 WS 的 token 只认专用变量：不复用 NEOBOT_LOCAL_ADAPTER_TOKEN，
+    # 否则 local 模式的老配置会突然让反向 WS 开始强制校验、连不上框架。
+    reverse_token = _env_ci("NEO_BOT_ADAPTER_TOKEN") or _env_ci("NEOBOT_ADAPTER_TOKEN")
+    if reverse_token:
+        values["reverse_ws_access_token"] = reverse_token
     if not values:
         return settings
     return replace(settings, **values)

--- a/app/src/neobot_app/bootstrap/__init__.py
+++ b/app/src/neobot_app/bootstrap/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from neobot_contracts.ports.clock import SystemClock
-from neobot_storage import run_migrations, sqlite_url
+from neobot_storage import backup_sqlite_database, run_migrations, sqlite_url
 
 from neobot_app.assembly.storage import build_storage
 from neobot_app.core import DATA_DIR, SRC_DATA_DIR
@@ -236,7 +236,16 @@ def create_application() -> NeoBotApplication:
         config=config, logger=logger_factory.get_logger("app.context")
     )
 
-    db_url = sqlite_url(DATA_DIR / "neobot.db")
+    # 迁移前先留一份可回滚快照：alembic 迁移里存在不可逆操作
+    # （如 0021 的去重 DELETE），失败时没有备份就只能人工恢复。
+    db_path = DATA_DIR / "neobot.db"
+    db_url = sqlite_url(db_path)
+    db_backup_logger = logger_factory.get_logger("app.db_backup")
+    backup_path = backup_sqlite_database(
+        db_path, DATA_DIR / "db_backup", logger=db_backup_logger
+    )
+    if backup_path is not None:
+        db_backup_logger.info(f"迁移前已备份数据库: {backup_path}")
     run_migrations(db_url)
     _engine, uow_factory = build_storage(db_url)
 

--- a/app/src/neobot_app/bootstrap/__init__.py
+++ b/app/src/neobot_app/bootstrap/__init__.py
@@ -346,10 +346,12 @@ def create_application() -> NeoBotApplication:
         data_dir=DATA_DIR,
     )
     if sandbox["temp_cleaner"] is not None:
-        sandbox["temp_cleaner"].logger = logger_factory.get_logger("app.temp_cleaner")
+        # 两个类的字段名是 _logger：写成 .logger 只是往实例上挂了个死属性，
+        # 生产里它们始终用构造时的 NullLogger，所有清理失败都不可见。
+        sandbox["temp_cleaner"]._logger = logger_factory.get_logger("app.temp_cleaner")
     if sandbox["sandbox_maintenance_manager"] is not None:
-        sandbox["sandbox_maintenance_manager"].logger = (
-            logger_factory.get_logger("app.sandbox_maintenance")
+        sandbox["sandbox_maintenance_manager"]._logger = logger_factory.get_logger(
+            "app.sandbox_maintenance"
         )
 
     # ── 解题 Agent 装配 ──

--- a/app/src/neobot_app/bootstrap/_skills.py
+++ b/app/src/neobot_app/bootstrap/_skills.py
@@ -9,7 +9,7 @@ from neobot_modloader import PluginInstaller, PluginRuntime, PluginStateStore
 from neobot_modloader.installer import ProxySettings
 
 from neobot_app.builtin_plugins import builtin_plugin_dirs
-from neobot_app.core import DATA_DIR
+from neobot_app.core import APP_VERSION, DATA_DIR
 from neobot_app.skills import build_all_skills
 
 if TYPE_CHECKING:
@@ -208,6 +208,7 @@ def build_plugin_runtime(
         official_config_provider=build_official_config_provider(config),
         installer=installer,
         user_plugins_enabled=bool(getattr(config.plugins, "enabled", True)),
+        host_version=APP_VERSION,
     )
     plugin_runtime.load_all()
     return plugin_runtime

--- a/app/src/neobot_app/builtin_plugins/dashboard/__init__.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/__init__.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any
 
 from neobot_modloader import Plugin
@@ -50,7 +49,7 @@ class DashboardPlugin:
             ctx.logger.info("网页面板已禁用（dashboard.enabled=false），跳过启动")
             return
 
-        from neobot_app.core import CONFIG_BACKUP_DIR, CONFIG_FILE, DATA_DIR, ENV_FILE
+        from neobot_app.core import CONFIG_BACKUP_DIR, CONFIG_FILE, ENV_FILE
 
         services = getattr(getattr(ctx, "plugin_host", None), "services", None)
         host_commands = None

--- a/app/src/neobot_app/builtin_plugins/dashboard/api.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/api.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import time
 from pathlib import Path
 from typing import Any
 
@@ -27,7 +26,7 @@ from .model_probe import list_provider_models
 from .plugin_config import PluginConfigConflictError, PluginConfigEditor, PluginConfigError
 from neobot_app.panel_auth import PasswordPolicyError
 
-from .security import client_ip, is_loopback
+from .security import is_loopback
 
 
 def _pydantic_errors(exc: Any) -> list[dict[str, str]]:

--- a/app/src/neobot_app/builtin_plugins/dashboard/api.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/api.py
@@ -117,6 +117,13 @@ class DashboardApi:
             )
         return None
 
+    def _can_manage(self, request: web.Request) -> bool:
+        """是否有管理权限（与 _require_manage 同判据，用于按权限裁剪响应）。"""
+        return self.console.manage_plugins and (
+            self.console.allow_remote_manage
+            or is_loopback(self.console.request_ip(request))
+        )
+
     async def _read_json(self, request: web.Request) -> dict[str, Any]:
         if not request.can_read_body:
             return {}
@@ -935,6 +942,14 @@ class DashboardApi:
         except Exception as exc:
             return _json_error(f"读取配置失败: {exc}", status=500)
         document["can_manage"] = self.console.manage_plugins
+        if not self._can_manage(request):
+            # config.toml 里也有机密（adapter.local_auth_token /
+            # adapter.reverse_ws_access_token）。结构化 config/schema 已按字段掩码，
+            # 但原文与 raw 副本同样带明文，只读会话不得获取——与 .env 侧
+            # 「密钥只回是否已设置」的约定保持一致。
+            document["source"] = ""
+            document["raw"] = {}
+            document["secrets_hidden"] = True
         return _json_ok(document)
 
     async def config_save(self, request: web.Request) -> web.Response:

--- a/app/src/neobot_app/builtin_plugins/dashboard/api.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/api.py
@@ -465,6 +465,10 @@ class DashboardApi:
                 payload["scheduled"] = value if isinstance(value, list) else []
             except Exception as exc:
                 payload["scheduled_error"] = str(exc)
+        elif manager is not None:
+            # 显式报错而不是静默留空：接口改名/缺失时面板会直接显示原因，
+            # 不会让「定时任务列表恒为空」这种问题再次无声无息。
+            payload["scheduled_error"] = "scheduled_task_manager 未提供 list_tasks 接口"
         drawing = self._service("drawing_manager")
         status = getattr(drawing, "list_active", None) if drawing is not None else None
         if callable(status):

--- a/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
@@ -16,7 +16,7 @@ import re
 import tempfile
 from dataclasses import MISSING, dataclass, fields, is_dataclass
 from pathlib import Path
-from typing import Any, Union, get_args, get_origin
+from typing import Any, Iterator, Union, get_args, get_origin
 
 import tomlkit
 
@@ -29,6 +29,7 @@ from neobot_app.config.schemas.bot import (
     ModelDefinition,
 )
 from neobot_app.config.schemas.env import EnvConfig
+from neobot_app.builtin_plugins.dashboard.security import is_sensitive_key
 
 ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 MAX_STRING_LENGTH = 200_000
@@ -411,15 +412,23 @@ class BotConfigManager:
             raise ConfigValidationError(
                 [{"path": "config.toml", "message": f"TOML 解析失败: {exc}"}]
             ) from exc
+        secret_state: dict[str, bool] = {}
+        config_payload = _mask_sensitive_leaves(_jsonable(instance), secret_state)
+        raw_payload = _mask_sensitive_leaves(_jsonable(parsed), None)
+        schema_payload = describe_dataclass(BotConfig, instance)
+        for item in schema_payload:
+            _mask_schema_defaults(item, secret_state, (str(item.get("name") or ""),))
         return {
             "path": str(self.config_path),
             "revision": self.revision(),
-            "source": source,
-            "config": _jsonable(instance),
-            "raw": _jsonable(parsed),
-            "schema": describe_dataclass(BotConfig, instance),
+            "source": _mask_toml_source(source),
+            "config": config_payload,
+            "raw": raw_payload,
+            "schema": schema_payload,
             "version": str(getattr(instance, "version", "")),
             "form_supported": True,
+            # 密钥字段只回「是否已设置」（与 .env 的 masked/has_value 语义一致）
+            "secrets_set": secret_state,
         }
 
     def validate(self, *, source: str | None = None, config: Any = None) -> list[dict[str, str]]:
@@ -442,6 +451,11 @@ class BotConfigManager:
         expected_revision: str | None = None,
         max_backups: int = 15,
     ) -> dict[str, Any]:
+        if source is not None and self.config_path.is_file():
+            # 原文模式的输入来自面板（密钥行是占位符）：先还原再校验/写入。
+            source = _restore_masked_source(
+                self.config_path.read_text(encoding="utf-8-sig"), source
+            )
         errors = self.validate(source=source, config=config)
         if errors:
             raise ConfigValidationError(errors)
@@ -452,7 +466,10 @@ class BotConfigManager:
                 else tomlkit.document()
             )
             current = document.unwrap() if self.config_path.is_file() else {}
-            _merge_into_document(document, _diff_document(current, config or {}, BotConfig))
+            # 面板拿到的密钥字段是掩码后的空串（见 read()）：回传的空串要还原成
+            # 文件里的现有值，否则一次表单保存就把 token 抹掉。
+            submitted = _restore_masked_secrets(current, config or {})
+            _merge_into_document(document, _diff_document(current, submitted, BotConfig))
             source = tomlkit.dumps(document)
         if expected_revision is not None and expected_revision != self.revision():
             raise ConfigConflictError("配置文件已被其它会话修改，请重新读取后再保存")
@@ -809,6 +826,158 @@ def _managed_tree(schema: type) -> dict[str, Any]:
                 tree[field_obj.name] = None
     _MANAGED_TREES[schema] = tree
     return tree
+
+
+def _mask_sensitive_leaves(data: Any, found: dict[str, bool] | None = None, path: tuple[str, ...] = ()) -> Any:
+    """把密钥类字段的值替换为空串，并记录「是否已设置」。
+
+    config.toml 里也有机密（``adapter.local_auth_token`` /
+    ``adapter.reverse_ws_access_token``）：认证/反向 WS 的 token 落到面板响应里，
+    任何已登录会话（含只读、远程）都能拿到并冒充 OneBot 框架注入伪造事件。
+    这里与 .env 的处理保持一致：只回「是否已设置」，不回值。
+    """
+    if isinstance(data, dict):
+        masked: dict[str, Any] = {}
+        for key, value in data.items():
+            child_path = (*path, str(key))
+            if is_sensitive_key(key):
+                has_value = bool(value)
+                if isinstance(value, str) and value:
+                    has_value = True
+                if found is not None:
+                    found[".".join(child_path)] = has_value
+                masked[key] = "" if isinstance(value, str) or value is None else value
+                continue
+            masked[key] = _mask_sensitive_leaves(value, found, child_path)
+        return masked
+    if isinstance(data, list):
+        return [_mask_sensitive_leaves(item, found, (*path, str(index))) for index, item in enumerate(data)]
+    return data
+
+
+_SECRET_PLACEHOLDER = "***"
+_TOML_SECTION_RE = re.compile(r"^\s*\[(?P<name>[^\]]+)\]\s*(?:#.*)?$")
+#: 只匹配「简单键 = 引号字符串/单 token（可带行尾注释）」，复杂值（数组、多行、
+#: 时间）原样放过：面板不需要脱敏它们，误改反而是数据损坏。
+_TOML_KEY_LINE_RE = re.compile(
+    r"^(?P<indent>\s*)(?P<key>[A-Za-z0-9_\-]+)(?P<sep>\s*=\s*)"
+    r"(?P<value>\"[^\"]*\"|'[^']*'|[^#\s]+)(?P<tail>\s*(?:#.*)?)$"
+)
+
+
+def _iter_secret_lines(source: str) -> Iterator[tuple[str, re.Match[str]]]:
+    """逐行产出 (当前分区名, 匹配到的密钥行)。"""
+    section = ""
+    for line in source.splitlines():
+        header = _TOML_SECTION_RE.match(line.strip())
+        if header:
+            section = header.group("name").strip()
+            continue
+        match = _TOML_KEY_LINE_RE.match(line)
+        if match and is_sensitive_key(match.group("key")):
+            yield section, match
+
+
+def _mask_toml_source(source: str) -> str:
+    """把原文里密钥键的值替换为占位符（面板响应不回明文）。"""
+    out: list[str] = []
+    for line in source.splitlines():
+        match = _TOML_KEY_LINE_RE.match(line)
+        if match and is_sensitive_key(match.group("key")):
+            out.append(
+                f'{match.group("indent")}{match.group("key")}{match.group("sep")}'
+                f'"{_SECRET_PLACEHOLDER}"{match.group("tail")}'
+            )
+            continue
+        out.append(line)
+    text = "\n".join(out)
+    return text + "\n" if source.endswith("\n") else text
+
+
+def _restore_masked_source(current_source: str, submitted: str) -> str:
+    """提交原文里仍是占位符的密钥键，还原成磁盘上的现有值。
+
+    面板原文是脱敏后返回的：用户没动那一行（提交回来仍是 ``***``）时必须还原，
+    否则一次保存就把 token 写成字面量 ``***``。
+    """
+    originals = {
+        (section, match.group("key")): match.group("value")
+        for section, match in _iter_secret_lines(current_source)
+    }
+    if not originals:
+        return submitted
+    out: list[str] = []
+    section = ""
+    for line in submitted.splitlines():
+        header = _TOML_SECTION_RE.match(line.strip())
+        if header:
+            section = header.group("name").strip()
+            out.append(line)
+            continue
+        match = _TOML_KEY_LINE_RE.match(line)
+        if match and is_sensitive_key(match.group("key")):
+            if match.group("value").strip("\"'") == _SECRET_PLACEHOLDER:
+                original = originals.get((section, match.group("key")))
+                if original is not None:
+                    out.append(
+                        f'{match.group("indent")}{match.group("key")}'
+                        f'{match.group("sep")}{original}{match.group("tail")}'
+                    )
+                    continue
+        out.append(line)
+    text = "\n".join(out)
+    return text + "\n" if submitted.endswith("\n") else text
+
+
+def _mask_schema_defaults(
+    item: dict[str, Any], found: dict[str, bool], path: tuple[str, ...]
+) -> None:
+    """schema 描述里的 default/value 同样不能带出密钥明文。"""
+    if path and is_sensitive_key(path[-1]):
+        for key in ("default", "value"):
+            if item.get(key):
+                found[".".join(path)] = True
+            item[key] = ""
+        return
+    # 分区节点自身也带 default/value（整段配置的字典副本），里面的密钥要一并掩码。
+    for key in ("default", "value"):
+        value = item.get(key)
+        if isinstance(value, (dict, list)):
+            item[key] = _mask_sensitive_leaves(value, found, path)
+    for child in item.get("fields") or []:
+        if isinstance(child, dict):
+            _mask_schema_defaults(child, found, (*path, str(child.get("name") or "")))
+    for child in item.get("item_fields") or []:
+        if isinstance(child, dict):
+            _mask_schema_defaults(child, found, (*path, str(child.get("name") or "")))
+
+
+def _restore_masked_secrets(current: Any, submitted: Any, path: tuple[str, ...] = ()) -> Any:
+    """把被掩码的密钥字段还原成文件里的现有值。
+
+    掩码后的空串回传时不能当成「用户清空」——否则面板保存会把 token 抹掉。
+    想清空请用 TOML 模式直接编辑。
+    """
+    if isinstance(current, dict) and isinstance(submitted, dict):
+        restored: dict[str, Any] = {}
+        for key, value in submitted.items():
+            child_path = (*path, str(key))
+            existing = current.get(key)
+            if is_sensitive_key(key) and value == "" and isinstance(existing, str) and existing:
+                restored[key] = existing
+                continue
+            restored[key] = _restore_masked_secrets(existing, value, child_path)
+        return restored
+    if isinstance(current, list) and isinstance(submitted, list):
+        return [
+            _restore_masked_secrets(
+                current[index] if index < len(current) else None,
+                item,
+                (*path, str(index)),
+            )
+            for index, item in enumerate(submitted)
+        ]
+    return submitted
 
 
 def _filter_managed(

--- a/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
@@ -452,7 +452,7 @@ class BotConfigManager:
                 else tomlkit.document()
             )
             current = document.unwrap() if self.config_path.is_file() else {}
-            _merge_into_document(document, _diff_document(current, config or {}))
+            _merge_into_document(document, _diff_document(current, config or {}, _managed_tree(BotConfig)))
             source = tomlkit.dumps(document)
         if expected_revision is not None and expected_revision != self.revision():
             raise ConfigConflictError("配置文件已被其它会话修改，请重新读取后再保存")
@@ -514,7 +514,9 @@ class BotConfigManager:
         if errors:
             raise ConfigValidationError(errors)
 
-        _merge_into_document(document, _diff_document(current, new_config))
+        _merge_into_document(
+            document, _diff_document(current, new_config, _managed_tree(BotConfig))
+        )
         if self.config_path.is_file():
             backup_config(self.config_path, self.backup_dir, max_backups=max_backups)
         source = tomlkit.dumps(document)
@@ -563,7 +565,9 @@ class BotConfigManager:
         if errors:
             raise ConfigValidationError(errors)
 
-        _merge_into_document(document, _diff_document(current, new_config))
+        _merge_into_document(
+            document, _diff_document(current, new_config, _managed_tree(BotConfig))
+        )
         if self.config_path.is_file():
             backup_config(self.config_path, self.backup_dir, max_backups=15)
         source = tomlkit.dumps(document)
@@ -723,7 +727,9 @@ class BotConfigManager:
         if config_errors:
             raise ConfigValidationError(config_errors)
 
-        _merge_into_document(document, _diff_document(current, new_config))
+        _merge_into_document(
+            document, _diff_document(current, new_config, _managed_tree(BotConfig))
+        )
         if self.config_path.is_file():
             backup_config(self.config_path, self.backup_dir, max_backups=max_backups)
         source = tomlkit.dumps(document)
@@ -767,22 +773,63 @@ def _assignment_items(assignments: dict[str, Any]) -> list[tuple[str, str]]:
 _DELETE = object()
 _MISSING = object()
 
+#: 自由映射字段（dict 类型）：键由用户/账号决定，例如分群回复系数，
+#: 表单里删掉某个键就是真的要删，不做「未知键保护」。
+_FREE_MAPPING = object()
 
-def _diff_document(current: Any, new: Any) -> Any:
-    """只保留相对当前文件真正变化的键，避免整份重写丢掉注释与顺序。"""
+_MANAGED_TREES: dict[type, dict[str, Any]] = {}
+
+
+def _managed_tree(schema: type) -> dict[str, Any]:
+    """按 dataclass 声明生成托管字段树，用于判断哪些键允许被表单删除。
+
+    - dataclass 字段 -> 递归子字典（分区：只有声明过的键才允许删）
+    - dict 字段 -> ``_FREE_MAPPING``（键由用户决定，允许删）
+    - 其它字段 -> ``None``（标量/数组，整值替换，不涉及删键）
+    """
+    cached = _MANAGED_TREES.get(schema)
+    if cached is not None:
+        return cached
+    tree: dict[str, Any] = {}
+    if is_dataclass(schema):
+        for field_obj in fields(schema):
+            inner = _inner_types(field_obj.type)
+            target = inner[0] if inner else field_obj.type
+            if is_dataclass(target):
+                tree[field_obj.name] = _managed_tree(target)
+            elif get_origin(target) is dict:
+                tree[field_obj.name] = _FREE_MAPPING
+            else:
+                tree[field_obj.name] = None
+    _MANAGED_TREES[schema] = tree
+    return tree
+
+
+def _diff_document(current: Any, new: Any, managed: Any = None) -> Any:
+    """只保留相对当前文件真正变化的键，避免整份重写丢掉注释与顺序。
+
+    ``managed`` 是 :func:`_managed_tree` 给出的托管字段树。表单只认识托管字段，
+    因此文件里那些面板不认识的键（用户自定义分区、插件写入的字段、更新版本
+    留下的新字段）一律保留：之前它们会被当成「表单里删掉的键」直接删掉，
+    一次面板保存就能把它们从 config.toml 里抹掉。
+    """
     if not isinstance(current, dict) or not isinstance(new, dict):
         return new
     changes: dict[str, Any] = {}
     for key, value in new.items():
+        child = managed.get(key) if isinstance(managed, dict) else None
         if isinstance(value, dict) and isinstance(current.get(key), dict):
-            nested = _diff_document(current[key], value)
+            nested = _diff_document(current[key], value, child)
             if nested:
                 changes[key] = nested
         elif current.get(key, _MISSING) != value:
             changes[key] = value
     for key in current:
-        if key not in new:
-            changes[key] = _DELETE
+        if key in new:
+            continue
+        if isinstance(managed, dict) and key not in managed:
+            continue
+        changes[key] = _DELETE
     return changes
 
 

--- a/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
@@ -16,7 +16,7 @@ import re
 import tempfile
 from dataclasses import MISSING, dataclass, fields, is_dataclass
 from pathlib import Path
-from typing import Any, Iterator, Union, get_args, get_origin
+from typing import Any, Iterator, NamedTuple, Union, get_args, get_origin
 
 import tomlkit
 
@@ -800,6 +800,15 @@ _MISSING = object()
 #: 表单里删掉某个键就是真的要删，不做「未知键保护」。
 _FREE_MAPPING = object()
 
+
+class _ListOfTables(NamedTuple):
+    """表数组字段（``List[dataclass]``，如 models.registry / chat.key_word）。
+
+    逐元素 diff：元素里面板不认识的键同样要保留。
+    """
+
+    element: Any
+
 _MANAGED_TREES: dict[type, dict[str, Any]] = {}
 
 
@@ -820,6 +829,12 @@ def _managed_tree(schema: type) -> dict[str, Any]:
             target = inner[0] if inner else field_obj.type
             if is_dataclass(target):
                 tree[field_obj.name] = target
+            elif get_origin(target) is list:
+                args = get_args(target)
+                element = args[0] if args else None
+                tree[field_obj.name] = (
+                    _ListOfTables(element) if is_dataclass(element) else None
+                )
             elif get_origin(target) is dict:
                 tree[field_obj.name] = _FREE_MAPPING
             else:
@@ -1009,6 +1024,33 @@ def _filter_managed(
     return filtered
 
 
+def _diff_sequence(
+    current: Any, new: Any, element_schema: Any
+) -> Any:
+    """表数组（``[[models.registry]]`` 这类）逐元素 diff。
+
+    数组是「整值替换」的话，元素里面板不认识的键会随一次表单保存被抹掉
+    （与分区字段同一类数据丢失）。这里按序号逐元素 diff：下标对得上的元素走
+    dict diff（未知键保留），新增的元素整体写入，变短的数组由合并阶段截断。
+    返回 None 表示无需改动。
+    """
+    if not isinstance(current, list) or not isinstance(new, list):
+        return new
+    diff: list[Any] = []
+    for index, item in enumerate(new):
+        if (
+            index < len(current)
+            and isinstance(current[index], dict)
+            and isinstance(item, dict)
+        ):
+            diff.append(_diff_document(current[index], item, element_schema))
+        else:
+            diff.append(item)
+    if diff == current:
+        return None
+    return diff
+
+
 def _diff_document(current: Any, new: Any, managed: Any = None) -> Any:
     """只保留相对当前文件真正变化的键，避免整份重写丢掉注释与顺序。
 
@@ -1023,7 +1065,11 @@ def _diff_document(current: Any, new: Any, managed: Any = None) -> Any:
     changes: dict[str, Any] = {}
     for key, value in new.items():
         child = tree.get(key) if tree is not None else None
-        if isinstance(value, dict) and isinstance(current.get(key), dict):
+        if isinstance(child, _ListOfTables):
+            nested_list = _diff_sequence(current.get(key), value, child.element)
+            if nested_list is not None:
+                changes[key] = nested_list
+        elif isinstance(value, dict) and isinstance(current.get(key), dict):
             nested = _diff_document(current[key], value, child)
             if nested:
                 changes[key] = nested
@@ -1036,6 +1082,21 @@ def _diff_document(current: Any, new: Any, managed: Any = None) -> Any:
             continue
         changes[key] = _DELETE
     return changes
+
+
+def _merge_sequence(document: Any, values: list[Any]) -> None:
+    """把元素级 diff 合并回 TOML 表数组（保留未变元素的注释与顺序）。"""
+    while len(document) > len(values):
+        del document[-1]
+    for index, item in enumerate(values):
+        if index >= len(document):
+            document.append(tomlkit.item(item))
+            continue
+        target = document[index]
+        if isinstance(item, dict) and hasattr(target, "get"):
+            _merge_into_document(target, item)
+        else:
+            document[index] = tomlkit.item(item)
 
 
 def _merge_into_document(document: Any, data: dict[str, Any], prefix: tuple[str, ...] = ()) -> None:
@@ -1056,8 +1117,14 @@ def _merge_into_document(document: Any, data: dict[str, Any], prefix: tuple[str,
                 document[key] = tomlkit.table()
                 existing = document[key]
             _merge_into_document(existing, value, (*prefix, str(key)))
+        elif isinstance(value, list) and _is_table_array(document.get(key)):
+            _merge_sequence(document.get(key), value)
         else:
             document[key] = tomlkit.item(value)
+
+
+def _is_table_array(node: Any) -> bool:
+    return isinstance(node, tomlkit.items.AoT)
 
 
 class EnvFileManager:

--- a/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
@@ -22,7 +22,12 @@ import tomlkit
 
 from neobot_app.config.loader.backup import backup_config
 from neobot_app.config.loader.converter import dict_to_dataclass
-from neobot_app.config.schemas.bot import BotConfig
+from neobot_app.config.schemas.bot import (
+    MODEL_TYPE_LABELS,
+    BotConfig,
+    ModelAssignments,
+    ModelDefinition,
+)
 from neobot_app.config.schemas.env import EnvConfig
 
 ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -1187,12 +1192,6 @@ def models_view(config: Any = None) -> dict[str, Any]:
                 "key_configured": bool(platform.get("has_key")),
             }
         )
-
-    from neobot_app.config.schemas.bot import (
-        MODEL_TYPE_LABELS,
-        ModelAssignments,
-        ModelDefinition,
-    )
 
     provider_names: set[str] = set(EnvConfig.PLATFORM_NAME_ALIASES.values())
     for field_obj in fields(EnvConfig):

--- a/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
@@ -14,7 +14,7 @@ import hashlib
 import os
 import re
 import tempfile
-from dataclasses import MISSING, dataclass, field, fields, is_dataclass
+from dataclasses import MISSING, dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any, Union, get_args, get_origin
 

--- a/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/config_manager.py
@@ -452,7 +452,7 @@ class BotConfigManager:
                 else tomlkit.document()
             )
             current = document.unwrap() if self.config_path.is_file() else {}
-            _merge_into_document(document, _diff_document(current, config or {}, _managed_tree(BotConfig)))
+            _merge_into_document(document, _diff_document(current, config or {}, BotConfig))
             source = tomlkit.dumps(document)
         if expected_revision is not None and expected_revision != self.revision():
             raise ConfigConflictError("配置文件已被其它会话修改，请重新读取后再保存")
@@ -510,12 +510,14 @@ class BotConfigManager:
 
         new_config = dict(current)
         new_config[name] = merged
-        errors = self.validate(config=new_config)
+        errors = self.validate(
+            config=_filter_managed(BotConfig, new_config, strict=frozenset({(name,)}))
+        )
         if errors:
             raise ConfigValidationError(errors)
 
         _merge_into_document(
-            document, _diff_document(current, new_config, _managed_tree(BotConfig))
+            document, _diff_document(current, new_config, BotConfig)
         )
         if self.config_path.is_file():
             backup_config(self.config_path, self.backup_dir, max_backups=max_backups)
@@ -561,12 +563,14 @@ class BotConfigManager:
 
         new_config = dict(current)
         new_config["plugins"] = plugins_raw
-        errors = self.validate(config=new_config)
+        errors = self.validate(
+            config=_filter_managed(BotConfig, new_config, strict=frozenset({("plugins",)}))
+        )
         if errors:
             raise ConfigValidationError(errors)
 
         _merge_into_document(
-            document, _diff_document(current, new_config, _managed_tree(BotConfig))
+            document, _diff_document(current, new_config, BotConfig)
         )
         if self.config_path.is_file():
             backup_config(self.config_path, self.backup_dir, max_backups=15)
@@ -723,12 +727,14 @@ class BotConfigManager:
             "registry": library,
             "assignments": current_assignments,
         }
-        config_errors = self.validate(config=new_config)
+        config_errors = self.validate(
+            config=_filter_managed(BotConfig, new_config, strict=frozenset({("models",)}))
+        )
         if config_errors:
             raise ConfigValidationError(config_errors)
 
         _merge_into_document(
-            document, _diff_document(current, new_config, _managed_tree(BotConfig))
+            document, _diff_document(current, new_config, BotConfig)
         )
         if self.config_path.is_file():
             backup_config(self.config_path, self.backup_dir, max_backups=max_backups)
@@ -783,7 +789,7 @@ _MANAGED_TREES: dict[type, dict[str, Any]] = {}
 def _managed_tree(schema: type) -> dict[str, Any]:
     """按 dataclass 声明生成托管字段树，用于判断哪些键允许被表单删除。
 
-    - dataclass 字段 -> 递归子字典（分区：只有声明过的键才允许删）
+    - dataclass 字段 -> 子 dataclass（分区：只有声明过的键才允许删）
     - dict 字段 -> ``_FREE_MAPPING``（键由用户决定，允许删）
     - 其它字段 -> ``None``（标量/数组，整值替换，不涉及删键）
     """
@@ -796,7 +802,7 @@ def _managed_tree(schema: type) -> dict[str, Any]:
             inner = _inner_types(field_obj.type)
             target = inner[0] if inner else field_obj.type
             if is_dataclass(target):
-                tree[field_obj.name] = _managed_tree(target)
+                tree[field_obj.name] = target
             elif get_origin(target) is dict:
                 tree[field_obj.name] = _FREE_MAPPING
             else:
@@ -805,19 +811,49 @@ def _managed_tree(schema: type) -> dict[str, Any]:
     return tree
 
 
+def _filter_managed(
+    schema: type,
+    data: Any,
+    *,
+    strict: frozenset[tuple[str, ...]] = frozenset(),
+    path: tuple[str, ...] = (),
+) -> Any:
+    """复制一份配置并丢掉声明之外的键（校验用）。
+
+    配置文件里可能本来就有面板不认识的键（自定义分区、插件字段、更新版本
+    留下的新字段）。它们既不该让整次保存因「未知配置项」失败，也不该参与
+    本次校验。``strict`` 里的路径保持原样：正在编辑的那个分区若出现未知键，
+    依然会被校验拦下。
+    """
+    if not isinstance(data, dict) or not is_dataclass(schema) or path in strict:
+        return data
+    tree = _managed_tree(schema)
+    filtered: dict[str, Any] = {}
+    for key, value in data.items():
+        if key not in tree:
+            continue
+        child = tree[key]
+        if is_dataclass(child) and isinstance(value, dict):
+            filtered[key] = _filter_managed(child, value, strict=strict, path=(*path, key))
+        else:
+            filtered[key] = value
+    return filtered
+
+
 def _diff_document(current: Any, new: Any, managed: Any = None) -> Any:
     """只保留相对当前文件真正变化的键，避免整份重写丢掉注释与顺序。
 
-    ``managed`` 是 :func:`_managed_tree` 给出的托管字段树。表单只认识托管字段，
-    因此文件里那些面板不认识的键（用户自定义分区、插件写入的字段、更新版本
-    留下的新字段）一律保留：之前它们会被当成「表单里删掉的键」直接删掉，
-    一次面板保存就能把它们从 config.toml 里抹掉。
+    ``managed`` 是 :func:`_managed_tree` 对应的 dataclass（或 ``_FREE_MAPPING``）。
+    表单只认识托管字段，因此文件里那些面板不认识的键（用户自定义分区、插件
+    写入的字段、更新版本留下的新字段）一律保留：之前它们会被当成「表单里
+    删掉的键」直接删掉，一次面板保存就能把它们从 config.toml 里抹掉。
     """
     if not isinstance(current, dict) or not isinstance(new, dict):
         return new
+    tree = _managed_tree(managed) if is_dataclass(managed) else None
     changes: dict[str, Any] = {}
     for key, value in new.items():
-        child = managed.get(key) if isinstance(managed, dict) else None
+        child = tree.get(key) if tree is not None else None
         if isinstance(value, dict) and isinstance(current.get(key), dict):
             nested = _diff_document(current[key], value, child)
             if nested:
@@ -827,7 +863,7 @@ def _diff_document(current: Any, new: Any, managed: Any = None) -> Any:
     for key in current:
         if key in new:
             continue
-        if isinstance(managed, dict) and key not in managed:
+        if tree is not None and key not in tree:
             continue
         changes[key] = _DELETE
     return changes

--- a/app/src/neobot_app/builtin_plugins/dashboard/metrics.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/metrics.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from neobot_app.utils.atomic import atomic_write_text
 from neobot_contracts.ports.logging import Logger, NullLogger
 
 _API_ACTION_RE = re.compile(r"action['\"]?\s*[:=]\s*['\"]([A-Za-z0-9_]+)")
@@ -249,11 +250,11 @@ class Metrics:
     def _save(self) -> None:
         try:
             self._data_dir.mkdir(parents=True, exist_ok=True)
-            self._stats_path.write_text(
+            atomic_write_text(
+                self._stats_path,
                 json.dumps(self._stats, ensure_ascii=False, indent=2),
-                encoding="utf-8",
             )
-        except OSError as exc:
+        except Exception as exc:
             self._logger.warning(f"面板统计文件写入失败: {exc}")
 
     def flush(self) -> None:

--- a/app/src/neobot_app/builtin_plugins/dashboard/security.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/security.py
@@ -120,12 +120,18 @@ def secrets_equal(left: str, right: str) -> bool:
 
 
 def client_ip(request: Any, *, trust_proxy: bool = False) -> str:
-    """解析客户端地址；仅在显式信任代理时使用转发头。"""
+    """解析客户端地址；仅在显式信任代理时使用转发头。
+
+    XFF 取**最右**一项而不是最左：最左是客户端自己可以随意伪造的（浏览器/脚本
+    发一个 ``X-Forwarded-For: 127.0.0.1`` 就变成了「本机访问」，从而绕过
+    auth_setup 的「仅本机可设置密码」与 allow_remote_manage=false 的远程限制）。
+    最右一项由我们信任的那一跳代理追加，客户端无法控制。
+    """
     if trust_proxy:
         for header in ("X-Forwarded-For", "X-Real-IP"):
             raw = request.headers.get(header)
             if raw:
-                candidate = raw.split(",")[0].strip()
+                candidate = raw.split(",")[-1].strip()
                 if candidate:
                     return candidate
     peer = request.transport.get_extra_info("peername") if request.transport else None

--- a/app/src/neobot_app/builtin_plugins/dashboard/security.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/security.py
@@ -16,7 +16,6 @@ import re
 import secrets
 import time
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
 
 SENSITIVE_KEY_RE = re.compile(r"(?i)(api[_-]?key|token|password|secret|credential|authorization)")

--- a/app/src/neobot_app/builtin_plugins/dashboard/server.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/server.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 
 from aiohttp import web
 
+from neobot_adapter.utils.net import is_loopback_host
 from neobot_app.panel_auth import get_panel_password_store
 
 from . import system as system_module
@@ -212,6 +213,14 @@ class DashboardServer:
             self.logger.warning(
                 "网页面板尚未设置登录密码：此时不允许外网访问。"
                 "请在本机打开面板按提示设置密码，或由超级管理员在 QQ 私聊发送 /set_password 设置"
+            )
+        elif not is_loopback_host(self.config.host) and not self.secure_cookies:
+            # 默认 host=0.0.0.0 是「对网络开放」：面板已有登录与 CSRF，但纯 HTTP 下
+            # 登录凭据与 Cookie 可被同网段嗅探，这里每次启动都提醒一次。
+            self.logger.warning(
+                f"网页面板监听 {self.config.host}（对网络开放）且未启用 Secure Cookie："
+                "HTTP 明文下登录凭据可能被同网段嗅探。仅本机使用请把 dashboard.host 改为 127.0.0.1；"
+                "跨机/公网访问请经 HTTPS 反向代理，并在确认 HTTPS 生效后把 dashboard.secure_cookies 设为 true"
             )
         return self.public_url
 

--- a/app/src/neobot_app/builtin_plugins/dashboard/server.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/server.py
@@ -10,6 +10,7 @@ import asyncio
 import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from aiohttp import web
 
@@ -33,6 +34,38 @@ _STATIC_DIR = Path(__file__).resolve().parent / "web"
 _INDEX_FILE = _STATIC_DIR / "index.html"
 _API_PREFIX = "/api/"
 _PORT_SEARCH_LIMIT = 10
+
+#: 建立会话之前就要改状态、因而拿不到 CSRF token 的端点（需要额外跨站防护）
+_PRE_SESSION_STATE_CHANGE_PATHS = frozenset({"/api/auth/login", "/api/auth/setup"})
+
+
+def _cross_site_guard(request: web.Request) -> web.Response | None:
+    """登录/首次设置密码的跨站防护。
+
+    这两个端点在建立会话之前，没有 CSRF token 可用，因此改用两条与浏览器行为
+    绑定的约束：
+
+    1. 请求体必须是 ``application/json`` —— 跨站表单只能发
+       ``application/x-www-form-urlencoded`` / ``multipart/form-data`` /
+       ``text/plain``，而 aiohttp 的 ``request.json()`` 并不校验 Content-Type，
+       所以「text/plain 表单伪造 JSON 体」这类 CSRF 由这条拦住；
+    2. 若带 ``Origin``，其主机必须与请求 ``Host`` 同源。
+
+    返回非 None 表示应当直接以该响应拒绝请求。
+    """
+    content_type = (
+        (request.headers.get("Content-Type") or "").split(";", 1)[0].strip().casefold()
+    )
+    if content_type != "application/json":
+        return _json_error("该接口只接受 application/json 请求", status=415)
+
+    origin = request.headers.get("Origin")
+    if origin:
+        origin_host = (urlparse(origin).netloc or "").casefold()
+        request_host = (request.headers.get("Host") or "").casefold()
+        if origin_host and request_host and origin_host != request_host:
+            return _json_error("跨站请求已被拒绝", status=403)
+    return None
 
 
 class DashboardServer:
@@ -285,6 +318,15 @@ class DashboardServer:
         ip = self.request_ip(request)
         loopback = is_loopback(ip)
         configured = self.passwords.configured
+
+        if (
+            path in _PRE_SESSION_STATE_CHANGE_PATHS
+            and request.method in {"POST", "PUT", "PATCH", "DELETE"}
+        ):
+            # 会话建立前无法校验 CSRF token，用 Content-Type / Origin 兜住跨站提交
+            guarded = _cross_site_guard(request)
+            if guarded is not None:
+                return guarded
 
         if not configured:
             # 未设置密码：禁止外网访问；本机只允许进入设置流程。

--- a/app/src/neobot_app/builtin_plugins/dashboard/server.py
+++ b/app/src/neobot_app/builtin_plugins/dashboard/server.py
@@ -40,7 +40,7 @@ _PORT_SEARCH_LIMIT = 10
 _PRE_SESSION_STATE_CHANGE_PATHS = frozenset({"/api/auth/login", "/api/auth/setup"})
 
 
-def _cross_site_guard(request: web.Request) -> web.Response | None:
+def _cross_site_guard(request: web.Request, *, trust_proxy: bool = False) -> web.Response | None:
     """登录/首次设置密码的跨站防护。
 
     这两个端点在建立会话之前，没有 CSRF token 可用，因此改用两条与浏览器行为
@@ -51,6 +51,11 @@ def _cross_site_guard(request: web.Request) -> web.Response | None:
        ``text/plain``，而 aiohttp 的 ``request.json()`` 并不校验 Content-Type，
        所以「text/plain 表单伪造 JSON 体」这类 CSRF 由这条拦住；
     2. 若带 ``Origin``，其主机必须与请求 ``Host`` 同源。
+
+    反向代理部署下浏览器地址栏是公网域名，而到达这里的 ``Host`` 可能是
+    ``127.0.0.1:9981``（nginx 默认不改写 Host），只比 Host 会让「经 HTTPS 反向
+    代理访问」的用户永远登录不上。因此开启 ``trust_proxy_headers`` 时，
+    额外接受 ``X-Forwarded-Host``（由代理写入、客户端无法控制）。
 
     返回非 None 表示应当直接以该响应拒绝请求。
     """
@@ -63,8 +68,14 @@ def _cross_site_guard(request: web.Request) -> web.Response | None:
     origin = request.headers.get("Origin")
     if origin:
         origin_host = (urlparse(origin).netloc or "").casefold()
-        request_host = (request.headers.get("Host") or "").casefold()
-        if origin_host and request_host and origin_host != request_host:
+        accepted = {(request.headers.get("Host") or "").casefold()}
+        if trust_proxy:
+            for value in (request.headers.get("X-Forwarded-Host") or "").split(","):
+                candidate = value.strip().casefold()
+                if candidate:
+                    accepted.add(candidate)
+        accepted.discard("")
+        if origin_host and accepted and origin_host not in accepted:
             return _json_error("跨站请求已被拒绝", status=403)
     return None
 
@@ -333,7 +344,9 @@ class DashboardServer:
             and request.method in {"POST", "PUT", "PATCH", "DELETE"}
         ):
             # 会话建立前无法校验 CSRF token，用 Content-Type / Origin 兜住跨站提交
-            guarded = _cross_site_guard(request)
+            guarded = _cross_site_guard(
+                request, trust_proxy=self.config.trust_proxy_headers
+            )
             if guarded is not None:
                 return guarded
 

--- a/app/src/neobot_app/config/loader/backup.py
+++ b/app/src/neobot_app/config/loader/backup.py
@@ -9,17 +9,26 @@ from neobot_app.utils.logger import get_module_logger
 
 logger = get_module_logger("config_backup")
 
+#: 备份文件名：``<源文件名>_<时间戳>.<原后缀>``（时间戳精确到毫秒，避免同秒覆盖）
+_TIMESTAMP_FORMAT = "%Y%m%d_%H%M%S"
+
 
 def backup_config(file_path: Path, backup_dir: Path, max_backups: int = 15) -> None:
-    """备份配置文件到备份目录，保留指定数量的最新备份"""
+    """备份配置文件到备份目录，保留指定数量的最新备份。
+
+    备份名带上源文件名：备份目录里同时存在 config.toml 与 .env 的备份，
+    之前两者都叫 ``config_<ts>.toml``（.env 的明文密钥被写进名为 config 的文件），
+    既容易误把 .env 备份当配置还原，也会让两类备份互相挤占保留额度。
+    """
     if not file_path.exists():
         logger.info(f"配置文件不存在，无需备份: {file_path}")
         return
 
-    # 毫秒级时间戳,避免同一秒内多次备份互相覆盖
-    timestamp = time.strftime("%Y%m%d_%H%M%S") + f"_{int(time.time() * 1000) % 1000:03d}"
-    backup_name = f"config_{timestamp}.toml"
-    backup_path = backup_dir / backup_name
+    timestamp = time.strftime(_TIMESTAMP_FORMAT) + f"_{int(time.time() * 1000) % 1000:03d}"
+    name = file_path.name
+    suffix = file_path.suffix
+    stem = name[: -len(suffix)] if suffix else name
+    backup_path = backup_dir / f"{stem}_{timestamp}{suffix}"
 
     try:
         # 备份目录可能被清空/权限异常,先确保存在
@@ -31,17 +40,19 @@ def backup_config(file_path: Path, backup_dir: Path, max_backups: int = 15) -> N
         return
 
     try:
-        backup_files = []
-        pattern = re.compile(r"^config_\d{8}_\d{6}(?:_\d{3})?\.toml$")
-        for file in backup_dir.iterdir():
-            if file.is_file() and pattern.match(file.name):
-                backup_files.append(file)
-
+        # 只轮转同一来源的备份：不同来源各自保留 max_backups 份
+        pattern = re.compile(
+            rf"^{re.escape(stem)}_\d{{8}}_\d{{6}}(?:_\d{{3}})?{re.escape(suffix)}$"
+        )
+        backup_files = [
+            file
+            for file in backup_dir.iterdir()
+            if file.is_file() and pattern.match(file.name)
+        ]
         backup_files.sort(key=lambda x: x.stat().st_mtime)
 
         if len(backup_files) > max_backups:
-            files_to_delete = backup_files[: len(backup_files) - max_backups]
-            for old_file in files_to_delete:
+            for old_file in backup_files[: len(backup_files) - max_backups]:
                 old_file.unlink()
                 logger.info(f"删除旧备份文件: {old_file}")
     except Exception as e:

--- a/app/src/neobot_app/config/loader/converter.py
+++ b/app/src/neobot_app/config/loader/converter.py
@@ -360,7 +360,7 @@ def dataclass_to_toml(
         doc.add(tomlkit.comment("警告:此文件由程序自动生成和维护"))
         doc.add(tomlkit.comment("所有除了键值的内容（包括注释）都会在重新执行程序时丢失"))
         doc.add(tomlkit.comment("如需更改配置项/注释,请修改neobot_app/config/schemas/bot.py文件"))
-        doc.add(tomlkit.comment("格式损坏的文件会被覆盖,data/config_backup下会存储最多十五个备份,如果意外损坏导致文件被覆盖,可自行提取备份"))
+        doc.add(tomlkit.comment("格式损坏的文件不会被覆盖：程序会报错退出并保留原文件（缺失项补全前会先备份到 data/config_backup，最多十五份）"))
         doc.add(tomlkit.nl())
     else:
         doc = tomlkit.table()

--- a/app/src/neobot_app/config/loader/manager.py
+++ b/app/src/neobot_app/config/loader/manager.py
@@ -1,7 +1,5 @@
 """配置加载器"""
 
-import os
-import tempfile
 from dataclasses import fields, is_dataclass
 from pathlib import Path
 from typing import Any, Dict, Tuple, Type, TypeVar
@@ -10,6 +8,7 @@ import tomlkit
 
 from neobot_app.config.loader.backup import backup_config
 from neobot_app.config.loader.converter import dataclass_to_toml, dict_to_dataclass
+from neobot_app.utils.atomic import atomic_write_text
 from neobot_app.utils.logger import get_module_logger
 
 T = TypeVar("T")
@@ -25,27 +24,14 @@ class ConfigLoadError(RuntimeError):
 
 
 def _atomic_write_text(path: Path, text: str) -> None:
-    """原子写入文本文件（同目录临时文件 + fsync + os.replace）。
+    """原子写入文本文件（同目录临时文件 + fsync + os.replace + 占用重试）。
 
     config.toml 有三个写入者（本模块、面板、命令系统），直接 `open(w)`
     截断写在崩溃/并发下可能留下半截文件，下次启动即解析失败。
+    统一走 neobot_app.utils.atomic：Windows 上目标被编辑器/杀软短暂占用时
+    会重试，否则「补全缺失项」的写回会静默失败（只记 error 日志）。
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temp_name = tempfile.mkstemp(
-        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
-    )
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
-            handle.write(text)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temp_name, path)
-    except BaseException:
-        try:
-            os.unlink(temp_name)
-        except OSError:
-            pass
-        raise
+    atomic_write_text(path, text)
 
 
 def _build_provider_extra_body(

--- a/app/src/neobot_app/config/loader/manager.py
+++ b/app/src/neobot_app/config/loader/manager.py
@@ -1,5 +1,7 @@
 """配置加载器"""
 
+import os
+import tempfile
 from dataclasses import fields, is_dataclass
 from pathlib import Path
 from typing import Any, Dict, Tuple, Type, TypeVar
@@ -20,6 +22,30 @@ class ConfigLoadError(RuntimeError):
     由调用方决定处理方式：启动路径可以打印清单后退出，
     reload 路径应记录错误并保持旧配置生效。
     """
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """原子写入文本文件（同目录临时文件 + fsync + os.replace）。
+
+    config.toml 有三个写入者（本模块、面板、命令系统），直接 `open(w)`
+    截断写在崩溃/并发下可能留下半截文件，下次启动即解析失败。
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+    except BaseException:
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise
 
 
 def _build_provider_extra_body(
@@ -368,6 +394,7 @@ class Config:
 
         existing_data: dict[Any, Any] = {}
         file_exists = file_path.exists()
+        load_error: Exception | None = None
 
         if file_exists:
             try:
@@ -392,7 +419,18 @@ class Config:
                     )
             except Exception as e:
                 logger.error(f"读取配置文件失败: {e}")
+                load_error = e
                 existing_data = {}
+
+        if load_error is not None:
+            # 解析失败时绝不能继续走「补全缺失项 → 写回」：dataclass_to_toml 会把
+            # schema 的所有字段都当成缺失项，等于用默认值整份覆盖用户配置
+            # （只有 config_backup/ 能人工救回）。宁可启动失败并报出原因。
+            raise ConfigLoadError(
+                f"配置文件解析失败，已保持原文件不变：{file_path}\n"
+                f"原因: {load_error}\n"
+                "请修复该文件（或先移走它重新生成）后重试。"
+            )
 
         toml_doc, missing_required, missing_optional = dataclass_to_toml(
             schema, existing_data if file_exists else None, is_root=True
@@ -417,8 +455,7 @@ class Config:
 
             assert toml_doc is not None, "toml_doc should not be None for valid dataclass"
             try:
-                with open(file_path, "w", encoding="utf-8") as f:
-                    f.write(tomlkit.dumps(toml_doc))
+                _atomic_write_text(file_path, tomlkit.dumps(toml_doc))
                 logger.info(
                     f"配置文件已{'更新并补全缺失项' if file_exists else '生成'}: {file_path}"
                 )

--- a/app/src/neobot_app/config/schemas/bot.py
+++ b/app/src/neobot_app/config/schemas/bot.py
@@ -971,7 +971,7 @@ class ScheduledTask:
     )
     poll_interval_seconds: Optional[int] = field(
         default=10,
-        metadata={"description": "定时任务扫描间隔秒数，默认每分钟扫描一次"},
+        metadata={"description": "定时任务扫描间隔秒数，默认 10 秒"},
     )
     default_window_seconds: Optional[int] = field(
         default=3600,

--- a/app/src/neobot_app/config/schemas/bot.py
+++ b/app/src/neobot_app/config/schemas/bot.py
@@ -834,6 +834,17 @@ class Adapter:
             )
         },
     )
+    reverse_ws_access_token: str = field(
+        default="",
+        metadata={
+            "description": (
+                "OneBot 反向 WebSocket 握手鉴权的 access token（onebot 模式，"
+                "OneBot 11 规范）：框架侧在握手请求头带 Authorization: Bearer <token>，"
+                "本端校验一致才接受连接。留空表示不校验（此时监听非回环地址会告警）。"
+                "也可用环境变量 NEO_BOT_ADAPTER_TOKEN / NEOBOT_ADAPTER_TOKEN 配置"
+            )
+        },
+    )
 
 
 

--- a/app/src/neobot_app/config/schemas/bot.py
+++ b/app/src/neobot_app/config/schemas/bot.py
@@ -1,5 +1,5 @@
 import re
-from dataclasses import dataclass, field, fields as dataclass_fields
+from dataclasses import dataclass, field
 from typing import Any, ClassVar, Dict, Iterator, List, Optional, TypedDict
 
 _MODEL_KEY_RE = re.compile(r"[^A-Za-z0-9_.-]+")

--- a/app/src/neobot_app/config/schemas/bot.py
+++ b/app/src/neobot_app/config/schemas/bot.py
@@ -814,6 +814,16 @@ class Adapter:
         default=8090,
         metadata={"description": "本地适配器 HTTP/WebSocket 监听端口"},
     )
+    local_auth_token: str = field(
+        default="",
+        metadata={
+            "description": (
+                "本地适配器（local 模式）的 Bearer token：留空表示不校验，"
+                "此时若监听非回环地址会在启动日志告警。也可用环境变量 "
+                "NEOBOT_LOCAL_ADAPTER_TOKEN 配置"
+            )
+        },
+    )
     reverse_ws_host: str = field(
         default="",
         metadata={

--- a/app/src/neobot_app/core/file_server.py
+++ b/app/src/neobot_app/core/file_server.py
@@ -12,6 +12,7 @@ from typing import Any, Dict
 
 from aiohttp import web
 from neobot_app.time_context import epoch_seconds
+from neobot_app.utils.atomic import atomic_write_text
 
 
 @dataclass
@@ -365,9 +366,10 @@ class FileServer:
         if not self._metadata_file.exists():
             return
         try:
-            with open(self._metadata_file) as f:
+            with open(self._metadata_file, encoding="utf-8") as f:
                 data = json.load(f)
-        except Exception:
+        except Exception as exc:
+            logging.warning("读取文件元数据失败（按空处理）: %s", exc)
             return
         loaded: Dict[str, FileMetadata] = {}
         for key, value in data.items():
@@ -386,10 +388,19 @@ class FileServer:
         self._files = loaded
 
     def _save_metadata(self) -> None:
-        """保存元数据"""
+        """保存元数据。
+
+        原子写入：这里记录已上传文件的过期时间，写一半被杀会留下截断的 JSON，
+        重启后整份元数据丢失、临时文件再也清不掉。编码固定 UTF-8，避免
+        中文文件名在非 UTF-8 默认编码下写入失败（旧实现静默吞掉异常）。
+        """
         try:
-            with open(self._metadata_file, "w") as f:
-                json.dump({k: asdict(v) for k, v in self._files.items()}, f)
-        except Exception:
-            pass
+            atomic_write_text(
+                self._metadata_file,
+                json.dumps(
+                    {k: asdict(v) for k, v in self._files.items()}, ensure_ascii=False
+                ),
+            )
+        except Exception as exc:
+            logging.warning("保存文件元数据失败: %s", exc)
 

--- a/app/src/neobot_app/drawing/service.py
+++ b/app/src/neobot_app/drawing/service.py
@@ -35,7 +35,10 @@ from neobot_app.drawing.config import (
     DrawServiceConfig,
     ImageGenerationError,
 )
-from neobot_app.message.image_pipeline import prepare_local_image
+from neobot_app.message.image_pipeline import (
+    prepare_local_image,
+    prepare_local_image_async,
+)
 from neobot_app.utils.http import image_http_client, is_local_or_private_url
 from neobot_app.utils.media_sender import send_image as _media_send_image
 
@@ -274,7 +277,7 @@ class CreatorImageService:
                 resolved = str(child.resolve())
                 disk_files.add(resolved)
                 try:
-                    prepared = prepare_local_image(child)
+                    prepared = await prepare_local_image_async(child)
                     hash_to_files.setdefault(prepared.file_hash, []).append(child)
                 except Exception:
                     continue
@@ -1391,7 +1394,7 @@ class CreatorImageService:
                 if not file_path.exists() or not file_path.is_file():
                     continue
 
-                prepared = prepare_local_image(file_path)
+                prepared = await prepare_local_image_async(file_path)
                 txt_text = _read_sidecar_description(file_path)
                 if txt_text:
                     description = txt_text
@@ -1423,7 +1426,7 @@ class CreatorImageService:
                 if resolved_path in known_paths:
                     continue
 
-                prepared = prepare_local_image(file_path)
+                prepared = await prepare_local_image_async(file_path)
                 txt_text = _read_sidecar_description(file_path)
                 same_hash_description = descriptions_by_hash.get(prepared.file_hash)
                 if txt_text:
@@ -1473,7 +1476,7 @@ class CreatorImageService:
         if self._vision_provider is None:
             return "[未配置视觉模型]"
         try:
-            prepared = prepare_local_image(file_path)
+            prepared = await prepare_local_image_async(file_path)
             image_url = f"data:{prepared.mime_type};base64,{base64.b64encode(prepared.image_bytes).decode('utf-8')}"
             messages: list[dict[str, Any]] = [
                 {

--- a/app/src/neobot_app/drawing/service.py
+++ b/app/src/neobot_app/drawing/service.py
@@ -1256,9 +1256,9 @@ class CreatorImageService:
         if ref.startswith("base64://"):
             return base64.b64decode(ref[9:])
         if ref.startswith("file:///"):
-            return Path(ref[8:]).read_bytes()
+            return await self._read_local_image(Path(ref[8:]))
         if ref.startswith("file://"):
-            return Path(ref[7:]).read_bytes()
+            return await self._read_local_image(Path(ref[7:]))
         if ref.startswith(("http://", "https://")):
             if is_local_or_private_url(ref):
                 # 本机/内网地址（含 Bot 自己的文件服务器）不能走系统代理
@@ -1275,8 +1275,35 @@ class CreatorImageService:
             return await self._read_limited(response)
         path = Path(ref)
         if path.exists() and path.is_file():
-            return path.read_bytes()
+            return await self._read_local_image(path)
         raise LookupError("无法下载图片内容")
+
+    async def _read_local_image(self, path: Path) -> bytes:
+        """读取本地图片引用（file:// 或裸路径）。
+
+        本地引用可能来自 OneBot 框架自身的图片缓存，也可能来自被注入的事件，
+        而原实现对任何路径都直接 read_bytes，等于把「任意本地文件读取」暴露给
+        上游：内容形态校验 + 体积上限把它收敛为「只读图片」，同时不改变
+        框架正常传图的行为（真实图片无论放在哪个目录都仍可读）。
+        """
+        return await asyncio.to_thread(self._read_local_image_sync, path)
+
+    @staticmethod
+    def _read_local_image_sync(path: Path) -> bytes:
+        from neobot_app.utils.image_bytes import looks_like_image
+
+        if not path.is_file():
+            raise LookupError(f"本地图片不存在: {path}")
+        try:
+            size = path.stat().st_size
+        except OSError as exc:
+            raise LookupError(f"无法读取本地图片: {exc}") from exc
+        if size > _MAX_REMOTE_FETCH_BYTES:
+            raise LookupError(f"本地图片过大（{size} 字节），已拒绝读取")
+        data = path.read_bytes()
+        if not looks_like_image(data):
+            raise LookupError(f"本地引用不是图片内容，已拒绝读取: {path.name}")
+        return data
 
     async def _upsert_record(
         self,

--- a/app/src/neobot_app/drawing/service.py
+++ b/app/src/neobot_app/drawing/service.py
@@ -36,7 +36,6 @@ from neobot_app.drawing.config import (
     ImageGenerationError,
 )
 from neobot_app.message.image_pipeline import (
-    prepare_local_image,
     prepare_local_image_async,
 )
 from neobot_app.utils.http import image_http_client, is_local_or_private_url

--- a/app/src/neobot_app/emoji/service.py
+++ b/app/src/neobot_app/emoji/service.py
@@ -12,7 +12,9 @@ from typing import TYPE_CHECKING, Any
 from neobot_contracts.models.memory import EmojiRecord
 from neobot_contracts.ports.logging import Logger, NullLogger
 
-from neobot_app.message.image_pipeline import prepare_local_image
+from neobot_app.message.image_pipeline import (
+    prepare_local_image_async,
+)
 
 if TYPE_CHECKING:
     from neobot_chat.providers.base import Provider
@@ -210,7 +212,7 @@ class EmojiService:
         if entry is None:
             return
         try:
-            file_hash = prepare_local_image(entry.file_path).file_hash
+            file_hash = (await prepare_local_image_async(entry.file_path)).file_hash
             async with self._uow_factory() as uow:
                 await uow.emojis.increment_usage(file_hash)
                 await uow.commit()
@@ -300,7 +302,7 @@ class EmojiService:
         text = (analysis_text or "").strip()
         if text:
             target_path.with_suffix(".txt").write_text(text, encoding="utf-8")
-            prepared = prepare_local_image(target_path)
+            prepared = await prepare_local_image_async(target_path)
             async with self._uow_factory() as uow:
                 await uow.emojis.set(
                     prepared.file_hash,
@@ -327,7 +329,7 @@ class EmojiService:
 
         file_hash: str | None = None
         try:
-            file_hash = prepare_local_image(entry.file_path).file_hash
+            file_hash = (await prepare_local_image_async(entry.file_path)).file_hash
         except Exception as exc:
             self._logger.warning(f"计算表情包哈希失败 {entry.file_name}: {exc}")
 
@@ -355,7 +357,7 @@ class EmojiService:
             raise FileNotFoundError(f"表情包文件不存在: {entry.file_path}")
 
         entry.file_path.with_suffix(".txt").write_text(text, encoding="utf-8")
-        prepared = prepare_local_image(entry.file_path)
+        prepared = await prepare_local_image_async(entry.file_path)
         async with self._uow_factory() as uow:
             await uow.emojis.set(
                 prepared.file_hash,
@@ -391,7 +393,7 @@ class EmojiService:
         if not entry.file_path.exists():
             raise LookupError(f"表情包文件不存在: {entry.file_path}")
 
-        prepared = prepare_local_image(entry.file_path)
+        prepared = await prepare_local_image_async(entry.file_path)
         async with self._uow_factory() as uow:
             result = await uow.emojis.set(
                 prepared.file_hash,
@@ -432,7 +434,7 @@ class EmojiService:
         if old_txt.exists():
             old_txt.rename(new_txt)
 
-        prepared = prepare_local_image(new_path)
+        prepared = await prepare_local_image_async(new_path)
         try:
             async with self._uow_factory() as uow:
                 renamed = await uow.emojis.rename(
@@ -481,7 +483,7 @@ class EmojiService:
         path_to_hash: dict[Path, str] = {}
         for file_path in image_files:
             try:
-                prepared = prepare_local_image(file_path)
+                prepared = await prepare_local_image_async(file_path)
                 if prepared.file_hash in hash_to_path:
                     existing = hash_to_path[prepared.file_hash]
                     # 保留较旧的文件
@@ -520,7 +522,7 @@ class EmojiService:
                 if file_hash is None:
                     continue
 
-                prepared = prepare_local_image(file_path)
+                prepared = await prepare_local_image_async(file_path)
                 txt_text = _read_sidecar_text(file_path)
                 try:
                     record = await uow.emojis.get_by_hash(file_hash)
@@ -570,7 +572,7 @@ class EmojiService:
             try:
                 async with self._uow_factory() as uow:
                     for file_hash, file_path, analysis_text in new_results:
-                        prepared = prepare_local_image(file_path)
+                        prepared = await prepare_local_image_async(file_path)
                         file_path.with_suffix(".txt").write_text(analysis_text, encoding="utf-8")
                         record = await uow.emojis.set(
                             file_hash,
@@ -646,7 +648,7 @@ class EmojiService:
         async def parse_one(file_hash: str, file_path: Path) -> tuple[str, Path, str]:
             async with semaphore:
                 try:
-                    prepared = prepare_local_image(file_path)
+                    prepared = await prepare_local_image_async(file_path)
                     import base64
                     b64 = base64.b64encode(prepared.image_bytes).decode("utf-8")
                     image_url = f"data:{prepared.mime_type};base64,{b64}"
@@ -856,8 +858,10 @@ class EmojiService:
                 continue
             text = _read_sidecar_text(path) or "[待解析]"
             try:
-                prepared = prepare_local_image(path)
-                file_hash = prepared.file_hash
+                # 这里只需要 file_hash（prepare_local_image 定义它就是原始字节的
+                # sha256），直接算哈希即可：避免在同步路径上做 PIL 解码+缩放。
+                # 本函数由 _notify_disk_changed 从同步访问器调用，不能 await。
+                file_hash = hashlib.sha256(path.read_bytes()).hexdigest()
             except Exception:
                 file_hash = ""
             number = self._next_number

--- a/app/src/neobot_app/image/parser.py
+++ b/app/src/neobot_app/image/parser.py
@@ -14,6 +14,7 @@ from PIL import Image
 
 from neobot_contracts.ports.logging import Logger, NullLogger
 from neobot_app.utils.http import image_http_client
+from neobot_app.utils.image_bytes import IMAGE_MAGIC_PREFIXES, looks_like_image
 
 if TYPE_CHECKING:
     from neobot_adapter import OneBotAdapter
@@ -457,26 +458,12 @@ def _normalize_for_vision(
     return buf.getvalue(), Image.MIME.get(out_format, "image/png")
 
 
-_VALID_IMAGE_MAGIC = (
-    b"\xff\xd8\xff",       # JPEG
-    b"\x89PNG\r\n\x1a\n",  # PNG
-    b"RIFF",               # WebP (need further check)
-    b"GIF87a",             # GIF
-    b"GIF89a",             # GIF
-    b"BM",                 # BMP
-)
+_VALID_IMAGE_MAGIC = IMAGE_MAGIC_PREFIXES
 
 
 def _is_valid_image(content: bytes) -> bool:
     """检查字节内容是否是有效的图片格式"""
-    if len(content) < 16:
-        return False
-    for magic in _VALID_IMAGE_MAGIC:
-        if content.startswith(magic):
-            if magic == b"RIFF":
-                return len(content) >= 12 and content[8:12] == b"WEBP"
-            return True
-    return False
+    return looks_like_image(content)
 
 
 def _detect_image_mime(image_bytes: bytes) -> str:

--- a/app/src/neobot_app/message/image_pipeline.py
+++ b/app/src/neobot_app/message/image_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 import hashlib
 from io import BytesIO
@@ -71,7 +72,11 @@ class ImagePromptPreparer:
         self._max_pixels = max_pixels
 
     async def resolve_local_image(self, image_path: str | Path) -> ImagePromptResolution:
-        prepared = prepare_local_image(image_path, max_pixels=self._max_pixels)
+        # prepare_local_image 会 read_bytes + PIL 解码 + LANCZOS 重采样重编码，
+        # 属于纯 CPU/磁盘工作：留在事件循环上会让每条带图消息都卡住整个 Bot。
+        prepared = await asyncio.to_thread(
+            prepare_local_image, image_path, max_pixels=self._max_pixels
+        )
         cached = await self._image_analysis_service.get(prepared.file_hash)
         return ImagePromptResolution(prepared=prepared, cached_analysis=cached)
 
@@ -88,11 +93,20 @@ class ImagePromptPreparer:
         )
 
 
+async def prepare_local_image_async(
+    image_path: str | Path, *, max_pixels: int = DEFAULT_MAX_IMAGE_PIXELS
+) -> PreparedImage:
+    """``prepare_local_image`` 的异步入口：解码/缩放属于 CPU+磁盘工作，
+    在事件循环里直接调用会卡住整个 Bot（含其它会话与心跳）。"""
+    return await asyncio.to_thread(
+        prepare_local_image, image_path, max_pixels=max_pixels
+    )
+
+
 def prepare_local_image(image_path: str | Path, *, max_pixels: int = DEFAULT_MAX_IMAGE_PIXELS) -> PreparedImage:
     """读取本地图片、计算哈希，并在需要时按比例缩小尺寸。"""
     if max_pixels <= 0:
         raise ValueError("max_pixels must be greater than 0")
-
     path = Path(image_path).expanduser().resolve()
     if not path.exists():
         raise ImagePreparationError(f"image does not exist: {path}")

--- a/app/src/neobot_app/message/queue.py
+++ b/app/src/neobot_app/message/queue.py
@@ -91,6 +91,11 @@ class QueueEntry:
     reaction: Optional[ReactionEntry] = None
     poke: Optional[PokeEntry] = None
     replied_messages: List[QueueMessage] = field(default_factory=list)
+    #: 该条目占用的容量权重（入队时固化）。
+    #: 驱逐与「按权重取最近消息」必须读同一个值：此前驱逐按 kind 重算
+    #: （MESSAGE 恒为 1.0），而入队按内容计算（合并转发为 forward_weight），
+    #: 导致权重账本单调虚高、队列提前丢弃真实消息。
+    weight: float = 1.0
 
 
 class MessageQueue:
@@ -209,21 +214,22 @@ class MessageQueue:
         if self._get_message_count(key) == 0:
             if include_on_empty:
                 queue.append(
-                    QueueEntry(kind=QueueEntryType.TIMESTAMP, occurred_at=occurred_at)
+                    QueueEntry(
+                        kind=QueueEntryType.TIMESTAMP,
+                        occurred_at=occurred_at,
+                        weight=0.0,
+                    )
                 )
             return
         if last_message_time is None:
             return
         if occurred_at - last_message_time <= self.timestamp_interval_seconds:
             return
-        queue.append(QueueEntry(kind=QueueEntryType.TIMESTAMP, occurred_at=occurred_at))
-
-    def _get_entry_weight(self, kind: QueueEntryType) -> float:
-        if kind == QueueEntryType.POKE:
-            return self.poke_weight
-        if kind == QueueEntryType.REACTION:
-            return self.reaction_weight
-        return 1.0
+        queue.append(
+            QueueEntry(
+                kind=QueueEntryType.TIMESTAMP, occurred_at=occurred_at, weight=0.0
+            )
+        )
 
     def _compute_message_weight(self, message: QueueMessage) -> float:
         if message.message:
@@ -252,7 +258,7 @@ class MessageQueue:
             if dropped_entry.kind == QueueEntryType.TIMESTAMP:
                 continue
 
-            weighted_count -= self._get_entry_weight(dropped_entry.kind)
+            weighted_count -= dropped_entry.weight
             self._message_counts[key] -= 1
             stats.dropped_messages += 1
 
@@ -307,6 +313,7 @@ class MessageQueue:
                 occurred_at=resolved_time,
                 message=converted_message,
                 replied_messages=converted_replies,
+                weight=entry_weight,
             )
         )
         self._message_counts[key] += 1
@@ -368,6 +375,7 @@ class MessageQueue:
                 occurred_at=resolved_time,
                 notice=copy.deepcopy(notice),
                 recalled_message=recalled_message,
+                weight=1.0,
             )
         )
         self._message_counts[key] += 1
@@ -388,6 +396,7 @@ class MessageQueue:
                 kind=QueueEntryType.REACTION,
                 occurred_at=reaction.target_message_id,
                 reaction=reaction,
+                weight=entry_weight,
             )
         )
         self._message_counts[key] += 1
@@ -404,6 +413,7 @@ class MessageQueue:
                 kind=QueueEntryType.POKE,
                 occurred_at=resolved_time,
                 poke=poke,
+                weight=entry_weight,
             )
         )
         self._message_counts[key] += 1
@@ -496,14 +506,7 @@ class MessageQueue:
         for entry in reversed(queue):
             if entry.kind == QueueEntryType.TIMESTAMP:
                 continue
-            if entry.kind == QueueEntryType.MESSAGE and entry.message is not None:
-                weight = self._compute_message_weight(entry.message)
-            elif entry.kind == QueueEntryType.POKE:
-                weight = self.poke_weight
-            elif entry.kind == QueueEntryType.REACTION:
-                weight = self.reaction_weight
-            else:
-                weight = 1.0
+            weight = entry.weight
 
             if not first and accumulated + weight > max_weight:
                 return

--- a/app/src/neobot_app/observability/logging.py
+++ b/app/src/neobot_app/observability/logging.py
@@ -23,19 +23,37 @@ _REDACTED = "***REDACTED***"
 # 敏感信息脱敏模式：sk- 前缀的 OpenAI 风格 Key，以及常见键值形式的
 # key/token/password/secret/authorization/bearer。值边界限定为空白/逗号/分号，
 # 避免吞掉相邻内容；纯单词 "token" 等不会被误伤。
+#
+# 键名允许带前缀（``DEEPSEEK_APIKEY=``、``client_secret=``、``csrf_token=``）：
+# 旧写法用 ``\b`` 卡词边界，而下划线是词字符，导致这些形态整类漏脱敏。
 _REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"sk-[A-Za-z0-9_-]{8,}"),
     re.compile(
-        r"(?i)\b(api[_-]?key|access[_-]?token|token|password|secret|authorization)"
-        r"\b\s*[=:]\s*(?:(?:bearer|token)\s+)?[^\s,;]+"
+        r"(?i)(?<![A-Za-z0-9])[A-Za-z0-9_]*"
+        r"(?:api[_-]?key|apikey|access[_-]?token|auth[_-]?token|token|password|"
+        r"passwd|pwd|secret|credential|authorization)"
+        r"\s*[=:]\s*(?:(?:bearer|token)\s+)?[^\s,;\"']+"
     ),
     re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+"),
+    # 无分隔符的裸形态：「密码是 hunter2」。值必须含数字且不短于 6 位，
+    # 否则会把 "password strength is weak" 这类正常句子一起脱敏。
+    re.compile(
+        r"(?i)(?<![A-Za-z0-9])(?:password|passwd|pwd|secret|token|api[_-]?key)"
+        r"(?:\s+is)?\s*[=:]?\s+(?=[A-Za-z0-9._~+/=-]*\d)[A-Za-z0-9._~+/=-]{6,}"
+    ),
+    # URL 内嵌凭据：https://user:password@host/...
+    re.compile(r"(?i)([a-z][a-z0-9+.-]*://)[^/\s:@]+:[^/\s@]+@"),
 )
+
+_URL_USERINFO_RE = _REDACTION_PATTERNS[-1]
 
 
 def redact_sensitive(text: str) -> str:
     """将文本中的常见敏感信息（API Key / token / password 等）替换为 ***REDACTED***。"""
     for pattern in _REDACTION_PATTERNS:
+        if pattern is _URL_USERINFO_RE:
+            text = pattern.sub(rf"\1{_REDACTED}@", text)
+            continue
         text = pattern.sub(_REDACTED, text)
     return text
 
@@ -53,7 +71,14 @@ def _redacting_filter(record: dict[str, Any]) -> bool:
     （保留原 traceback 对象）挂回 record；文件 sink 使用 _file_sink_format
     （函数式 format，不含 {exception}）避免 loguru 渲染原始 traceback 的
     未脱敏源码行，密钥不再泄露。
+
+    控制台与文件 sink 都挂这个 filter，且 record 在各 sink 间共享，因此用标记
+    保证只执行一次（否则 traceback 会被追加两遍）。
     """
+    extra = record.setdefault("extra", {})
+    if extra.get("_redaction_applied"):
+        return True
+    extra["_redaction_applied"] = True
     record["message"] = redact_sensitive(record["message"])
     exc = record.get("exception")
     if not exc:
@@ -243,6 +268,9 @@ def configure_loguru(log_dir: Path | None = None, *, runtime_events: bool = Fals
         format=console_format,
         level="DEBUG",
         colorize=True,
+        # 控制台此前没有挂脱敏 filter：密钥会以明文进 stderr（容器/重定向日志
+        # 同样会落盘）。挂上后 record 被改写，后续 sink 也拿到脱敏文本。
+        filter=_redacting_filter,
     )
 
     if log_dir is not None:

--- a/app/src/neobot_app/reply/orchestrator.py
+++ b/app/src/neobot_app/reply/orchestrator.py
@@ -266,6 +266,15 @@ if TYPE_CHECKING:
     from neobot_app.core.file_server import FileServer
 
 
+def _hook_name(hook: object) -> str:
+    """钩子的可读标识（用于日志）。"""
+    return str(
+        getattr(hook, "__qualname__", None)
+        or getattr(hook, "__name__", None)
+        or type(hook).__name__
+    )
+
+
 class ReplyOrchestrator:
     def __init__(
         self,
@@ -389,8 +398,18 @@ class ReplyOrchestrator:
                 result = await hook(event)
                 if result is not None:
                     return result
-            except Exception:
-                pass
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                # 钩子是插件扩展点：失败必须留痕，否则「钩子没生效」与
+                # 「钩子抛异常被吞」从外部完全无法区分。
+                self._logger.warning(
+                    "pre_reply hook 执行失败，已跳过",
+                    event_id=event.event_id,
+                    hook=_hook_name(hook),
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
         return None
 
     async def _apply_post_reply_hooks(
@@ -401,8 +420,16 @@ class ReplyOrchestrator:
                 modified = await hook(event, text)
                 if modified is not None:
                     text = modified
-            except Exception:
-                pass
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._logger.warning(
+                    "post_reply hook 执行失败，已跳过",
+                    event_id=event.event_id,
+                    hook=_hook_name(hook),
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
         return text
 
     async def handle_agent_tool_input(self, message: Any, *, kind: str, queue_key: str) -> str | None:

--- a/app/src/neobot_app/reply/orchestrator.py
+++ b/app/src/neobot_app/reply/orchestrator.py
@@ -586,13 +586,32 @@ class ReplyOrchestrator:
     def _release_executor(self, event_id: str) -> None:
         """释放某次回复创建的工具执行器。
 
-        执行器持有该轮完整对话历史与技能 token，必须随管线结束释放；
-        关闭失败只记日志，不能影响管线收尾。
+        执行器持有该轮完整对话历史与技能 token，必须随管线结束释放；但不能直接
+        ``close()``：close() 会取消在途的会话工具（download__url / parse_image
+        等），而它们的契约是活过本轮回复、完成后由通知中心唤醒下一次回复。
+        所以先等在途会话任务自然结束，再关闭执行器——内存依然会被释放，只是
+        释放时机推迟到后台工作完成。关闭失败只记日志，不能影响管线收尾。
         """
         executor = self._tool_executors.pop(event_id, None)
         if executor is None:
             return
-        close_task = asyncio.ensure_future(executor.close())
+
+        async def _drain_and_close() -> None:
+            drain = getattr(executor, "drain_sessions", None)
+            if callable(drain):
+                await drain()
+            await executor.close()
+
+        close_task: asyncio.Future[None]
+        try:
+            close_task = asyncio.ensure_future(_drain_and_close())
+        except Exception as exc:
+            # 同步异常绝不能冒泡到 done 回调：那会连带跳过 on_reply_done，
+            # 让「回复中」标记永久残留。
+            self._logger.warning(
+                "回复工具执行器释放失败", event_id=event_id, error=str(exc)
+            )
+            return
         self._callback_tasks.add(close_task)
 
         def _done(done_task: asyncio.Future[None]) -> None:

--- a/app/src/neobot_app/reply/orchestrator.py
+++ b/app/src/neobot_app/reply/orchestrator.py
@@ -836,11 +836,13 @@ class ReplyOrchestrator:
             raise deferred
 
     def _resolve_mode(self) -> str:
+        # 回退值必须与 config.schemas.bot.Chat.reply_mode 的默认值一致（agent），
+        # 否则「字段缺失」时会静默降级成 common（只有基础回复能力）。
         if self._config is not None:
-            mode = getattr(self._config.chat, "reply_mode", "common") or "common"
+            mode = getattr(self._config.chat, "reply_mode", "agent") or "agent"
             if mode in ("common", "agent"):
                 return mode
-        return "common"
+        return "agent"
 
     def _get_cooldown_seconds(self) -> int:
         if self._config is not None:

--- a/app/src/neobot_app/reply/orchestrator.py
+++ b/app/src/neobot_app/reply/orchestrator.py
@@ -343,7 +343,10 @@ class ReplyOrchestrator:
         self._config_update_callback = config_update_callback
         self._tasks: set[asyncio.Task[None]] = set()
         self._callback_tasks: set[asyncio.Task[None]] = set()
-        self._tool_executors: set[Any] = set()
+        #: 事件 ID -> 该次回复创建的工具执行器。
+        #: 必须按事件索引并在回复结束时释放：旧实现只 add 不 remove，
+        #: 每个 agent 模式回复都会永久留下一个持有完整对话历史的执行器。
+        self._tool_executors: dict[str, Any] = {}
         self._agent_tool_turns: dict[str, tuple[Any, Any, list[dict]]] = {}
         self._active_pipelines: dict[str, asyncio.Task[None]] = {}
         self._last_reply_time: dict[str, float] = {}
@@ -553,6 +556,7 @@ class ReplyOrchestrator:
                     runtime.finish_turn(context, history, cancelled=event.state in {ReplyState.CANCELLED, ReplyState.FAILED})
                 except Exception as exc:
                     self._logger.warning("agent 目标续跑未能调度", error=str(exc))
+            self._release_executor(event.event_id)
             if on_reply_done is not None:
                 callback_task = asyncio.ensure_future(on_reply_done())
                 self._callback_tasks.add(callback_task)
@@ -578,6 +582,33 @@ class ReplyOrchestrator:
         self._active_pipelines[pipeline_key] = task
         task.add_done_callback(_cleanup)
         return event
+
+    def _release_executor(self, event_id: str) -> None:
+        """释放某次回复创建的工具执行器。
+
+        执行器持有该轮完整对话历史与技能 token，必须随管线结束释放；
+        关闭失败只记日志，不能影响管线收尾。
+        """
+        executor = self._tool_executors.pop(event_id, None)
+        if executor is None:
+            return
+        close_task = asyncio.ensure_future(executor.close())
+        self._callback_tasks.add(close_task)
+
+        def _done(done_task: asyncio.Future[None]) -> None:
+            self._callback_tasks.discard(close_task)
+            try:
+                done_task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                self._logger.warning(
+                    "回复工具执行器释放失败",
+                    event_id=event_id,
+                    error=str(exc),
+                )
+
+        close_task.add_done_callback(_done)
 
     def is_pipeline_active(self, kind: str, conversation_id: str) -> bool:
         pipeline_key = f"{kind}:{conversation_id}"
@@ -754,7 +785,7 @@ class ReplyOrchestrator:
                 await asyncio.gather(*pending, return_exceptions=True)
 
         async def _close_executors() -> None:
-            executors = list(self._tool_executors)
+            executors = list(self._tool_executors.values())
             if not executors:
                 return
             fatal: BaseException | None = None
@@ -2035,7 +2066,7 @@ class ReplyOrchestrator:
             config_update_callback=self._config_update_callback,
             native_vision_provider=self._provider,
         )
-        self._tool_executors.add(reply_toolset.executor)
+        self._tool_executors[event.event_id] = reply_toolset.executor
         if self._skill_manager is not None and conv_kind in {"group", "private"} and str(conv_id).isdigit():
             from neobot_app.skills.agent_tools_skill import AgentToolsSkill
             from neobot_app.agent_tools.contracts import ToolContext

--- a/app/src/neobot_app/reply/orchestrator.py
+++ b/app/src/neobot_app/reply/orchestrator.py
@@ -2492,12 +2492,17 @@ class ReplyOrchestrator:
                             cancel_for_silence(f"tool:{name}")
                             return
                     except Exception as tool_exc:
-                        tool_error = f"工具 {name} 执行失败"
+                        # 保留失败原因：只记 error_type 的话，日志与模型都拿不到
+                        # 真实原因（旧实现连 str(exc) 都没保留）。回给模型的文案
+                        # 先脱敏，避免异常信息里的密钥进入 LLM 上下文。
+                        raw_detail = f"{type(tool_exc).__name__}: {tool_exc}".strip()
+                        detail = _scrub_secret_values(raw_detail)[:300]
+                        tool_error = f"工具 {name} 执行失败：{detail}"
                         self._logger.warning(
                             f"工具调用失败: {name}",
                             event_id=event.event_id,
                             tool=name,
-                            error_type=type(tool_exc).__name__,
+                            error=detail,
                         )
                         await self._emit_runtime_event(
                             "tool.call.after",

--- a/app/src/neobot_app/reply/orchestrator.py
+++ b/app/src/neobot_app/reply/orchestrator.py
@@ -182,18 +182,27 @@ def _redact_tool_value(
 
 _SECRET_VALUE_RE = re.compile(
     r"(?i)(bearer\s+|"
-    r"[\"']?(?:authorization|api[_-]?key|access[_-]?key|private[_-]?key|"
-    r"client[_-]?secret|secret|token|passwd|password|credential|pwd)"
+    r"[\"']?(?:authorization|api[_-]?key|apikey|access[_-]?token|access[_-]?key|"
+    r"auth[_-]?token|client[_-]?secret|private[_-]?key|"
+    r"secret|token|passwd|password|credential|pwd)"
     r"[\"']?\s*[:=]\s*[\"']?)"
     r"(?:bearer\s+)?[^\s,;\"']+"
 )
+
+#: 没有键名的裸密钥形态（``sk-proj-...``）：上面那条正则要求 ``key=value``
+#: 或 ``Bearer``，异常文本里直接出现的 key 会整条漏给模型。
+_BARE_SECRET_KEY_RE = re.compile(r"sk-[A-Za-z0-9_-]{8,}")
+#: URL 内嵌凭据：``https://user:password@host``。
+_URL_USERINFO_RE = re.compile(r"(?i)([a-z][a-z0-9+.-]*://)[^/\s:@]+:[^/\s@]+@")
 
 
 def _scrub_secret_values(text: str) -> str:
     """把字符串值内嵌的常见密钥形态（Bearer <token>、token=xxx 等）替换为占位符。"""
     if not isinstance(text, str):
         return text
-    return _SECRET_VALUE_RE.sub(lambda match: match.group(1) + "<redacted>", text)
+    scrubbed = _SECRET_VALUE_RE.sub(lambda match: match.group(1) + "<redacted>", text)
+    scrubbed = _BARE_SECRET_KEY_RE.sub("<redacted>", scrubbed)
+    return _URL_USERINFO_RE.sub(r"\1<redacted>@", scrubbed)
 
 
 def _redacted_tool_text(value: object, limit: int = _MAX_TOOL_LOG_CHARS) -> str:

--- a/app/src/neobot_app/reply/tools.py
+++ b/app/src/neobot_app/reply/tools.py
@@ -2284,6 +2284,18 @@ class ReplyToolExecutor(ToolExecutor):
             )
         return "\n".join(lines)
 
+    async def drain_sessions(self) -> None:
+        """等待在途会话工具任务自然结束，不取消它们。
+
+        回复管线结束时调用。会话工具的契约是活过本轮回复（工具返回值明确要求模型
+        「立即结束本轮回复」，完成后由通知中心唤醒下一次回复），所以这里只等它们
+        跑完，好让执行器连同完整对话历史一起释放；只有进程关停才用 close() 取消。
+        """
+        while self._session_tasks:
+            tasks = tuple(self._session_tasks)
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self._session_tasks.difference_update(tasks)
+
     async def close(self) -> None:
         """Idempotently reject new session work, cancel active work, and wait for it."""
         if self._close_task is None:

--- a/app/src/neobot_app/runtime/archive_memory_summary.py
+++ b/app/src/neobot_app/runtime/archive_memory_summary.py
@@ -46,6 +46,9 @@ class ArchiveMemoryAutoSummaryService:
         self._config = config
         self._logger = logger or NullLogger()
         self._locks: dict[str, asyncio.Lock] = {}
+        #: 计数器状态的解析缓存（键 = conversation_kind:conversation_id）。
+        #: 见 _cached_counter：避免每条消息都重新读库并 json.loads 整个 blob。
+        self._counter_cache: dict[str, dict[str, Any]] = {}
         self._tool_definitions = tool_definitions or []
         self._tool_executor = tool_executor
         fav_cfg = getattr(getattr(getattr(config, "agent", None), "memory", None), "favorability", None)
@@ -97,7 +100,7 @@ class ArchiveMemoryAutoSummaryService:
 
         counter_key = self._counter_key(conversation_kind, conversation_id)
         async with self._counter_lock(counter_key):
-            state = await self._load_counter(counter_key)
+            state = await self._cached_counter(counter_key)
             messages = list(state.get("messages", []))
             messages.append(
                 {
@@ -288,6 +291,20 @@ class ArchiveMemoryAutoSummaryService:
                 del self._locks[counter_key]
             lock.release()
 
+    async def _cached_counter(self, key: str) -> dict[str, Any]:
+        """读取计数器状态（带进程内解析缓存）。
+
+        record_message 每条消息都要读一次计数器，而它是一整个 JSON blob
+        （间隔 500 条 × 800 字符 ≈ 400KB）：在事件循环上每条消息做一次 DB 读 +
+        json.loads 是实实在在的开销。缓存解析结果后，读路径只在首次落到 DB；
+        写路径仍然每条都落库，因此崩溃丢失窗口与原来一致。
+        """
+        cached = self._counter_cache.get(key)
+        if cached is None:
+            cached = await self._load_counter(key)
+            self._counter_cache[key] = cached
+        return cached
+
     async def _load_counter(self, key: str) -> dict[str, Any]:
         item = await self._archive.get(COUNTER_TABLE, key)
         if item is None or not item.value:
@@ -316,6 +333,8 @@ class ArchiveMemoryAutoSummaryService:
             json.dumps(state, ensure_ascii=False),
             ["auto_summary_counter"],
         )
+        # 同步缓存，避免下次读到过期内容（尤其是总结成功后的清零）
+        self._counter_cache[key] = state
 
     async def flush_all(self) -> None:
         """关闭时并发刷新所有待处理的计数器。

--- a/app/src/neobot_app/runtime/archive_memory_summary.py
+++ b/app/src/neobot_app/runtime/archive_memory_summary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
@@ -25,6 +26,10 @@ DEFAULT_MAX_TOOL_ROUNDS = 20
 # 工具执行失败(未知工具/执行异常)累计达到该次数即中止本次总结，避免模型反复重试烧 token。
 MAX_TOOL_FAILURES = 3
 _TOOL_FAILURE_MARKERS = ("未知工具", "工具执行失败", "Tool error")
+#: 计数器解析缓存的存活时间：缓存把「每条消息一次 DB 读 + json.loads」降到
+#: 「每 30 秒一次」，同时保证外部对该行的修改（模型经 archive_crud 写
+#: memory_counter、另一进程、人工改库）在有限时间内重新可见。
+_COUNTER_CACHE_TTL_SECONDS = 30.0
 
 
 class ArchiveMemoryAutoSummaryService:
@@ -46,9 +51,10 @@ class ArchiveMemoryAutoSummaryService:
         self._config = config
         self._logger = logger or NullLogger()
         self._locks: dict[str, asyncio.Lock] = {}
-        #: 计数器状态的解析缓存（键 = conversation_kind:conversation_id）。
-        #: 见 _cached_counter：避免每条消息都重新读库并 json.loads 整个 blob。
-        self._counter_cache: dict[str, dict[str, Any]] = {}
+        #: 计数器状态的解析缓存（键 = conversation_kind:conversation_id，值 =
+        #: (计数器, 载入时刻)）。见 _cached_counter：避免每条消息都重新读库并
+        #: json.loads 整个 blob，同时靠 TTL 让外部修改在有限时间内可见。
+        self._counter_cache: dict[str, tuple[dict[str, Any], float]] = {}
         self._tool_definitions = tool_definitions or []
         self._tool_executor = tool_executor
         fav_cfg = getattr(getattr(getattr(config, "agent", None), "memory", None), "favorability", None)
@@ -292,18 +298,24 @@ class ArchiveMemoryAutoSummaryService:
             lock.release()
 
     async def _cached_counter(self, key: str) -> dict[str, Any]:
-        """读取计数器状态（带进程内解析缓存）。
+        """读取计数器状态（带进程内解析缓存，缓存有 TTL）。
 
         record_message 每条消息都要读一次计数器，而它是一整个 JSON blob
         （间隔 500 条 × 800 字符 ≈ 400KB）：在事件循环上每条消息做一次 DB 读 +
-        json.loads 是实实在在的开销。缓存解析结果后，读路径只在首次落到 DB；
-        写路径仍然每条都落库，因此崩溃丢失窗口与原来一致。
+        json.loads 是实实在在的开销。缓存解析结果后，读路径只在缓存过期（或首次）
+        时落到 DB；写路径仍然每条都落库，因此崩溃丢失窗口与原来一致。
+
+        缓存必须过期：计数器行的外部修改（模型通过 archive_crud 写
+        memory_counter、另一个进程、人工改库）在旧实现里是可见的——永不重读会
+        让本进程把陈旧 blob 整块写回，撤消外部的删除/清零。
         """
+        now = time.monotonic()
         cached = self._counter_cache.get(key)
-        if cached is None:
-            cached = await self._load_counter(key)
-            self._counter_cache[key] = cached
-        return cached
+        if cached is not None and now - cached[1] < _COUNTER_CACHE_TTL_SECONDS:
+            return cached[0]
+        fresh = await self._load_counter(key)
+        self._counter_cache[key] = (fresh, now)
+        return fresh
 
     async def _load_counter(self, key: str) -> dict[str, Any]:
         item = await self._archive.get(COUNTER_TABLE, key)
@@ -334,7 +346,7 @@ class ArchiveMemoryAutoSummaryService:
             ["auto_summary_counter"],
         )
         # 同步缓存，避免下次读到过期内容（尤其是总结成功后的清零）
-        self._counter_cache[key] = state
+        self._counter_cache[key] = (state, time.monotonic())
 
     async def flush_all(self) -> None:
         """关闭时并发刷新所有待处理的计数器。

--- a/app/src/neobot_app/runtime/browser_lifecycle.py
+++ b/app/src/neobot_app/runtime/browser_lifecycle.py
@@ -157,6 +157,25 @@ class BrowserLifecycleManager:
                 idle.append((cid, set(state.tab_ids)))
         return idle
 
+    def _get_stale_flow_ids(self) -> list[str]:
+        """没有任何标签页、也不再 hold 的过期流。
+
+        ``touch`` / ``hold`` 会为每个聊天流建一条状态，标签页关掉后
+        ``track_tab_close`` 只清空 tab_ids，条目本身留着；``_get_idle_flows``
+        又跳过没有标签页的流，于是这些空壳永远不会被回收，长期运行的 Bot 会
+        按聊天流数量无限堆积。
+        """
+        now = time.time()
+        stale: list[str] = []
+        for cid, state in list(self._flows.items()):
+            if state.tab_ids:
+                continue
+            if state.held_until is not None and now < state.held_until:
+                continue
+            if now - state.last_access >= self._idle_timeout:
+                stale.append(cid)
+        return stale
+
     # ── 后台自动关闭 ──
 
     async def start(self) -> None:
@@ -190,6 +209,9 @@ class BrowserLifecycleManager:
                         except Exception:
                             pass
                     async with self._lock:
+                        self._flows.pop(chat_flow_id, None)
+                async with self._lock:
+                    for chat_flow_id in self._get_stale_flow_ids():
                         self._flows.pop(chat_flow_id, None)
             except asyncio.CancelledError:
                 return

--- a/app/src/neobot_app/runtime/event_pipeline.py
+++ b/app/src/neobot_app/runtime/event_pipeline.py
@@ -924,10 +924,21 @@ class EventPipeline:
 
     async def _process_pending_image_willing(self, queue_key: str) -> None:
         """等待图片解析完成，然后按序处理待处理队列。若触发回复则清空剩余。"""
-        if self._image_parse_service is not None:
-            await self._image_parse_service.wait_for_queue(
-                queue_key,
-                timeout=self._get_group_agent_silent_timeout_seconds(),
+        try:
+            if self._image_parse_service is not None:
+                await self._image_parse_service.wait_for_queue(
+                    queue_key,
+                    timeout=self._get_group_agent_silent_timeout_seconds(),
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # 等待失败也必须继续往下走：旧实现直接抛出会让 pending 列表既不
+            # 被取出也不被处理，这些消息会永久滞留（不再触发回复）。
+            self._logger.warning(
+                "等待图片解析失败，继续处理待处理消息",
+                queue_key=queue_key,
+                error=str(exc),
             )
 
         async with self._image_willing_lock(queue_key):

--- a/app/src/neobot_app/runtime/event_pipeline.py
+++ b/app/src/neobot_app/runtime/event_pipeline.py
@@ -828,7 +828,6 @@ class EventPipeline:
             return False
 
         pre_reply_msg_id = queue.get_last_message_id(queue_key)
-        self._replying_queues.add(queue_key)
 
         # 群聊寿命机制：寿命>0时，回复后队列由管线挂起循环处理，
         # 管线结束时直接丢弃_避免唤起新回复管线
@@ -855,8 +854,10 @@ class EventPipeline:
             background_content=background_content,
         )
         if event is None:
-            self._replying_queues.discard(queue_key)
+            # 标记归「真正启动成功的那条管线」所有：这里若 discard，会把同会话
+            # 正在运行的另一条管线的标记一并删掉（分流守卫被静默破坏）。
             return False
+        self._replying_queues.add(queue_key)
         return True
 
     @asynccontextmanager
@@ -1272,7 +1273,6 @@ class EventPipeline:
             reasons=("command_sync_reply",),
         )
         pre_reply_msg_id = queue.get_last_message_id(queue_key)
-        self._replying_queues.add(queue_key)
 
         async def on_reply_done() -> None:
             self._replying_queues.discard(queue_key)
@@ -1288,14 +1288,15 @@ class EventPipeline:
             background_content=background,
         )
         if started is None:
-            # 管线被拒（编排器已关闭／同会话管线在跑／冷却中）：on_reply_done 永远
-            # 不会被调用，必须自己回滚刚打上的标记，否则该会话会永久留在
-            # _replying_queues 里——命令的 sync_reply 结果再也不会投递，
-            # 后续新消息也一律被当「回复中」处理。
-            self._replying_queues.discard(queue_key)
+            # 管线被拒（编排器已关闭／同会话管线在跑／冷却中）：此时不能 discard ——
+            # 标记可能属于另一条**正在运行**的管线（同会话管线在跑正是这里的常见
+            # 拒绝原因），删掉它会破坏那条管线的分流守卫，让后续消息走意愿路径并
+            # 在同样被拒时丢失。标记改为「启动成功后才打」，这里什么都不用做。
             self._logger.debug(
-                "命令同步回复未能启动，已回滚回复中标记", queue_key=queue_key
+                "命令同步回复未能启动，未设置回复中标记", queue_key=queue_key
             )
+            return
+        self._replying_queues.add(queue_key)
 
     async def _try_issue_credential(
         self,

--- a/app/src/neobot_app/runtime/event_pipeline.py
+++ b/app/src/neobot_app/runtime/event_pipeline.py
@@ -1336,7 +1336,7 @@ class EventPipeline:
             self._replying_queues.discard(queue_key)
             await self._process_post_reply_queue(queue_key)
 
-        self._reply_orchestrator.start_reply(
+        started = self._reply_orchestrator.start_reply(
             message=message,
             queue=queue,
             queue_key=queue_key,
@@ -1345,6 +1345,15 @@ class EventPipeline:
             on_reply_done=on_reply_done,
             background_content=background,
         )
+        if started is None:
+            # 管线被拒（编排器已关闭／同会话管线在跑／冷却中）：on_reply_done 永远
+            # 不会被调用，必须自己回滚刚打上的标记，否则该会话会永久留在
+            # _replying_queues 里——命令的 sync_reply 结果再也不会投递，
+            # 后续新消息也一律被当「回复中」处理。
+            self._replying_queues.discard(queue_key)
+            self._logger.debug(
+                "命令同步回复未能启动，已回滚回复中标记", queue_key=queue_key
+            )
 
     async def _try_issue_credential(
         self,

--- a/app/src/neobot_app/runtime/event_pipeline.py
+++ b/app/src/neobot_app/runtime/event_pipeline.py
@@ -7,9 +7,9 @@ import inspect
 import time
 from collections import deque
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, AsyncIterator, Dict
 
-from neobot_adapter import OneBotAdapter, Subscription
+from neobot_adapter import OneBotAdapter
 from neobot_adapter.model.message import GroupMessage, PrivateMessage
 from neobot_adapter.model.notice import (
     EmojiReaction,
@@ -108,8 +108,6 @@ class EventPipeline:
         self._command_service = command_service
         self._credential_manager = credential_manager
         self._sleep_service = sleep_service
-        self._subscriptions: List[Subscription] = []
-        self._started = False
         self._warmed_up_friends: set[str] = set()
         self._warmup_lock = asyncio.Lock()
         self._replying_queues: set[str] = set()
@@ -121,56 +119,20 @@ class EventPipeline:
         self._background_tasks: set[asyncio.Task[None]] = set()
         self._stopping = False
 
-    def start(self) -> None:
-        if self._started:
-            return
-
-        self._stopping = False
-        self._subscriptions = [
-            self.adapter.subscribe(
-                "message",
-                self._handle_private_message,
-                message_type="private",
-            ),
-            self.adapter.subscribe(
-                "message",
-                self._handle_group_message,
-                message_type="group",
-            ),
-            self.adapter.subscribe(
-                "notice",
-                self._handle_notice,
-            ),
-            self.adapter.subscribe(
-                "request",
-                self._handle_request,
-            ),
-        ]
-        self._started = True
-        self._logger.info("实时事件管线已启动")
-
-    def stop(self) -> None:
-        self._stopping = True
-        if self._started:
-            for subscription in self._subscriptions:
-                subscription.unsubscribe()
-            self._subscriptions.clear()
-            self._started = False
-            self._logger.info("实时事件管线已停止")
-        for task in list(self._background_tasks):
-            task.cancel()
-
     async def flush_pending_summaries(self) -> None:
-        """对所有未达到阈值但有待处理消息的计数器触发摘要。"""
-        restore_scheduling = self._started and not self._stopping
+        """关闭时的收尾：停止派生后台任务、取消在途任务、冲刷未达阈值的摘要。
+
+        事件订阅由 EventGateway 负责（它才是唯一入口），EventPipeline 不再自己
+        订阅：旧实现的 ``start()`` 会再注册一套 ``message``/``notice``/``request``
+        订阅，一旦被调用就是同一条事件被投递两次，而它实际上从来没有被调用过。
+
+        ``_stopping`` 在这里一次性置位（关闭流程只会调用一次），此后
+        ``_schedule_archive_summary`` 不再派生新的后台任务。
+        """
         self._stopping = True
-        try:
-            await self._cancel_background_tasks()
-            if self._archive_summary_service is not None:
-                await self._archive_summary_service.flush_all()
-        finally:
-            if restore_scheduling:
-                self._stopping = False
+        await self._cancel_background_tasks()
+        if self._archive_summary_service is not None:
+            await self._archive_summary_service.flush_all()
 
     def _track_background_task(
         self,
@@ -399,9 +361,6 @@ class EventPipeline:
 
         await self._handle_private_reply(message=message, queue_key=queue_key)
 
-    async def _handle_private_message(self, event: Dict[str, Any]) -> None:
-        await self.handle_private_message_event(event)
-
     async def _maybe_warmup_friend_chat(self, user_id: str) -> None:
         if self._config is None:
             return
@@ -604,9 +563,6 @@ class EventPipeline:
         await self._handle_willing_decision(
             message=message, queue=self._group_queue, queue_key=queue_key
         )
-
-    async def _handle_group_message(self, event: Dict[str, Any]) -> None:
-        await self.handle_group_message_event(event)
 
     async def _record_archive_summary(
         self,
@@ -1287,20 +1243,6 @@ class EventPipeline:
                 pass
 
         return f"QQ:{user_id}"
-
-    async def _handle_request(self, event: Dict[str, Any]) -> None:
-        request_type = event.get("request_type", "未知")
-        sub_type = event.get("sub_type", "")
-        label = f"{request_type}" + (f".{sub_type}" if sub_type else "")
-
-        details: list[str] = []
-        for key in ("user_id", "group_id", "comment", "flag"):
-            val = event.get(key)
-            if val is not None:
-                details.append(f"{key}={val}")
-
-        info = " ".join(details)
-        self._logger.info(f"收到请求[{label}] {info}".rstrip())
 
     def _consume_ai_reply_block(self, message: PrivateMessage | GroupMessage) -> bool:
         if self._reply_block_registry is None:

--- a/app/src/neobot_app/runtime/notifications.py
+++ b/app/src/neobot_app/runtime/notifications.py
@@ -142,7 +142,13 @@ class BackgroundNotificationHub:
         except asyncio.QueueEmpty:
             return None
 
-        await self._consume(notification)
+        try:
+            await self._consume(notification)
+        except asyncio.CancelledError:
+            # 取消发生在消费回调（例如「已通知」落盘标记）完成之前：直接丢弃会
+            # 让这条通知消失，管理器的状态没更新还可能稍后重复投递，所以放回队列。
+            self._requeue(pipeline_key, notification)
+            raise
 
         self._last_used[pipeline_key] = time.monotonic()
         self._logger.info(
@@ -242,6 +248,28 @@ class BackgroundNotificationHub:
             pipeline_key=notification.pipeline_key,
         )
         return True
+
+    def _requeue(
+        self, pipeline_key: str, notification: BackgroundNotification
+    ) -> None:
+        """把通知放回队列（消费被取消时使用），沿用 publish 的有界策略。"""
+        queue = self._queues.get(pipeline_key)
+        if queue is None:
+            queue = asyncio.Queue(maxsize=self._queue_max_size)
+            self._queues[pipeline_key] = queue
+        if queue.full():
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+        try:
+            queue.put_nowait(notification)
+        except asyncio.QueueFull:
+            self._logger.warning(
+                "后台通知重新入队失败，通知已丢弃",
+                source=notification.source,
+                pipeline_key=pipeline_key,
+            )
 
     async def _consume(self, notification: BackgroundNotification) -> None:
         if notification.on_consumed is None:

--- a/app/src/neobot_app/runtime/reply_block.py
+++ b/app/src/neobot_app/runtime/reply_block.py
@@ -34,6 +34,7 @@ class ReplyBlockRegistry:
             return True
         if key in self._keys:
             self._keys.remove(key)
+            self._forget_in_order(key)
             if not any(existing[2] == key[2] for existing in self._keys):
                 self._message_ids.discard(key[2])
             return True
@@ -42,10 +43,24 @@ class ReplyBlockRegistry:
             return True
         return False
 
+    def _forget_in_order(self, key: tuple[str, str, int]) -> None:
+        """把已消费的键从 FIFO 队列中摘掉。
+
+        否则 _order 会被已消费项占满：淘汰条件 ``len(_order) > max_size``
+        实际按「事件数（含已消费）」而非「活跃阻塞数」计算，活跃阻塞的保留
+        窗口短于设计值，可能出现应拦截的消息被提前放行。
+        """
+        try:
+            self._order.remove(key)
+        except ValueError:
+            pass
+
     def _remove_message_id(self, message_id: int) -> None:
         removed_keys = {key for key in self._keys if key[2] == message_id}
         self._keys.difference_update(removed_keys)
         self._message_ids.discard(message_id)
+        for key in removed_keys:
+            self._forget_in_order(key)
 
     @staticmethod
     def _message_id(event: Any) -> int | None:

--- a/app/src/neobot_app/runtime/sandbox_maintenance.py
+++ b/app/src/neobot_app/runtime/sandbox_maintenance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import re
 import shutil
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,8 @@ _MAINTENANCE_MARKER = ".last_maintenance"
 _WRITE_TEMP_PREFIX = ".neobot-write-"
 #: 超过这个年龄的临时文件才算孤儿：正在进行的写入只有毫秒级寿命。
 _ORPHAN_TEMP_MAX_AGE_SECONDS = 3600
+#: 维护周期的进程内互斥（搬进线程池后不再有事件循环的隐式串行）。
+_MAINTENANCE_LOCK = threading.Lock()
 
 
 class SandboxMaintenanceManager:
@@ -65,6 +68,18 @@ class SandboxMaintenanceManager:
         return await asyncio.to_thread(self._maintenance_cycle_sync, force=force)
 
     def _maintenance_cycle_sync(self, *, force: bool = False) -> dict[str, Any]:
+        # 移进线程池后不再有「事件循环单线程」的隐式互斥：AI 的
+        # trigger_maintenance、CLI 与 3 小时后台循环可以真正并行，两个周期同时
+        # rglob/move/rmtree 同一棵树会互相踩。拿不到锁就直接跳过本次。
+        if not _MAINTENANCE_LOCK.acquire(blocking=False):
+            self._logger.info("已有维护周期在运行，跳过本次触发")
+            return {"ok": True, "skipped": True, "reason": "已有维护在运行"}
+        try:
+            return self._maintenance_cycle_locked(force=force)
+        finally:
+            _MAINTENANCE_LOCK.release()
+
+    def _maintenance_cycle_locked(self, *, force: bool = False) -> dict[str, Any]:
         if not force and not self._has_changes_since_last():
             self._logger.debug("无文件变更，跳过维护")
             return {"ok": True, "skipped": True, "reason": "无文件变更"}

--- a/app/src/neobot_app/runtime/sandbox_maintenance.py
+++ b/app/src/neobot_app/runtime/sandbox_maintenance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 import shutil
 import time
@@ -49,7 +50,15 @@ class SandboxMaintenanceManager:
         return await self._maintenance_cycle(force=force)
 
     async def _maintenance_cycle(self, *, force: bool = False) -> dict[str, Any]:
-        """执行一次完整的维护周期。force=True 时跳过变更检查强制执行。"""
+        """执行一次完整的维护周期。force=True 时跳过变更检查强制执行。
+
+        整个周期都是同步文件系统操作（整树 rglob、rmtree、move），必须放进工作
+        线程：它由后台协程每 3 小时自动触发一次，直接跑在事件循环上会让整个 Bot
+        （所有会话、通知、心跳）停顿数秒。
+        """
+        return await asyncio.to_thread(self._maintenance_cycle_sync, force=force)
+
+    def _maintenance_cycle_sync(self, *, force: bool = False) -> dict[str, Any]:
         if not force and not self._has_changes_since_last():
             self._logger.debug("无文件变更，跳过维护")
             return {"ok": True, "skipped": True, "reason": "无文件变更"}

--- a/app/src/neobot_app/runtime/sandbox_maintenance.py
+++ b/app/src/neobot_app/runtime/sandbox_maintenance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 import shutil
 import threading
@@ -20,6 +21,8 @@ _MAINTENANCE_MARKER = ".last_maintenance"
 #: 原子写的临时文件前缀（sandbox_service.atomic_write / 复制时的 mkstemp）。
 #: 正常路径在 finally 里清理，进程被强杀时才会留在原地。
 _WRITE_TEMP_PREFIX = ".neobot-write-"
+#: mkstemp 的真实形态：前缀 + 8 位 [A-Za-z0-9_]；精确匹配避免误删用户文件。
+_WRITE_TEMP_NAME_RE = re.compile(r"\.neobot-write-[A-Za-z0-9_]{8}")
 #: 超过这个年龄的临时文件才算孤儿：正在进行的写入只有毫秒级寿命。
 _ORPHAN_TEMP_MAX_AGE_SECONDS = 3600
 #: 维护周期的进程内互斥（搬进线程池后不再有事件循环的隐式串行）。
@@ -80,9 +83,17 @@ class SandboxMaintenanceManager:
             _MAINTENANCE_LOCK.release()
 
     def _maintenance_cycle_locked(self, *, force: bool = False) -> dict[str, Any]:
+        # 孤儿清理与「有没有文件变更」无关：安静运行的 Bot 上变更门会一直跳过，
+        # 孤儿临时文件就永远清不掉（它的 mtime 反而会被 marker 越过）。
+        orphans = self._clean_orphan_write_temps()
         if not force and not self._has_changes_since_last():
             self._logger.debug("无文件变更，跳过维护")
-            return {"ok": True, "skipped": True, "reason": "无文件变更"}
+            return {
+                "ok": True,
+                "skipped": True,
+                "reason": "无文件变更",
+                "orphan_temps_cleaned": orphans,
+            }
 
         result: dict[str, Any] = {
             "ok": True,
@@ -118,6 +129,9 @@ class SandboxMaintenanceManager:
         # 5. 更新维护标记
         self._touch_maintenance_marker()
 
+        result["orphan_temps_cleaned"] = orphans
+        if orphans:
+            result["removed"].append(f"原子写残留 x{orphans}")
         return result
 
     def _has_changes_since_last(self) -> bool:
@@ -359,33 +373,46 @@ class SandboxMaintenanceManager:
                 except OSError:
                     pass
 
-        cleaned_files += self._clean_orphan_write_temps()
-
         if cleaned_dirs > 0:
             result["removed"].append(f"垃圾目录 x{cleaned_dirs}")
         if cleaned_files > 0:
             result["removed"].append(f"垃圾文件 x{cleaned_files}")
 
     def _clean_orphan_write_temps(self) -> int:
-        """清理原子写残留的 ``.neobot-write-*`` 临时文件。
+        """清理原子写残留的 ``.neobot-write-XXXXXXXX`` 临时文件。
 
         sandbox_service 写文件时先写同目录临时文件再 os.replace，正常路径会在
         finally 里删除；进程被强杀（崩溃 / 任务管理器结束）才会留下孤儿。这些
         文件以 "." 开头、没有扩展名，既不会被垃圾后缀规则命中，也不会出现在
-        目录索引里，只能靠年龄判断。仍在进行中的写入寿命只有毫秒级，
-        因此只清理超过一小时的。
+        目录索引里，只能靠名字前缀 + 年龄判断（仍在进行中的写入只有毫秒级寿命）。
+
+        名字按 mkstemp 的真实形态精确匹配，避免误删用户自己建的
+        ``.neobot-write-notes.md``；遍历用 ``os.walk(followlinks=False)`` 并显式
+        跳过目录联接（junction 的 ``is_symlink()`` 为 False，rglob 会穿过去删到
+        沙箱外的文件）。
         """
         cutoff = time.time() - _ORPHAN_TEMP_MAX_AGE_SECONDS
         cleaned = 0
-        for entry in sorted(self._root.rglob(f"{_WRITE_TEMP_PREFIX}*"), reverse=True):
-            try:
-                if not entry.is_file() or entry.stat().st_mtime > cutoff:
+        for current_dir, dirnames, filenames in os.walk(self._root, followlinks=False):
+            current = Path(current_dir)
+            dirnames[:] = [
+                name
+                for name in dirnames
+                if not (current / name).is_symlink()
+                and not (current / name).is_junction()
+            ]
+            for name in filenames:
+                if _WRITE_TEMP_NAME_RE.fullmatch(name) is None:
                     continue
-                entry.unlink()
-                cleaned += 1
-                self._logger.debug(f"清理原子写残留: {entry.relative_to(self._root)}")
-            except OSError:
-                continue
+                entry = current / name
+                try:
+                    if entry.stat().st_mtime > cutoff:
+                        continue
+                    entry.unlink()
+                    cleaned += 1
+                    self._logger.debug(f"清理原子写残留: {entry.relative_to(self._root)}")
+                except OSError as exc:
+                    self._logger.debug(f"清理原子写残留失败: {entry.name} ({exc})")
         return cleaned
 
     def _get_capacity_info(self) -> dict[str, Any]:

--- a/app/src/neobot_app/runtime/sandbox_maintenance.py
+++ b/app/src/neobot_app/runtime/sandbox_maintenance.py
@@ -16,6 +16,12 @@ _STORAGE_DOC = "文件存储.md"
 _TODO_DOC = "TODO.md"
 _MAINTENANCE_MARKER = ".last_maintenance"
 
+#: 原子写的临时文件前缀（sandbox_service.atomic_write / 复制时的 mkstemp）。
+#: 正常路径在 finally 里清理，进程被强杀时才会留在原地。
+_WRITE_TEMP_PREFIX = ".neobot-write-"
+#: 超过这个年龄的临时文件才算孤儿：正在进行的写入只有毫秒级寿命。
+_ORPHAN_TEMP_MAX_AGE_SECONDS = 3600
+
 
 class SandboxMaintenanceManager:
     """沙箱持久化文件维护管理器。
@@ -338,10 +344,34 @@ class SandboxMaintenanceManager:
                 except OSError:
                     pass
 
+        cleaned_files += self._clean_orphan_write_temps()
+
         if cleaned_dirs > 0:
             result["removed"].append(f"垃圾目录 x{cleaned_dirs}")
         if cleaned_files > 0:
             result["removed"].append(f"垃圾文件 x{cleaned_files}")
+
+    def _clean_orphan_write_temps(self) -> int:
+        """清理原子写残留的 ``.neobot-write-*`` 临时文件。
+
+        sandbox_service 写文件时先写同目录临时文件再 os.replace，正常路径会在
+        finally 里删除；进程被强杀（崩溃 / 任务管理器结束）才会留下孤儿。这些
+        文件以 "." 开头、没有扩展名，既不会被垃圾后缀规则命中，也不会出现在
+        目录索引里，只能靠年龄判断。仍在进行中的写入寿命只有毫秒级，
+        因此只清理超过一小时的。
+        """
+        cutoff = time.time() - _ORPHAN_TEMP_MAX_AGE_SECONDS
+        cleaned = 0
+        for entry in sorted(self._root.rglob(f"{_WRITE_TEMP_PREFIX}*"), reverse=True):
+            try:
+                if not entry.is_file() or entry.stat().st_mtime > cutoff:
+                    continue
+                entry.unlink()
+                cleaned += 1
+                self._logger.debug(f"清理原子写残留: {entry.relative_to(self._root)}")
+            except OSError:
+                continue
+        return cleaned
 
     def _get_capacity_info(self) -> dict[str, Any]:
         """获取当前沙箱容量信息。"""

--- a/app/src/neobot_app/runtime/sandbox_service.py
+++ b/app/src/neobot_app/runtime/sandbox_service.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import glob as glob_module
 import hashlib
 import os
@@ -276,7 +277,13 @@ class SandboxService:
 
         文本文件超过 MAX_TEXT_READ_BYTES 时仅返回前 MAX_TEXT_READ_BYTES 字节；
         二进制/未知类型文件保持完整读取（不对二进制做截断）。
+
+        文件 IO 交给工作线程：这些方法原先声明为 async 但内部零 await，
+        同步磁盘操作实际是跑在事件循环上的（大文件/慢盘会卡住整个 Bot）。
         """
+        return await asyncio.to_thread(self._read_file_sync, path)
+
+    def _read_file_sync(self, path: Path) -> bytes:
         resolved = path.resolve()
         if not self.is_path_allowed(resolved):
             raise PermissionError(f"路径不允许: {path}")
@@ -352,11 +359,17 @@ class SandboxService:
 
         Agent callers must use AgentFileTools (or the legacy skill adapter).
         """
+        await asyncio.to_thread(self._write_file_sync, path, data)
+
+    def _write_file_sync(self, path: Path, data: bytes) -> None:
         with self.file_lock(path):
             self.atomic_write(path, data)
 
     async def delete_file(self, path: Path) -> None:
         """删除文件或空目录。"""
+        await asyncio.to_thread(self._delete_file_sync, path)
+
+    def _delete_file_sync(self, path: Path) -> None:
         resolved = path.resolve()
         if not self._is_within_sandbox(resolved):
             raise PermissionError(f"删除路径越界: {path}")
@@ -374,6 +387,9 @@ class SandboxService:
         pattern: str | None = None,
     ) -> list[dict]:
         """列出目录下的文件。"""
+        return await asyncio.to_thread(self._list_files_sync, path, pattern)
+
+    def _list_files_sync(self, path: Path, pattern: str | None = None) -> list[dict]:
         resolved = path.resolve()
         if not self.is_path_allowed(resolved):
             raise PermissionError(f"路径不允许: {path}")
@@ -422,6 +438,9 @@ class SandboxService:
 
     async def move_file(self, src: Path, dst: Path) -> None:
         """移动文件或目录。"""
+        await asyncio.to_thread(self._move_file_sync, src, dst)
+
+    def _move_file_sync(self, src: Path, dst: Path) -> None:
         src_r = src.resolve()
         dst_r = dst.resolve()
         if not self._is_within_sandbox(src_r):
@@ -436,6 +455,9 @@ class SandboxService:
 
     async def copy_file(self, src: Path, dst: Path) -> None:
         """复制文件。"""
+        await asyncio.to_thread(self._copy_file_sync, src, dst)
+
+    def _copy_file_sync(self, src: Path, dst: Path) -> None:
         src_r = src.resolve()
         dst_r = dst.resolve()
         if not self.is_path_allowed(src_r):

--- a/app/src/neobot_app/runtime/scheduled_tasks.py
+++ b/app/src/neobot_app/runtime/scheduled_tasks.py
@@ -22,7 +22,7 @@ from neobot_contracts.models.scheduled_task import (
 )
 from neobot_contracts.ports.logging import Logger, NullLogger
 from neobot_contracts.ports.unit_of_work import UnitOfWorkFactory
-from neobot_app.time_context import now_utc, to_utc
+from neobot_app.time_context import now_utc, to_local, to_utc
 
 
 @dataclass(frozen=True)
@@ -118,6 +118,37 @@ class ScheduledTaskManager:
 
     def set_notification_hub(self, hub: Any) -> None:
         self._notification_hub = hub
+
+    async def list_tasks(self, *, limit: int = 200) -> list[dict[str, Any]]:
+        """列出当前活跃的定时任务（供网页面板「后台任务」展示）。
+
+        面板 /api/tasks 用 ``getattr(manager, "list_tasks", None)`` 探测本方法，
+        而 ScheduledTaskManager 此前没有它 —— 面板里的定时任务列表恒为空。
+        """
+        if self._uow_factory is None:
+            return []
+        try:
+            tasks = await self._list_active_tasks()
+        except Exception as exc:
+            self._logger.warning("读取定时任务列表失败", error=str(exc))
+            return []
+        items: list[dict[str, Any]] = []
+        for task in tasks[: max(0, int(limit))]:
+            items.append(
+                {
+                    "task_id": task.task_uuid,
+                    "name": task.title,
+                    "description": task.detail or task.title,
+                    "next_run": _format_task_time(task.start_at),
+                    "trigger_time": _format_task_time(task.start_at),
+                    "status": str(getattr(task.state, "value", task.state)),
+                    "recurrence": str(
+                        getattr(task.recurrence, "value", task.recurrence)
+                    ),
+                    "bindings": len(task.bindings or ()),
+                }
+            )
+        return items
 
     async def create_task(
         self,
@@ -633,3 +664,13 @@ def _combine_date_time(day: date, source: datetime) -> datetime:
 
 def _normalize_datetime(value: datetime) -> datetime:
     return to_utc(value)
+
+
+def _format_task_time(value: datetime | None) -> str:
+    """任务时间格式化为本地时区的可读字符串（面板展示用）。"""
+    if value is None:
+        return ""
+    try:
+        return to_local(value).strftime("%Y-%m-%d %H:%M")
+    except Exception:
+        return str(value)

--- a/app/src/neobot_app/runtime/scheduled_tasks.py
+++ b/app/src/neobot_app/runtime/scheduled_tasks.py
@@ -29,7 +29,9 @@ from neobot_app.time_context import now_utc, to_local, to_utc
 class ScheduledTaskConfig:
     enabled: bool = True
     reminder_cooldown_seconds: int = 300
-    poll_interval_seconds: int = 60
+    #: 与 config.schemas.bot.ScheduledTask.poll_interval_seconds 保持一致（10 秒），
+    #: 否则「未提供 config」与「提供了 config」两条路径的扫描频率不同。
+    poll_interval_seconds: int = 10
     default_window_seconds: int = 3600
     max_repeating_tasks: int = 15
     default_one_shot_notification: bool = True
@@ -45,7 +47,7 @@ class ScheduledTaskConfig:
                 1,
             ),
             poll_interval_seconds=max(
-                int(getattr(config, "poll_interval_seconds", 60) or 60),
+                int(getattr(config, "poll_interval_seconds", 10) or 10),
                 1,
             ),
             default_window_seconds=max(

--- a/app/src/neobot_app/runtime/scheduled_tasks.py
+++ b/app/src/neobot_app/runtime/scheduled_tasks.py
@@ -24,6 +24,9 @@ from neobot_contracts.ports.logging import Logger, NullLogger
 from neobot_contracts.ports.unit_of_work import UnitOfWorkFactory
 from neobot_app.time_context import now_utc, to_local, to_utc
 
+#: 单页拉取活跃任务的数量（仓库 list_active 的默认上限，避免一次载入过多行）。
+_ACTIVE_TASK_PAGE_SIZE = 500
+
 
 @dataclass(frozen=True)
 class ScheduledTaskConfig:
@@ -368,8 +371,24 @@ class ScheduledTaskManager:
                 )
 
     async def _list_active_tasks(self) -> list[ScheduledTaskRecord]:
+        """分页取回全部活跃任务。
+
+        ``list_active`` 单次上限 500 条，而一次性任务没有数量上限（只有循环
+        任务受 max_repeating_tasks 限制）：只取第一页会让排在第 501 位之后的
+        任务永远不会被扫描，提醒静默不触发。按 offset 翻页直到取完。
+        """
+        tasks: list[ScheduledTaskRecord] = []
         async with self._uow_factory() as uow:
-            return await uow.scheduled_tasks.list_active(limit=500)
+            offset = 0
+            while True:
+                page = await uow.scheduled_tasks.list_active(
+                    limit=_ACTIVE_TASK_PAGE_SIZE, offset=offset
+                )
+                tasks.extend(page)
+                if len(page) < _ACTIVE_TASK_PAGE_SIZE:
+                    break
+                offset += len(page)
+        return tasks
 
     def _plan_task_scan(
         self,

--- a/app/src/neobot_app/runtime/temp_cleaner.py
+++ b/app/src/neobot_app/runtime/temp_cleaner.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import os
 import shutil
+import threading
 import time
 from pathlib import Path
 
 from neobot_contracts.ports.logging import Logger, NullLogger
+
+#: 清理任务的进程内互斥（可能被 AI 技能 / CLI / 后台循环并发触发）。
+_CLEANUP_LOCK = threading.Lock()
 
 
 class TempCleaner:
@@ -90,9 +94,17 @@ class TempCleaner:
         return result
 
     def run_once(self) -> dict:
-        """执行一次清理并返回结果统计。"""
-        result = self._cleanup_once()
-        return result
+        """执行一次清理并返回结果统计。
+
+        清理会被搬进线程池（AI 技能 / CLI / 后台循环都可能触发），因此需要
+        进程内互斥：两次清理并行会对同一批文件重复 unlink/rmdir 并互相报错。
+        """
+        if not _CLEANUP_LOCK.acquire(blocking=False):
+            return {"files_removed": 0, "dirs_removed": 0, "nests_fixed": 0, "skipped": "busy"}
+        try:
+            return self._cleanup_once()
+        finally:
+            _CLEANUP_LOCK.release()
 
     def _cleanup_once(self) -> dict:
         """执行一次清理并返回统计信息。"""

--- a/app/src/neobot_app/skills/archive_crud.py
+++ b/app/src/neobot_app/skills/archive_crud.py
@@ -96,7 +96,7 @@ class ArchiveCRUDSkill(SkillModule):
             },
             "required": ["table_name", "key"],
         }
-        return [
+        tools = [
             self._tool_def(
                 "save_archive",
                 "创建或更新一条档案记忆。修改已有档案时，必须写回整合后的完整内容，不要只写增量。",
@@ -206,6 +206,15 @@ class ArchiveCRUDSkill(SkillModule):
                 },
             ),
         ]
+        if not self._allow_delete:
+            # 未启用删除时干脆不把工具暴露给模型（与 allow_delete=false 语义一致），
+            # 避免模型反复调用一个必然被拒的工具。
+            tools = [
+                tool
+                for tool in tools
+                if tool.get("function", {}).get("name") != "delete_archive"
+            ]
+        return tools
 
     async def execute(self, tool_name: str, args: dict[str, Any]) -> str:
         handler = _HANDLERS.get(tool_name)
@@ -219,6 +228,35 @@ _ARCHIVE_PAGE_SIZE = 500
 _OUTLINE_MAX_LINES = 80
 _OUTLINE_LINE_CHARS = 80
 _MAX_PATCH_OPERATIONS = 20
+
+
+def _table_guard(self: ArchiveCRUDSkill, table_name: str) -> str | None:
+    """校验表名是否在 ``agent.memory.archive.allowed_tables`` 白名单内。
+
+    返回 None 表示放行，否则返回给模型的错误文案。留空表示不限制。
+    """
+    allowed = tuple(self._allowed_tables or ())
+    if not allowed or table_name in allowed:
+        return None
+    return _json(
+        {
+            "ok": False,
+            "error": f"该档案表不允许访问: {table_name}",
+            "allowed_tables": list(allowed),
+        }
+    )
+
+
+def _delete_guard(self: ArchiveCRUDSkill) -> str | None:
+    """``agent.memory.archive.allow_delete`` 开关（默认 false）。"""
+    if self._allow_delete:
+        return None
+    return _json(
+        {
+            "ok": False,
+            "error": "档案删除未启用（agent.memory.archive.allow_delete=false）",
+        }
+    )
 
 
 def _apply_patch_operations(value: str, operations: list[Any]) -> tuple[str, list[str]]:
@@ -365,6 +403,9 @@ async def _handle_save_archive(self: ArchiveCRUDSkill, args: dict) -> str:
     value = str(args.get("value", "")).strip()
     if not table_name or not key or not value:
         return _json({"ok": False, "error": "缺少必要参数"})
+    blocked = _table_guard(self, table_name)
+    if blocked is not None:
+        return blocked
     try:
         # 原始档案完整保存,不做长度截断;超长档案在渲染时自动生成摘要,
         # 完整内容通过 read_archive 的 offset 分页阅读
@@ -391,6 +432,9 @@ async def _handle_patch_archive(self: ArchiveCRUDSkill, args: dict) -> str:
         return _json({"ok": False, "error": "缺少必要参数"})
     if not isinstance(operations, list) or not operations:
         return _json({"ok": False, "error": "operations 不能为空"})
+    blocked = _table_guard(self, table_name)
+    if blocked is not None:
+        return blocked
     if len(operations) > _MAX_PATCH_OPERATIONS:
         return _json(
             {"ok": False, "error": f"单次最多 {_MAX_PATCH_OPERATIONS} 个操作"}
@@ -442,6 +486,9 @@ async def _handle_patch_archive(self: ArchiveCRUDSkill, args: dict) -> str:
 async def _handle_read_archive(self: ArchiveCRUDSkill, args: dict) -> str:
     if self._archive_service is None:
         return _json({"ok": False, "error": "archive_service 未配置"})
+    blocked = _table_guard(self, str(args.get("table_name", "")).strip())
+    if blocked is not None:
+        return blocked
     try:
         mode = str(args.get("mode") or "full").strip().lower()
         if mode not in ("full", "outline"):
@@ -481,6 +528,8 @@ async def _handle_read_archive(self: ArchiveCRUDSkill, args: dict) -> str:
 
 
 async def _handle_read_pending_messages(self: ArchiveCRUDSkill, args: dict) -> str:
+    # 有意不套 allowed_tables 白名单：这里读的是自动总结用的内部计数表
+    # （memory_counter），不是用户档案；限制它会让档案自动总结功能整体失效。
     if self._archive_service is None:
         return _json({"ok": False, "error": "archive_service 未配置"})
     conversation_key = str(args.get("conversation_key", "")).strip()
@@ -548,6 +597,9 @@ async def _handle_list_archive(self: ArchiveCRUDSkill, args: dict) -> str:
     if self._archive_service is None:
         return _json({"ok": False, "error": "archive_service 未配置"})
     table_name = str(args.get("table_name", "")).strip()
+    blocked = _table_guard(self, table_name)
+    if blocked is not None:
+        return blocked
     try:
         items = await self._archive_service.list(table_name, limit=args.get("limit", 10), offset=args.get("offset", 0))
         return _json({"ok": True, "items": [{"table_name": i.table_name, "key": i.key, "value": i.value} for i in items]})
@@ -557,6 +609,13 @@ async def _handle_list_archive(self: ArchiveCRUDSkill, args: dict) -> str:
 async def _handle_delete_archive(self: ArchiveCRUDSkill, args: dict) -> str:
     if self._archive_service is None:
         return _json({"ok": False, "error": "archive_service 未配置"})
+    table_name = str(args.get("table_name", "")).strip()
+    blocked = _delete_guard(self)
+    if blocked is not None:
+        return blocked
+    blocked = _table_guard(self, table_name)
+    if blocked is not None:
+        return blocked
     try:
         await self._archive_service.delete(args["table_name"], args["key"])
         return _json({"ok": True})

--- a/app/src/neobot_app/skills/archive_crud.py
+++ b/app/src/neobot_app/skills/archive_crud.py
@@ -23,7 +23,10 @@ class ArchiveCRUDSkill(SkillModule):
 
     @property
     def description(self) -> str:
-        return "长期记忆档案管理：增量编辑/读取/列出/删除档案条目"
+        # 与工具表保持一致：allow_delete=false 时 delete_archive 不注入给模型，
+        # 摘要里再宣称「删除」会让模型调用一个不存在的工具。
+        suffix = "增量编辑/读取/列出/删除档案条目" if self._allow_delete else "增量编辑/读取/列出档案条目"
+        return f"长期记忆档案管理：{suffix}"
 
     @property
     def instructions(self) -> str:
@@ -36,6 +39,22 @@ class ArchiveCRUDSkill(SkillModule):
             if limits
             else ""
         )
+        # 工具表会按开关裁剪，提示词必须同步：否则模型按 instructions 去调用
+        # 一个被隐藏的工具（错误回灌、白费轮次），或向用户声称已删除记忆。
+        delete_line = (
+            "  delete_archive — 删除档案记忆\n" if self._allow_delete else ""
+        )
+        delete_note = (
+            ""
+            if self._allow_delete
+            else "删除档案未启用（agent.memory.archive.allow_delete=false），不要尝试删除。\n"
+        )
+        allowed = self._allowed_tables
+        allowed_note = (
+            f"可访问的档案表：{', '.join(allowed)}（其余表一律拒绝）。\n"
+            if allowed
+            else ""
+        )
         return (
             "档案管理 Skill 提供以下能力：\n\n"
             "  patch_archive — 增量编辑档案（推荐）：append/prepend 追加片段，replace/delete 定点改删，"
@@ -44,7 +63,9 @@ class ArchiveCRUDSkill(SkillModule):
             "  read_archive — 读取档案记忆；mode='outline' 只看目录/大纲，offset 分页读正文\n"
             "  read_pending_messages — 读取待总结的实时消息全文（总结提示词里被截断时用）\n"
             "  list_archive — 列出档案条目，支持按内容/标签筛选\n"
-            "  delete_archive — 删除档案记忆\n\n"
+            f"{delete_line}\n"
+            f"{allowed_note}"
+            f"{delete_note}"
             "写入原则：新增内容用 patch_archive(append) 只写增量；修改已有内容先 outline 定位、"
             "再分页读该片段、然后 patch_archive(replace) 定点修改；不要为了写入而先读全文。"
             "原始档案不会截断，可长期积累。\n"

--- a/app/src/neobot_app/skills/archive_crud.py
+++ b/app/src/neobot_app/skills/archive_crud.py
@@ -486,9 +486,6 @@ async def _handle_patch_archive(self: ArchiveCRUDSkill, args: dict) -> str:
 async def _handle_read_archive(self: ArchiveCRUDSkill, args: dict) -> str:
     if self._archive_service is None:
         return _json({"ok": False, "error": "archive_service 未配置"})
-    blocked = _table_guard(self, str(args.get("table_name", "")).strip())
-    if blocked is not None:
-        return blocked
     try:
         mode = str(args.get("mode") or "full").strip().lower()
         if mode not in ("full", "outline"):
@@ -511,6 +508,16 @@ async def _handle_read_archive(self: ArchiveCRUDSkill, args: dict) -> str:
         if items_raw:
             results = []
             for it in items_raw:
+                if not isinstance(it, dict):
+                    return _json({"ok": False, "error": "items 元素必须是对象"})
+                # 逐项校验：items 批量模式与单条读取走同一套 allowed_tables 限制，
+                # 否则只要顶层 table_name 合法（或干脆不填），就能借 items 里的任意
+                # 表名读到任何档案。
+                blocked = _table_guard(self, str(it.get("table_name", "")).strip())
+                if blocked is not None:
+                    return blocked
+                if it.get("key") is None:
+                    return _json({"ok": False, "error": "items 元素缺少 key"})
                 item = await self._archive_service.get(it["table_name"], it["key"])
                 if item:
                     results.append(_payload(item))
@@ -518,6 +525,9 @@ async def _handle_read_archive(self: ArchiveCRUDSkill, args: dict) -> str:
         table_name = args.get("table_name")
         key = args.get("key")
         if table_name and key:
+            blocked = _table_guard(self, str(table_name).strip())
+            if blocked is not None:
+                return blocked
             item = await self._archive_service.get(table_name, key)
             if item:
                 return _json({"ok": True, "item": _payload(item)})

--- a/app/src/neobot_app/skills/archive_skill.py
+++ b/app/src/neobot_app/skills/archive_skill.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tarfile
@@ -141,6 +142,10 @@ class ArchiveSkill(SkillModule):
             })
 
     async def _compress_zip(self, sources: list[Path], output: Path) -> str:
+        # 压缩是 CPU+磁盘密集工作：放进工作线程，避免卡住事件循环
+        return await asyncio.to_thread(self._compress_zip_sync, sources, output)
+
+    def _compress_zip_sync(self, sources: list[Path], output: Path) -> str:
         count = 0
         total_size = 0
         with zipfile.ZipFile(str(output), "w", zipfile.ZIP_DEFLATED) as zf:
@@ -169,6 +174,9 @@ class ArchiveSkill(SkillModule):
         })
 
     async def _compress_tar(self, sources: list[Path], output: Path) -> str:
+        return await asyncio.to_thread(self._compress_tar_sync, sources, output)
+
+    def _compress_tar_sync(self, sources: list[Path], output: Path) -> str:
         mode_map = {
             ".tar": "w",
             ".tar.gz": "w:gz",
@@ -243,6 +251,9 @@ class ArchiveSkill(SkillModule):
             })
 
     async def _decompress_zip(self, archive: Path, dest: Path) -> str:
+        return await asyncio.to_thread(self._decompress_zip_sync, archive, dest)
+
+    def _decompress_zip_sync(self, archive: Path, dest: Path) -> str:
         count = 0
         total_size = 0
         with zipfile.ZipFile(str(archive), "r") as zf:
@@ -264,6 +275,9 @@ class ArchiveSkill(SkillModule):
         })
 
     async def _decompress_tar(self, archive: Path, dest: Path) -> str:
+        return await asyncio.to_thread(self._decompress_tar_sync, archive, dest)
+
+    def _decompress_tar_sync(self, archive: Path, dest: Path) -> str:
         mode_map = {
             ".tar": "r",
             ".tar.gz": "r:gz",

--- a/app/src/neobot_app/skills/base.py
+++ b/app/src/neobot_app/skills/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import inspect
 import json
@@ -10,6 +11,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
+from neobot_app.observability.logging import redact_sensitive
+from neobot_app.utils.logger import get_module_logger
+
+logger = get_module_logger("app.skills")
 
 _SEPARATOR = "__"
 _RESERVED_FINAL_TOOL_NAMES = frozenset(
@@ -330,8 +335,21 @@ class SkillManager:
 
         try:
             return await token.module.execute(token.local_name, args)
-        except Exception:
-            return f"工具执行失败 [{prefixed_name}]"
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # 旧实现只返回一句固定文案（不记日志、不带异常信息），技能故障在
+            # 生产中完全不可诊断。这里保留原因，但**先脱敏再回给模型**：
+            # 工具输出会进入 LLM 上下文，异常信息里可能带密钥。
+            raw = f"{type(exc).__name__}: {exc}".strip()
+            logger.warning(
+                f"技能工具执行失败: {prefixed_name}",
+                skill=skill_name,
+                tool=token.local_name,
+                error=raw[:500],
+            )
+            safe_detail = redact_sensitive(raw)[:300]
+            return f"工具执行失败 [{prefixed_name}]: {safe_detail}"
 
     def reset_all(self) -> None:
         """复位所有 Skill 的状态。"""

--- a/app/src/neobot_app/skills/base.py
+++ b/app/src/neobot_app/skills/base.py
@@ -342,14 +342,16 @@ class SkillManager:
             # 生产中完全不可诊断。这里保留原因，但**先脱敏再回给模型**：
             # 工具输出会进入 LLM 上下文，异常信息里可能带密钥。
             raw = f"{type(exc).__name__}: {exc}".strip()
+            safe_detail = redact_sensitive(raw)
             logger.warning(
                 f"技能工具执行失败: {prefixed_name}",
                 skill=skill_name,
                 tool=token.local_name,
-                error=raw[:500],
+                # 日志同样只能用脱敏后的文本：异常里可能带密钥，而日志会进
+                # 文件/控制台/自修复采集。
+                error=safe_detail[:500],
             )
-            safe_detail = redact_sensitive(raw)[:300]
-            return f"工具执行失败 [{prefixed_name}]: {safe_detail}"
+            return f"工具执行失败 [{prefixed_name}]: {safe_detail[:300]}"
 
     def reset_all(self) -> None:
         """复位所有 Skill 的状态。"""

--- a/app/src/neobot_app/skills/browser_skill.py
+++ b/app/src/neobot_app/skills/browser_skill.py
@@ -5,12 +5,23 @@
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 from datetime import datetime
 from typing import Any
 
 from neobot_app.skills.base import SkillModule
+
+
+def _convert_jpeg_file_to_png(jpg_path: str) -> bytes:
+    """读取 JPEG 并转成 PNG 字节（同步实现，由 asyncio.to_thread 调用）。"""
+    from PIL import Image
+
+    with Image.open(jpg_path) as image:
+        buf = io.BytesIO()
+        image.save(buf, format="PNG")
+    return buf.getvalue()
 
 def _json(data: dict[str, Any]) -> str:
     return json.dumps(data, ensure_ascii=False, sort_keys=True)
@@ -454,11 +465,8 @@ async def _handle_shot(self: BrowserSkill, args: dict) -> str:
         return _json({"ok": False, "error": "截图失败"})
     # loader 已经保存了 JPEG 文件，直接读取然后转换为 PNG
     jpg_path = result["path"]
-    from PIL import Image
-    img = Image.open(jpg_path)
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    png_bytes = buf.getvalue()
+    # JPEG→PNG 是纯 CPU 解码/编码，放进工作线程避免卡住事件循环
+    png_bytes = await asyncio.to_thread(_convert_jpeg_file_to_png, jpg_path)
     if self._sandbox:
         path = self._sandbox.ensure_temp_dir(chat_flow_id) / f"{name}.png"
         await self._sandbox.write_file(path, png_bytes)

--- a/app/src/neobot_app/skills/gallery_skill.py
+++ b/app/src/neobot_app/skills/gallery_skill.py
@@ -270,8 +270,8 @@ async def _handle_gallery_add(self: GallerySkill, args: dict) -> str:
     if not path.exists():
         return _json({"ok": False, "error": f"文件不存在: {image_path}"})
     try:
-        from neobot_app.message.image_pipeline import prepare_local_image
-        prepared = prepare_local_image(path)
+        from neobot_app.message.image_pipeline import prepare_local_image_async
+        prepared = await prepare_local_image_async(path)
         if prepared is None:
             return _json({"ok": False, "error": "无法处理图片"})
         record = await self._image_service.gallery_add(

--- a/app/src/neobot_app/skills/sandbox_maintenance_skill.py
+++ b/app/src/neobot_app/skills/sandbox_maintenance_skill.py
@@ -6,6 +6,7 @@ AI 自行决策何时清理、清理什么。
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -124,7 +125,8 @@ class SandboxMaintenanceSkill(SkillModule):
         if self._temp_cleaner is None:
             return _json({"ok": False, "error": "temp_cleaner 未配置"})
         try:
-            status = self._temp_cleaner.get_status()
+            # TempCleaner 是同步实现（整树扫描/删除），必须离开事件循环
+            status = await asyncio.to_thread(self._temp_cleaner.get_status)
             return _json(status)
         except Exception as e:
             return _json({"ok": False, "error": str(e)})
@@ -133,7 +135,7 @@ class SandboxMaintenanceSkill(SkillModule):
         if self._temp_cleaner is None:
             return _json({"ok": False, "error": "temp_cleaner 未配置"})
         try:
-            result = self._temp_cleaner.run_once()
+            result = await asyncio.to_thread(self._temp_cleaner.run_once)
             return _json(result)
         except Exception as e:
             return _json({"ok": False, "error": str(e)})

--- a/app/src/neobot_app/utils/atomic.py
+++ b/app/src/neobot_app/utils/atomic.py
@@ -1,0 +1,33 @@
+"""原子写入小文件：同目录临时文件 + fsync + ``os.replace``。
+
+覆盖写一个已存在的文件时，进程若在写到一半时被杀（崩溃、断电、任务管理器结束），
+磁盘上会留下被截断的内容，下次启动解析 JSON/TOML 直接失败，甚至把用户的配置
+或统计清零。凡是「覆盖写一个已存在的小文件」都应走这里。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """把 ``text`` 原子地写到 ``path``（先写同目录临时文件，再整体替换）。"""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temp_name = tempfile.mkstemp(
+        dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding=encoding, newline="\n") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, target)
+    except BaseException:
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise

--- a/app/src/neobot_app/utils/atomic.py
+++ b/app/src/neobot_app/utils/atomic.py
@@ -9,7 +9,29 @@ from __future__ import annotations
 
 import os
 import tempfile
+import time
 from pathlib import Path
+
+#: Windows 上 os.replace 需要目标文件的 DELETE 权限：目标被编辑器/杀软/同步盘
+#: 短暂持有句柄时会失败（WinError 5）。这类占用通常是瞬时的，短退避重试即可，
+#: 而旧的就地 open(path, "w") 在这些场景下反而能成功——不重试等于新增失败面。
+_REPLACE_RETRIES = 5
+_REPLACE_RETRY_DELAY_SECONDS = 0.05
+
+
+def _replace_with_retry(source: str, target: Path) -> None:
+    last_error: OSError | None = None
+    for attempt in range(_REPLACE_RETRIES):
+        try:
+            os.replace(source, target)
+            return
+        except PermissionError as exc:  # WinError 5 / 目标被占用
+            last_error = exc
+            if attempt == _REPLACE_RETRIES - 1:
+                break
+            time.sleep(_REPLACE_RETRY_DELAY_SECONDS * (attempt + 1))
+    assert last_error is not None
+    raise last_error
 
 
 def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
@@ -24,7 +46,7 @@ def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(temp_name, target)
+        _replace_with_retry(temp_name, target)
     except BaseException:
         try:
             os.unlink(temp_name)

--- a/app/src/neobot_app/utils/image_bytes.py
+++ b/app/src/neobot_app/utils/image_bytes.py
@@ -1,0 +1,28 @@
+"""图片字节的轻量校验（不依赖 Pillow）。"""
+
+from __future__ import annotations
+
+#: 常见图片格式的魔数前缀
+IMAGE_MAGIC_PREFIXES = (
+    b"\xff\xd8\xff",        # JPEG
+    b"\x89PNG\r\n\x1a\n",   # PNG
+    b"RIFF",                # WebP（RIFF 容器，需再校验 WEBP 标识）
+    b"GIF87a",              # GIF
+    b"GIF89a",              # GIF
+    b"BM",                  # BMP
+)
+
+_MIN_IMAGE_BYTES = 16
+
+
+def looks_like_image(content: bytes) -> bool:
+    """按文件头魔数判断字节内容是否像图片。
+
+    用于「读取本地文件」这类边界：内容形态校验可以挡住把配置/密钥/数据库
+    当作图片读出来的路径，且不引入 Pillow 解码开销。
+    """
+    if len(content) < _MIN_IMAGE_BYTES:
+        return False
+    if content.startswith(b"RIFF"):
+        return len(content) >= 12 and content[8:12] == b"WEBP"
+    return any(content.startswith(magic) for magic in IMAGE_MAGIC_PREFIXES)

--- a/app/src/neobot_app/web_search/session.py
+++ b/app/src/neobot_app/web_search/session.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from neobot_app.utils.ssrf import validate_public_url_async
 from neobot_app.web_search.manager import SearchManager
 from neobot_app.web_search.models import SearchResponse, SearchResult
 
@@ -327,6 +328,13 @@ class SearchSession:
         import asyncio
 
         async def _fetch_one(r: SearchResult) -> SearchResult:
+            # 搜索结果里的 URL 来自第三方页面（可被 SEO/恶意内容影响），
+            # 必须按 SSRF 处理：否则可被引导去探测内网、本机面板(9981)
+            # 或文件服务器(8765)。校验同时覆盖 IP 字面量与 DNS 解析结果。
+            if not await validate_public_url_async(r.url):
+                r.content = "[已阻止] 该地址不是公网地址，未抓取"
+                r.content_fetched = False
+                return r
             try:
                 resp = await client.get(r.url, headers={
                     "User-Agent": "Mozilla/5.0 (compatible; NeoBot/1.0)",

--- a/app/src/neobot_app/willing/service.py
+++ b/app/src/neobot_app/willing/service.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import hashlib
 import importlib.util
@@ -63,7 +63,8 @@ class WillingService:
         reply_mode: str | None = None,
     ) -> WillingDecision:
         if reply_mode is None:
-            reply_mode = getattr(self._config.chat, "reply_mode", "common") or "common"
+            # 与 Chat.reply_mode 的 schema 默认值保持一致（agent）
+            reply_mode = getattr(self._config.chat, "reply_mode", "agent") or "agent"
         context = self._build_context(
             message=message,
             queue=queue,

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -9,11 +9,46 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 from typing import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio
+
+
+# ── 进程级状态隔离 ──
+
+@pytest.fixture(autouse=True)
+def _isolate_process_state() -> Iterator[None]:
+    """隔离跨用例的全局副作用：os.environ 与模型注册表。
+
+    配置加载路径会直接写 ``os.environ``（``load_env``）并调用
+    ``register_models``，这些副作用不受 ``monkeypatch`` 追踪；漏到后续用例会
+    造成与顺序相关的假失败（例如面板用例断言「未配置 APIKey」时，却拿到了
+    前一个模块写进环境的密钥）。
+    """
+    environ_snapshot = dict(os.environ)
+
+    registry = None
+    registry_snapshot: tuple = ()
+    try:
+        from neobot_chat import get_model_registry
+
+        registry = get_model_registry()
+        registry_snapshot = registry.items()
+    except Exception:
+        registry = None
+
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(environ_snapshot)
+        if registry is not None:
+            registry.clear()
+            for _name, model in registry_snapshot:
+                registry.register(model, replace=True)
 
 
 # ── 事件循环 ──

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,4 +1,4 @@
-"""NeoBot 测试共享 fixtures — 全局约定见 bug_tracker/docs/TESTING_GUIDE.md。
+"""NeoBot 测试共享 fixtures — 全局约定见 docs/06-开发指南.md 的「测试」章节。
 
 新增 fixture 时请遵循:
 - 命名小写下划线, 尽量 scoped 到最窄 (function > module > session)
@@ -82,7 +82,9 @@ async def storage_engine(sqlite_db_path: Path):
     """neobot_storage 引擎 (WAL + busy_timeout, 与生产一致), 自动 dispose。"""
     from neobot_storage.engine import create_engine
 
-    engine = await create_engine(f"sqlite+aiosqlite:///{sqlite_db_path}")
+    # create_engine 是同步函数（返回 AsyncEngine），此前这里误写成 await，
+    # 一旦真有测试用到该 fixture 就会 TypeError。
+    engine = create_engine(f"sqlite+aiosqlite:///{sqlite_db_path}")
     yield engine
     await engine.dispose()
 
@@ -149,14 +151,3 @@ def _cache_httpx_ssl_context() -> Iterator[None]:
         for module, original in originals.items():
             module.create_ssl_context = original
 
-# ── BugStore (bug_tracker 数据层, 供 test_runner GUI 相关的测试) ──
-
-@pytest.fixture()
-def make_bug_store(tmp_path: Path):
-    """工厂 fixture: 在临时目录创建 BugStore。"""
-    from bugstore import BugStore
-
-    def _make() -> BugStore:
-        return BugStore(tmp_path)
-
-    return _make

--- a/app/tests/modules/adapter/test_adapter_tokens.py
+++ b/app/tests/modules/adapter/test_adapter_tokens.py
@@ -1,0 +1,46 @@
+"""适配器鉴权 token 的配置贯通测试。
+
+覆盖两类 token：
+- ``local_auth_token``：local 模式 HTTP/WS 的 Bearer token；
+- ``reverse_ws_access_token``：OneBot 反向 WebSocket 握手 token。
+
+历史上 ``[adapter]`` 与 ``AdapterSettings`` 都缺少 local token 字段，
+``assembly/adapter.py`` 的 ``getattr(..., "local_auth_token", "")`` 永远取空，
+导致 local 适配器已实现的鉴权中间件形同虚设。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from neobot_adapter import AdapterSettings
+from neobot_app.assembly.adapter import _settings_from_config
+from neobot_app.config.schemas.bot import Adapter
+
+
+def test_adapter_schema_has_local_auth_token() -> None:
+    assert Adapter().local_auth_token == ""
+    assert Adapter(local_auth_token="L").local_auth_token == "L"
+
+
+def test_adapter_schema_has_reverse_ws_access_token() -> None:
+    assert Adapter().reverse_ws_access_token == ""
+    assert Adapter(reverse_ws_access_token="R").reverse_ws_access_token == "R"
+
+
+def test_settings_from_config_carries_both_tokens() -> None:
+    config = SimpleNamespace(
+        adapter=Adapter(local_auth_token="LOCAL", reverse_ws_access_token="REVERSE"),
+        bot=SimpleNamespace(account=10001, nick_name="NeoBot"),
+    )
+    settings = _settings_from_config(config)
+    assert isinstance(settings, AdapterSettings)
+    assert settings.local_auth_token == "LOCAL"
+    assert settings.reverse_ws_access_token == "REVERSE"
+
+
+def test_settings_default_tokens_are_empty() -> None:
+    config = SimpleNamespace(adapter=Adapter(), bot=SimpleNamespace(account=0, nick_name=""))
+    settings = _settings_from_config(config)
+    assert settings.local_auth_token == ""
+    assert settings.reverse_ws_access_token == ""

--- a/app/tests/modules/adapter/test_reverse_ws_token.py
+++ b/app/tests/modules/adapter/test_reverse_ws_token.py
@@ -15,8 +15,8 @@ import websockets
 from neobot_adapter.onebot.receiver.core import (
     AdapterCore,
     _extract_access_token,
-    _is_loopback_host,
 )
+from neobot_adapter.utils.net import is_loopback_host
 
 
 class _FakeConnection:
@@ -155,7 +155,7 @@ async def test_handshake_legacy_signature_allows() -> None:
     ],
 )
 def test_is_loopback_host(host: str, expected: bool) -> None:
-    assert _is_loopback_host(host) is expected
+    assert is_loopback_host(host) is expected
 
 
 # ── 端到端：真实 websockets 握手 ─────────────────────────────────────

--- a/app/tests/modules/adapter/test_reverse_ws_token.py
+++ b/app/tests/modules/adapter/test_reverse_ws_token.py
@@ -1,0 +1,233 @@
+"""反向 WebSocket 握手鉴权（OneBot 11 access token）测试。
+
+规范依据（OneBot 11「鉴权」章节）：填写了 access token 时，OneBot 的反向
+WebSocket **客户端**在建立连接时会在请求头中加入 ``Authorization: Bearer
+<access_token>``；本端作为反向 WS 服务端负责校验。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import websockets
+
+from neobot_adapter.onebot.receiver.core import (
+    AdapterCore,
+    _extract_access_token,
+    _is_loopback_host,
+)
+
+
+class _FakeConnection:
+    """新版 websockets API 的 connection 替身：只记录 respond()。"""
+
+    def __init__(self) -> None:
+        self.responded: tuple[Any, str] | None = None
+
+    def respond(self, status: Any, text: str = "") -> str:
+        self.responded = (status, text)
+        return "response-sentinel"
+
+
+class _FakeRequest:
+    def __init__(self, headers: dict[str, str], path: str = "/onebot") -> None:
+        self.headers = headers
+        self.path = path
+
+
+# ── _extract_access_token ────────────────────────────────────────────
+
+
+def test_extract_token_from_bearer_header() -> None:
+    headers = {"Authorization": "Bearer kSLuTF2GC2Q4q4ugm3"}
+    assert _extract_access_token(headers, "/onebot") == "kSLuTF2GC2Q4q4ugm3"
+
+
+def test_extract_token_accepts_bare_header_value() -> None:
+    """部分框架只填 token、不带 Bearer 前缀，宽容接受。"""
+    assert _extract_access_token({"Authorization": "plain-token"}, "/") == "plain-token"
+
+
+def test_extract_token_from_query_parameter() -> None:
+    """规范对 HTTP / 正向 WS 给出的 query 兜底形式，这里同样兼容。"""
+    assert (
+        _extract_access_token({}, "/onebot?access_token=q-token&x=1") == "q-token"
+    )
+
+
+def test_extract_token_missing_returns_none() -> None:
+    assert _extract_access_token({}, "/onebot") is None
+    assert _extract_access_token(None, "/onebot") is None
+
+
+def test_extract_token_header_takes_precedence_over_query() -> None:
+    headers = {"Authorization": "Bearer from-header"}
+    assert _extract_access_token(headers, "/onebot?access_token=from-query") == (
+        "from-header"
+    )
+
+
+# ── 握手鉴权：配置了 token ───────────────────────────────────────────
+
+
+async def test_handshake_allows_matching_token_new_api() -> None:
+    core = AdapterCore(access_token="s3cret")
+    connection = _FakeConnection()
+    result = await core._authorize_handshake(
+        connection, _FakeRequest({"Authorization": "Bearer s3cret"})
+    )
+    assert result is None
+    assert connection.responded is None
+
+
+async def test_handshake_rejects_wrong_token_new_api() -> None:
+    core = AdapterCore(access_token="s3cret")
+    connection = _FakeConnection()
+    result = await core._authorize_handshake(
+        connection, _FakeRequest({"Authorization": "Bearer nope"})
+    )
+    assert result == "response-sentinel"
+    assert connection.responded is not None
+    assert int(connection.responded[0]) == 401
+
+
+async def test_handshake_rejects_missing_token_new_api() -> None:
+    core = AdapterCore(access_token="s3cret")
+    connection = _FakeConnection()
+    result = await core._authorize_handshake(connection, _FakeRequest({}))
+    assert result == "response-sentinel"
+    assert int(connection.responded[0]) == 401
+
+
+async def test_handshake_accepts_query_token_new_api() -> None:
+    core = AdapterCore(access_token="s3cret")
+    connection = _FakeConnection()
+    result = await core._authorize_handshake(
+        connection, _FakeRequest({}, path="/onebot?access_token=s3cret")
+    )
+    assert result is None
+    assert connection.responded is None
+
+
+# ── 握手鉴权：未配置 token（历史行为保持） ──────────────────────────
+
+
+async def test_handshake_allows_everything_without_token() -> None:
+    core = AdapterCore()
+    connection = _FakeConnection()
+    result = await core._authorize_handshake(connection, _FakeRequest({}))
+    assert result is None
+    assert connection.responded is None
+
+
+# ── 兼容旧版 websockets API 的签名 ──────────────────────────────────
+
+
+async def test_handshake_legacy_signature_rejects() -> None:
+    core = AdapterCore(access_token="s3cret")
+    status, _headers, _body = await core._authorize_handshake(
+        "/onebot", {"Authorization": "Bearer nope"}
+    )
+    assert int(status) == 401
+
+
+async def test_handshake_legacy_signature_allows() -> None:
+    core = AdapterCore(access_token="s3cret")
+    assert await core._authorize_handshake(
+        "/onebot", {"Authorization": "Bearer s3cret"}
+    ) is None
+
+
+# ── 回环判定（决定启动告警） ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("127.0.0.1", True),
+        ("127.0.0.53", True),
+        ("localhost", True),
+        ("::1", True),
+        ("0.0.0.0", False),
+        ("192.168.1.10", False),
+        ("", False),
+    ],
+)
+def test_is_loopback_host(host: str, expected: bool) -> None:
+    assert _is_loopback_host(host) is expected
+
+
+# ── 端到端：真实 websockets 握手 ─────────────────────────────────────
+
+
+async def _serve_once(core: AdapterCore):
+    """用真实的 websockets 服务端挂上鉴权钩子，返回 (server, port)。"""
+
+    async def _handler(websocket: Any) -> None:
+        # 保持连接直到客户端主动关闭，便于断言握手后的连接状态
+        await websocket.wait_closed()
+
+    server = await websockets.serve(
+        _handler,
+        "127.0.0.1",
+        0,
+        process_request=core._authorize_handshake,
+    )
+    port = int(server.sockets[0].getsockname()[1])
+    return server, port
+
+
+async def test_real_handshake_rejects_wrong_token() -> None:
+    core = AdapterCore(access_token="s3cret")
+    server, port = await _serve_once(core)
+    try:
+        with pytest.raises(websockets.exceptions.InvalidStatus) as excinfo:
+            async with websockets.connect(
+                f"ws://127.0.0.1:{port}/onebot",
+                additional_headers={"Authorization": "Bearer nope"},
+            ):
+                pass
+        assert excinfo.value.response.status_code == 401
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+async def test_real_handshake_accepts_matching_token() -> None:
+    core = AdapterCore(access_token="s3cret")
+    server, port = await _serve_once(core)
+    try:
+        async with websockets.connect(
+            f"ws://127.0.0.1:{port}/onebot",
+            additional_headers={"Authorization": "Bearer s3cret"},
+        ) as websocket:
+            assert websocket.state.name == "OPEN"
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+async def test_real_handshake_rejects_when_token_expected_but_absent() -> None:
+    core = AdapterCore(access_token="s3cret")
+    server, port = await _serve_once(core)
+    try:
+        with pytest.raises(websockets.exceptions.InvalidStatus) as excinfo:
+            async with websockets.connect(f"ws://127.0.0.1:{port}/onebot"):
+                pass
+        assert excinfo.value.response.status_code == 401
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+async def test_real_handshake_open_when_no_token_configured() -> None:
+    """未配置 token 时保持历史行为：任何来源都能连上。"""
+    core = AdapterCore()
+    server, port = await _serve_once(core)
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{port}/onebot") as websocket:
+            assert websocket.state.name == "OPEN"
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/app/tests/modules/agent_tools/test_lsp.py
+++ b/app/tests/modules/agent_tools/test_lsp.py
@@ -3,11 +3,35 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import subprocess
 import sys
+from pathlib import Path
+
 import pytest
 
 from neobot_app.agent_tools.contracts import ToolContext
 from neobot_app.agent_tools.lsp import LspTools
+
+
+def _make_directory_link(target: Path, link: Path) -> bool:
+    """尽力创建目录链接：POSIX 用 symlink，Windows 退化为免管理员的目录联接。"""
+    try:
+        os.symlink(target, link, target_is_directory=True)
+        return True
+    except OSError:
+        pass
+    if os.name == "nt":
+        try:
+            result = subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            return False
+        return result.returncode == 0
+    return False
 
 
 _SERVER = r'''
@@ -100,11 +124,40 @@ def setup_lsp(tmp_path):
     return root, build
 
 
-def test_deployment_executable_is_resolved_before_owner_cwd(setup_lsp):
+def test_deployment_executable_is_absolute_but_keeps_symlinks(setup_lsp):
+    """可执行路径要绝对化，但不能穿透符号链接。
+
+    ⚠️ 这是防回归用例，不要为了让实现"看起来更干净"而放宽它：穿透会让 venv 的
+    符号链接解释器（Linux/macOS 上的常态）退化成基础解释器，子进程带 -I 启动时
+    看不到 venv 的 site-packages，pylsp 直接起不来（只在 Linux/macOS 复现）。
+    """
     _, build = setup_lsp
     tools = build()
     configured = tools._servers[".py"][0]
-    assert configured[0] == str(__import__("pathlib").Path(sys.executable).resolve())
+    assert configured[0] == os.path.abspath(sys.executable)
+
+
+def test_deployment_executable_through_link_keeps_link_path(tmp_path):
+    """经链接指向解释器时，配置里必须保留链接路径（不解析到真身）。
+
+    ⚠️ 若有人把实现改回 Path(...).resolve() / os.path.realpath()，本用例会失败：
+    那正是 Linux 上 LSP 全挂（lsp_protocol_error）的根因。链接在 Windows 上用
+    目录联接实现（免管理员），无法创建时跳过。
+    """
+    linked_dir = tmp_path / "linked"
+    target_dir = Path(sys.executable).parent
+    if not _make_directory_link(target_dir, linked_dir):
+        pytest.skip("当前环境无法创建目录链接（Windows 需开发者模式或联接权限）")
+    linked_exe = linked_dir / Path(sys.executable).name
+
+    tools = LspTools(
+        lambda _context: tmp_path,
+        {".py": {"command": [str(linked_exe), "-I", "-m", "pylsp"], "language_id": "python"}},
+    )
+
+    configured = tools._servers[".py"][0][0]
+    assert configured == os.path.abspath(str(linked_exe))
+    assert configured != str(Path(linked_exe).resolve())
 
 
 def context(owner="owner-a"):

--- a/app/tests/modules/builtin_plugins/test_dashboard_api.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_api.py
@@ -261,6 +261,31 @@ async def test_unconfigured_panel_blocks_external_access(tmp_path: Path) -> None
         await server.stop()
 
 
+async def test_forwarded_for_cannot_forge_loopback(tmp_path: Path) -> None:
+    """客户端伪造 X-Forwarded-For 不能把自己变成「本机」，从而抢设面板密码。
+
+    可信代理会把真实客户端地址追加到 XFF **末尾**；客户端自己带的那些项在最左边，
+    因此只有最右一项可用于判定来源。旧实现取 split(",")[0]，任何人加一个
+    ``X-Forwarded-For: 127.0.0.1`` 就能通过「仅本机可设置密码」。
+    """
+    server, _, base, _ = await _start_panel(tmp_path, password=None, trust_proxy=True)
+    try:
+        spoofed = {"X-Forwarded-For": "127.0.0.1, 203.0.113.9"}
+        async with httpx.AsyncClient() as client:
+            status = await client.get(base + "/api/auth/status", headers=spoofed)
+            setup = await client.post(
+                base + "/api/auth/setup",
+                json={"password": PASSWORD, "confirm": PASSWORD},
+                headers=spoofed,
+            )
+
+        assert status.json()["loopback"] is False
+        assert setup.status_code == 403
+        assert server.passwords.configured is False
+    finally:
+        await server.stop()
+
+
 async def test_unconfigured_panel_allows_loopback_setup(tmp_path: Path) -> None:
     """本机访问未配置密码的面板时，只允许进入设置流程。"""
     server, _, base, _ = await _start_panel(tmp_path, password=None)

--- a/app/tests/modules/builtin_plugins/test_dashboard_api.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_api.py
@@ -286,6 +286,50 @@ async def test_forwarded_for_cannot_forge_loopback(tmp_path: Path) -> None:
         await server.stop()
 
 
+async def test_login_works_behind_reverse_proxy_with_forwarded_host(
+    tmp_path: Path,
+) -> None:
+    """经反向代理访问（Host 被改写）时登录必须可用。
+
+    文档推荐「公网经 HTTPS 反向代理访问」：浏览器地址栏是域名，而到达 NeoBot 的
+    Host 可能是 127.0.0.1:9981。只比 Host 会让登录/首设密码永久 403，面板彻底
+    不可用；开启 trust_proxy_headers 时应接受代理写入的 X-Forwarded-Host。
+    """
+    server, _, base, _ = await _start_panel(tmp_path, trust_proxy=True)
+    try:
+        headers = {
+            "Origin": "https://bot.example.com",
+            "X-Forwarded-Host": "bot.example.com",
+        }
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                base + "/api/auth/login", json={"password": PASSWORD}, headers=headers
+            )
+
+        assert response.status_code == 200, response.text
+    finally:
+        await server.stop()
+
+
+async def test_login_rejects_origin_not_matching_forwarded_host(
+    tmp_path: Path,
+) -> None:
+    server, _, base, _ = await _start_panel(tmp_path, trust_proxy=True)
+    try:
+        headers = {
+            "Origin": "https://evil.example",
+            "X-Forwarded-Host": "bot.example.com",
+        }
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                base + "/api/auth/login", json={"password": PASSWORD}, headers=headers
+            )
+
+        assert response.status_code == 403
+    finally:
+        await server.stop()
+
+
 async def test_unconfigured_panel_allows_loopback_setup(tmp_path: Path) -> None:
     """本机访问未配置密码的面板时，只允许进入设置流程。"""
     server, _, base, _ = await _start_panel(tmp_path, password=None)

--- a/app/tests/modules/builtin_plugins/test_dashboard_api.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_api.py
@@ -861,3 +861,55 @@ async def test_auth_setup_still_works_with_json_from_loopback(tmp_path: Path) ->
         assert server.passwords.configured is True
     finally:
         await server.stop()
+
+
+class _RecordingLogger(_NullLogger):
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+
+    def warning(self, message: str = "", *args, **kwargs) -> None:
+        self.warnings.append(str(message))
+
+
+async def _start_panel_with_host(tmp_path: Path, *, host: str) -> tuple[DashboardServer, _RecordingLogger]:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('version = "0.5.0"\n', encoding="utf-8")
+    env_path = tmp_path / ".env"
+    env_path.write_text("DeepSeek_APIKey=sk-super-secret\n", encoding="utf-8")
+    data_dir = tmp_path / "data"
+    PanelPasswordStore(data_dir / "auth.json").set_password(PASSWORD)
+    logger = _RecordingLogger()
+    server = DashboardServer(
+        plugin_name="dashboard",
+        config=DashboardConfig(
+            enabled=True, host=host, port=_free_port(), secure_cookies=False
+        ),
+        data_dir=data_dir,
+        logger=logger,
+        adapter=_FakeAdapter(),
+        plugin_control=_FakeControl(),
+        config_path=config_path,
+        env_path=env_path,
+        backup_dir=tmp_path / "backup",
+    )
+    await server.start()
+    return server, logger
+
+
+async def test_non_loopback_panel_warns_about_plaintext_credentials(
+    tmp_path: Path,
+) -> None:
+    """面板对网络开放且未启用 Secure Cookie 时必须给出启动告警。"""
+    server, logger = await _start_panel_with_host(tmp_path, host="0.0.0.0")
+    try:
+        assert any("Secure Cookie" in message for message in logger.warnings)
+    finally:
+        await server.stop()
+
+
+async def test_loopback_panel_does_not_warn(tmp_path: Path) -> None:
+    server, logger = await _start_panel_with_host(tmp_path, host="127.0.0.1")
+    try:
+        assert logger.warnings == []
+    finally:
+        await server.stop()

--- a/app/tests/modules/builtin_plugins/test_dashboard_api.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_api.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import json
 import socket
 from pathlib import Path
 

--- a/app/tests/modules/builtin_plugins/test_dashboard_api.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_api.py
@@ -786,3 +786,79 @@ async def test_logs_endpoint_shape(panel) -> None:
     assert payload["ok"] is True
     assert isinstance(payload["items"], list)
     assert "last_id" in payload
+
+
+# ── 会话建立前端点的跨站防护（登录 / 首次设置密码没有 CSRF token 可用） ──
+
+
+async def test_auth_login_rejects_non_json_content_type(panel) -> None:
+    """跨站表单只能发 urlencoded/multipart/text-plain，这条把表单类提交挡在门外。"""
+    _, _, base, _ = panel
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            base + "/api/auth/login",
+            content=b'{"password": "x"}',
+            headers={"Content-Type": "text/plain"},
+        )
+
+    assert response.status_code == 415
+
+
+async def test_auth_login_rejects_cross_origin(panel) -> None:
+    _, _, base, _ = panel
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            base + "/api/auth/login",
+            json={"password": PASSWORD},
+            headers={"Origin": "http://evil.example"},
+        )
+
+    assert response.status_code == 403
+
+
+async def test_auth_login_allows_same_origin_json(panel) -> None:
+    _, _, base, _ = panel
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            base + "/api/auth/login",
+            json={"password": PASSWORD},
+            headers={"Origin": base},
+        )
+
+    assert response.status_code == 200
+
+
+async def test_auth_setup_rejects_form_post(tmp_path: Path) -> None:
+    """未设置密码时不能被第三方页面「抢先设置」面板密码。"""
+    server, _, base, _ = await _start_panel(tmp_path, password=None)
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                base + "/api/auth/setup",
+                content=(
+                    b'{"password": "attacker-password-1", '
+                    b'"confirm": "attacker-password-1"}'
+                ),
+                headers={"Content-Type": "text/plain"},
+            )
+
+        assert response.status_code == 415
+        assert server.passwords.configured is False
+    finally:
+        await server.stop()
+
+
+async def test_auth_setup_still_works_with_json_from_loopback(tmp_path: Path) -> None:
+    """回归：前端用的是 JSON，正常初始化流程不受影响。"""
+    server, _, base, _ = await _start_panel(tmp_path, password=None)
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                base + "/api/auth/setup",
+                json={"password": "loopback-password-1", "confirm": "loopback-password-1"},
+            )
+
+        assert response.status_code == 200, response.text
+        assert server.passwords.configured is True
+    finally:
+        await server.stop()

--- a/app/tests/modules/builtin_plugins/test_dashboard_config_unknown_keys.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_config_unknown_keys.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -140,3 +141,81 @@ def test_plugins_proxy_save_survives_extra_keys(tmp_path: Path) -> None:
     saved = config_path.read_text(encoding="utf-8")
     assert "proxy_port = 7890" in saved
     assert "[my_plugin]" in saved
+
+
+def test_adapter_tokens_are_not_returned_by_read(tmp_path: Path) -> None:
+    """config.toml 里的 token 不能出现在面板响应里（只回「是否已设置」）。"""
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n'
+        "\n[adapter]\n"
+        'local_auth_token = "LTOK-SECRET"\n'
+        'reverse_ws_access_token = "RTOK-SECRET"\n',
+        encoding="utf-8",
+    )
+
+    document = manager.read()
+    dumped = json.dumps(document, ensure_ascii=False)
+
+    assert "LTOK-SECRET" not in dumped
+    assert "RTOK-SECRET" not in dumped
+    assert document["config"]["adapter"]["local_auth_token"] == ""
+    assert document["secrets_set"]["adapter.local_auth_token"] is True
+    assert document["secrets_set"]["adapter.reverse_ws_access_token"] is True
+
+
+def test_masked_tokens_survive_form_save(tmp_path: Path) -> None:
+    """掩码后的空串回传不能被当成「用户清空」，否则一次表单保存就抹掉 token。"""
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n'
+        "\n[adapter]\n"
+        'local_auth_token = "LTOK-SECRET"\n'
+        "\n[dashboard]\n"
+        "port = 9981\n",
+        encoding="utf-8",
+    )
+
+    document = manager.read()
+    payload = {
+        **document["config"],
+        "dashboard": {**document["config"]["dashboard"], "port": 9999},
+    }
+    manager.save(config=payload)
+
+    saved = config_path.read_text(encoding="utf-8")
+    assert "port = 9999" in saved
+    assert "LTOK-SECRET" in saved
+
+
+def test_explicit_token_value_still_updates(tmp_path: Path) -> None:
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n\n[adapter]\nlocal_auth_token = "old"\n',
+        encoding="utf-8",
+    )
+
+    document = manager.read()
+    adapter = {**document["config"]["adapter"], "local_auth_token": "new-token"}
+    manager.save(config={**document["config"], "adapter": adapter})
+
+    assert 'local_auth_token = "new-token"' in config_path.read_text(encoding="utf-8")
+
+
+def test_masked_source_roundtrip_keeps_token(tmp_path: Path) -> None:
+    """TOML 原文模式：脱敏后的原文保存回去时，未改动的密钥行必须还原。"""
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n\n[adapter]\nlocal_auth_token = "LTOK-SECRET"\n',
+        encoding="utf-8",
+    )
+
+    document = manager.read()
+    assert "LTOK-SECRET" not in document["source"]
+    assert '"***"' in document["source"]
+
+    manager.save(source=document["source"])
+
+    saved = config_path.read_text(encoding="utf-8")
+    assert 'local_auth_token = "LTOK-SECRET"' in saved
+    assert "***" not in saved

--- a/app/tests/modules/builtin_plugins/test_dashboard_config_unknown_keys.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_config_unknown_keys.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from neobot_app.builtin_plugins.dashboard.config_manager import BotConfigManager
+import pytest
+
+from neobot_app.builtin_plugins.dashboard.config_manager import (
+    BotConfigManager,
+    ConfigValidationError,
+)
 
 
 def _manager(tmp_path: Path) -> tuple[BotConfigManager, Path]:
@@ -82,3 +87,56 @@ def test_form_save_still_deletes_free_mapping_keys(tmp_path: Path) -> None:
     saved = config_path.read_text(encoding="utf-8")
     assert "999002" not in saved
     assert "999001 = 0.5" in saved
+
+
+def test_section_save_survives_extra_keys(tmp_path: Path) -> None:
+    """配置文件里已有面板不认识的键时，分区保存不能被「未知配置项」拦死。"""
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n'
+        'my_top_level = "keep-me"\n'
+        "\n[my_plugin]\n"
+        "enabled = true\n"
+        "\n[dashboard]\n"
+        "port = 9981\n",
+        encoding="utf-8",
+    )
+
+    manager.update_section("dashboard", {"port": 9999})
+
+    saved = config_path.read_text(encoding="utf-8")
+    assert "port = 9999" in saved
+    assert "my_top_level" in saved
+    assert "[my_plugin]" in saved
+
+
+def test_section_save_rejects_unknown_key_in_edited_section(tmp_path: Path) -> None:
+    """正在编辑的分区里出现未知键，依然要报错（不能静默写进去）。"""
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n\n[dashboard]\nport = 9981\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigValidationError):
+        manager.update_section("dashboard", {"nope": 1})
+
+    assert "nope" not in config_path.read_text(encoding="utf-8")
+
+
+def test_plugins_proxy_save_survives_extra_keys(tmp_path: Path) -> None:
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n'
+        "\n[my_plugin]\n"
+        "enabled = true\n"
+        "\n[plugins]\n"
+        'proxy_mode = "system"\n',
+        encoding="utf-8",
+    )
+
+    manager.update_plugins_proxy(mode="system", host="127.0.0.1", port=7890)
+
+    saved = config_path.read_text(encoding="utf-8")
+    assert "proxy_port = 7890" in saved
+    assert "[my_plugin]" in saved

--- a/app/tests/modules/builtin_plugins/test_dashboard_config_unknown_keys.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_config_unknown_keys.py
@@ -143,6 +143,62 @@ def test_plugins_proxy_save_survives_extra_keys(tmp_path: Path) -> None:
     assert "[my_plugin]" in saved
 
 
+def test_form_save_keeps_unknown_keys_inside_table_arrays(tmp_path: Path) -> None:
+    """表数组（[[models.registry]] 等）元素里的未知键同样要保留。
+
+    79035cc 的未知键保护只覆盖 table；数组是整值替换，元素里的额外键会被
+    一次表单保存静默抹掉。
+    """
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n'
+        "\n[[models.registry]]\n"
+        'key = "m1"\n'
+        'model_type = "chat"\n'
+        'provider = "DeepSeek"\n'
+        'model_name = "deepseek-chat"\n'
+        'brand_new_field = "keep-me"\n'
+        "\n[[chat.key_word]]\n"
+        'enabled = true\n'
+        'keywords = ["hi"]\n'
+        'prompt_list = ["greet"]\n'
+        'custom_key = "keep-me-too"\n',
+        encoding="utf-8",
+    )
+
+    document = manager.read()
+    manager.save(config=document["config"])
+
+    saved = config_path.read_text(encoding="utf-8")
+    assert "brand_new_field" in saved
+    assert "custom_key" in saved
+
+
+def test_form_save_can_still_remove_table_array_entries(tmp_path: Path) -> None:
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n'
+        "\n[[chat.key_word]]\n"
+        'enabled = true\n'
+        'keywords = ["a"]\n'
+        'prompt_list = ["x"]\n'
+        "\n[[chat.key_word]]\n"
+        'enabled = true\n'
+        'keywords = ["b"]\n'
+        'prompt_list = ["y"]\n',
+        encoding="utf-8",
+    )
+
+    document = manager.read()
+    chat = dict(document["config"]["chat"])
+    chat["key_word"] = chat["key_word"][:1]
+    manager.save(config={**document["config"], "chat": chat})
+
+    saved = config_path.read_text(encoding="utf-8")
+    assert saved.count("[[chat.key_word]]") == 1
+    assert "keywords = [\"a\"]" in saved
+
+
 def test_adapter_tokens_are_not_returned_by_read(tmp_path: Path) -> None:
     """config.toml 里的 token 不能出现在面板响应里（只回「是否已设置」）。"""
     manager, config_path = _manager(tmp_path)

--- a/app/tests/modules/builtin_plugins/test_dashboard_config_unknown_keys.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_config_unknown_keys.py
@@ -1,0 +1,84 @@
+"""面板保存 config.toml 时，必须保留表单不认识的键。
+
+面板表单的字段来自 ``BotConfig`` 的声明，文件里允许存在声明之外的键：
+用户自定义分区、插件写进去的字段、更新版本留下的新字段。旧实现把这些键
+当成「表单里删掉的键」，``_diff_document`` 直接给出删除指令，一次面板保存
+就会把它们从 config.toml 里抹掉。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from neobot_app.builtin_plugins.dashboard.config_manager import BotConfigManager
+
+
+def _manager(tmp_path: Path) -> tuple[BotConfigManager, Path]:
+    config_path = tmp_path / "config.toml"
+    return (
+        BotConfigManager(config_path=config_path, backup_dir=tmp_path / "backup"),
+        config_path,
+    )
+
+
+def test_form_save_keeps_unknown_sections(tmp_path: Path) -> None:
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n'
+        'my_top_level = "keep-me"\n'
+        "\n[bot]\n"
+        'nick_name = "Neo"\n'
+        "custom_in_section = 7\n"
+        "\n[my_plugin]\n"
+        "enabled = true\n",
+        encoding="utf-8",
+    )
+
+    document = manager.read()
+    manager.save(config=document["config"])
+
+    saved = config_path.read_text(encoding="utf-8")
+    assert "my_top_level" in saved
+    assert "[my_plugin]" in saved
+    assert "custom_in_section = 7" in saved
+
+
+def test_form_save_still_deletes_known_fields(tmp_path: Path) -> None:
+    """托管字段的删除必须照旧生效，不能被「未知键保护」误伤。"""
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n\n[bot]\nnick_name = "Neo"\nalias_name = ["N"]\n',
+        encoding="utf-8",
+    )
+
+    document = manager.read()
+    payload = {
+        key: value
+        for key, value in document["config"].items()
+        if key not in {"willing"}
+    }
+    manager.save(config=payload)
+
+    saved = config_path.read_text(encoding="utf-8")
+    assert "[willing]" not in saved
+
+
+def test_form_save_still_deletes_free_mapping_keys(tmp_path: Path) -> None:
+    """分群系数这类自由映射：键由用户决定，表单删掉就该删掉。"""
+    manager, config_path = _manager(tmp_path)
+    config_path.write_text(
+        'version = "0.6.0"\n'
+        "\n[chat.group_response_coefficient]\n"
+        '999001 = 0.5\n'
+        '999002 = 0.8\n',
+        encoding="utf-8",
+    )
+
+    document = manager.read()
+    chat = dict(document["config"]["chat"])
+    chat["group_response_coefficient"] = {"999001": 0.5}
+    manager.save(config={**document["config"], "chat": chat})
+
+    saved = config_path.read_text(encoding="utf-8")
+    assert "999002" not in saved
+    assert "999001 = 0.5" in saved

--- a/app/tests/modules/builtin_plugins/test_dashboard_message_stats.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_message_stats.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 from neobot_modloader.context import RuntimePluginContext

--- a/app/tests/modules/builtin_plugins/test_dashboard_usage.py
+++ b/app/tests/modules/builtin_plugins/test_dashboard_usage.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import datetime as dt
 from pathlib import Path
-from types import SimpleNamespace
 
 import httpx
 import pytest

--- a/app/tests/modules/config/test_backup_naming.py
+++ b/app/tests/modules/config/test_backup_naming.py
@@ -1,0 +1,59 @@
+"""备份命名必须区分来源文件。
+
+同一备份目录里既有 config.toml 也有 .env 的备份时，旧实现把两者都命名为
+``config_<ts>.toml``：.env 的明文密钥落在名为 config 的文件里（极易被误当配置
+还原），两类备份还会互相挤占保留额度。
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from neobot_app.config.loader.backup import backup_config
+
+
+def test_backup_name_carries_source_name(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('version = "1.0.0"\n', encoding="utf-8")
+    env_file = tmp_path / ".env"
+    env_file.write_text("DeepSeek_APIKey=sk-test\n", encoding="utf-8")
+    backup_dir = tmp_path / "config_backup"
+
+    backup_config(config_file, backup_dir)
+    backup_config(env_file, backup_dir)
+
+    names = sorted(p.name for p in backup_dir.iterdir())
+    assert any(name.startswith("config_") and name.endswith(".toml") for name in names)
+    assert any(name.startswith(".env_") for name in names)
+    # .env 的备份不能再伪装成 config.toml
+    assert len([n for n in names if n.endswith(".toml")]) == 1
+
+
+def test_rotation_is_per_source(tmp_path: Path) -> None:
+    """不同来源各自保留 max_backups 份，不互相挤占。"""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("a = 1\n", encoding="utf-8")
+    env_file = tmp_path / ".env"
+    env_file.write_text("A=1\n", encoding="utf-8")
+    backup_dir = tmp_path / "config_backup"
+
+    # 备份名的时间戳精确到毫秒，稍作间隔避免同毫秒互相覆盖
+    for _ in range(3):
+        backup_config(config_file, backup_dir, max_backups=2)
+        time.sleep(0.005)
+    for _ in range(3):
+        backup_config(env_file, backup_dir, max_backups=2)
+        time.sleep(0.005)
+
+    names = [p.name for p in backup_dir.iterdir()]
+    assert len([n for n in names if n.endswith(".toml")]) == 2
+    assert len([n for n in names if n.startswith(".env_")]) == 2
+
+
+def test_missing_source_is_noop(tmp_path: Path) -> None:
+    backup_dir = tmp_path / "config_backup"
+
+    backup_config(tmp_path / "nope.toml", backup_dir)
+
+    assert not backup_dir.exists()

--- a/app/tests/modules/config/test_config.py
+++ b/app/tests/modules/config/test_config.py
@@ -341,26 +341,31 @@ def test_load_missing_items_reports_exact_full_list_with_multiple_reasons(
     assert exited == []
 
 
-def test_load_damaged_toml_is_regenerated_as_valid_config(monkeypatch, tmp_path):
-    """损坏的 TOML 必须被覆盖重建为合法配置，缺 Key 时仍抛 ConfigLoadError 且文件可重新解析。"""
+def test_load_damaged_toml_is_rejected_without_touching_the_file(monkeypatch, tmp_path):
+    """损坏的 TOML 必须报错并保持原文件：既不能用默认值覆盖，也不能先备份再覆盖。
+
+    旧行为是「备份 + 用 schema 默认值重写整份文件」，等于把用户配置静默重置，
+    只有 config_backup/ 能人工救回；现在改为 fail-fast，由用户修复或移走该文件。
+    """
     # Arrange
     _clear_platform_env(monkeypatch)
     cfg_path = tmp_path / "bot.toml"
-    cfg_path.write_text("this is {{{ not valid toml", encoding="utf-8")
+    broken = "this is {{{ not valid toml"
+    cfg_path.write_text(broken, encoding="utf-8")
+    backup_calls: list[tuple] = []
     monkeypatch.setattr(
-        "neobot_app.config.loader.manager.backup_config", lambda *a, **k: None
+        "neobot_app.config.loader.manager.backup_config",
+        lambda *a, **k: backup_calls.append(a),
     )
 
     # Act
-    with pytest.raises(ConfigLoadError):
+    with pytest.raises(ConfigLoadError) as excinfo:
         Config.load(cfg_path, BotConfig)
 
     # Assert
-    doc = tomlkit.parse(cfg_path.read_text(encoding="utf-8")).unwrap()
-    assert "bot" in doc
-    assert "chat" in doc
-    assert "models" in doc
-    assert doc["bot"]["account"] == 0
+    assert "解析失败" in str(excinfo.value)
+    assert cfg_path.read_text(encoding="utf-8") == broken
+    assert backup_calls == []
 
 
 def test_load_invalid_type_value_falls_back_to_default_and_rewrites(monkeypatch, tmp_path):

--- a/app/tests/modules/config/test_config_safety.py
+++ b/app/tests/modules/config/test_config_safety.py
@@ -1,0 +1,95 @@
+"""配置加载的安全语义测试。
+
+覆盖两条路径：
+1. 配置文件解析失败时**不得**用默认值整份覆盖用户配置（原行为会先备份、
+   再用 schema 默认值重写整份文件，用户设置全部丢失）；
+2. 写回（补全缺失项/生成）必须是原子的，不留半截文件。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import tomlkit
+
+from neobot_app.config.loader.manager import Config, ConfigLoadError
+from neobot_app.config.schemas.bot import BotConfig
+
+_BROKEN_TOML = "this is {{{ not valid toml"
+
+
+def _clear_platform_env(monkeypatch) -> None:
+    for key in (
+        "DeepSeek_URL",
+        "DeepSeek_APIKey",
+        "SiliconFlow_URL",
+        "SiliconFlow_APIKey",
+        "HuoShan_APIKey",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_broken_toml_keeps_original_file(monkeypatch, tmp_path: Path) -> None:
+    """语法错误时报错并保持原文件内容，不能被默认值覆盖。"""
+    _clear_platform_env(monkeypatch)
+    cfg_path = tmp_path / "bot.toml"
+    cfg_path.write_text(_BROKEN_TOML, encoding="utf-8")
+
+    with pytest.raises(ConfigLoadError) as excinfo:
+        Config.load(cfg_path, BotConfig)
+
+    assert "解析失败" in str(excinfo.value)
+    assert cfg_path.read_text(encoding="utf-8") == _BROKEN_TOML
+
+
+def test_broken_toml_does_not_write_backup(monkeypatch, tmp_path: Path) -> None:
+    """解析失败时连备份/覆盖都不应发生（文件保持原样即可）。"""
+    _clear_platform_env(monkeypatch)
+    cfg_path = tmp_path / "bot.toml"
+    cfg_path.write_text(_BROKEN_TOML, encoding="utf-8")
+    backup_calls: list[tuple] = []
+    monkeypatch.setattr(
+        "neobot_app.config.loader.manager.backup_config",
+        lambda *args, **kwargs: backup_calls.append(args),
+    )
+
+    with pytest.raises(ConfigLoadError):
+        Config.load(cfg_path, BotConfig)
+
+    assert backup_calls == []
+
+
+def test_missing_file_is_generated_as_parseable_toml(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _clear_platform_env(monkeypatch)
+    cfg_path = tmp_path / "bot.toml"
+
+    # 缺平台密钥时仍会抛 ConfigLoadError，但文件已经生成
+    with pytest.raises(ConfigLoadError):
+        Config.load(cfg_path, BotConfig)
+
+    assert cfg_path.is_file()
+    doc = tomlkit.parse(cfg_path.read_text(encoding="utf-8")).unwrap()
+    assert doc["bot"]["account"] == 0
+
+
+def test_write_back_is_atomic_and_leaves_no_temp_files(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """补全缺失项走临时文件 + os.replace，目录里不留 .tmp 残片。"""
+    _clear_platform_env(monkeypatch)
+    cfg_path = tmp_path / "bot.toml"
+    cfg_path.write_text('[bot]\naccount = 10001\n\n[chat]\n', encoding="utf-8")
+    monkeypatch.setattr(
+        "neobot_app.config.loader.manager.backup_config", lambda *a, **k: None
+    )
+
+    with pytest.raises(ConfigLoadError):
+        Config.load(cfg_path, BotConfig)
+
+    doc = tomlkit.parse(cfg_path.read_text(encoding="utf-8")).unwrap()
+    assert doc["bot"]["account"] == 10001  # 用户填的值必须保留
+    assert "models" in doc  # 缺失项已补全
+    assert [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")] == []

--- a/app/tests/modules/config/test_default_alignment.py
+++ b/app/tests/modules/config/test_default_alignment.py
@@ -1,0 +1,62 @@
+"""schema 默认值 与 运行期回退值 必须一致。
+
+审查发现两处「同一配置项两个默认值」：字段缺失时的 getattr 回退与 dataclass
+默认值、schema 默认值互相矛盾，会让同一份配置在不同代码路径下表现不同。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from neobot_app.config.schemas.bot import Chat, ScheduledTask
+from neobot_app.reply.orchestrator import ReplyOrchestrator
+from neobot_app.runtime.scheduled_tasks import ScheduledTaskConfig
+
+
+def _bare_orchestrator(config) -> ReplyOrchestrator:
+    orchestrator = ReplyOrchestrator.__new__(ReplyOrchestrator)
+    orchestrator._config = config
+    return orchestrator
+
+
+# ── reply_mode ──────────────────────────────────────────────────────
+
+
+def test_reply_mode_schema_default_is_agent() -> None:
+    assert Chat().reply_mode == "agent"
+
+
+def test_resolve_mode_fallback_matches_schema_default() -> None:
+    """字段缺失/配置为空时必须回退到 schema 默认值 agent，而不是 common。"""
+    assert _bare_orchestrator(None)._resolve_mode() == "agent"
+    assert _bare_orchestrator(SimpleNamespace(chat=SimpleNamespace()))._resolve_mode() == "agent"
+
+
+def test_resolve_mode_honours_explicit_common() -> None:
+    config = SimpleNamespace(chat=SimpleNamespace(reply_mode="common"))
+    assert _bare_orchestrator(config)._resolve_mode() == "common"
+
+
+def test_resolve_mode_rejects_unknown_value() -> None:
+    config = SimpleNamespace(chat=SimpleNamespace(reply_mode="nonsense"))
+    assert _bare_orchestrator(config)._resolve_mode() == "agent"
+
+
+# ── poll_interval_seconds ───────────────────────────────────────────
+
+
+def test_poll_interval_schema_default_is_ten() -> None:
+    assert ScheduledTask().poll_interval_seconds == 10
+
+
+def test_scheduled_task_config_defaults_match_schema() -> None:
+    assert ScheduledTaskConfig().poll_interval_seconds == 10
+    built = ScheduledTaskConfig.from_schema(SimpleNamespace())
+    assert built.poll_interval_seconds == 10
+
+
+def test_poll_interval_override_is_honoured() -> None:
+    built = ScheduledTaskConfig.from_schema(
+        SimpleNamespace(poll_interval_seconds=30)
+    )
+    assert built.poll_interval_seconds == 30

--- a/app/tests/modules/drawing/test_drawing_service.py
+++ b/app/tests/modules/drawing/test_drawing_service.py
@@ -75,7 +75,7 @@ async def test_list_images_does_not_hash_disk_files(tmp_path, monkeypatch):
             )
             await uow.commit()
 
-        monkeypatch.setattr("neobot_app.drawing.service.prepare_local_image", _explode)
+        monkeypatch.setattr("neobot_app.drawing.service.prepare_local_image_async", _explode)
         records = await service.list_images(source="gallery")
         assert [r.image_id for r in records] == ["g_abc"]
     finally:
@@ -104,7 +104,7 @@ async def test_list_images_excludes_dead_records(tmp_path, monkeypatch):
                 )
             await uow.commit()
 
-        monkeypatch.setattr("neobot_app.drawing.service.prepare_local_image", _explode)
+        monkeypatch.setattr("neobot_app.drawing.service.prepare_local_image_async", _explode)
         records = await service.list_images(source="gallery")
         assert {r.image_id for r in records} == {"g_live"}
     finally:
@@ -115,7 +115,7 @@ async def test_list_images_excludes_dead_records(tmp_path, monkeypatch):
 async def test_count_images_does_not_hash(tmp_path, monkeypatch):
     service, engine, _ = await _make_service(tmp_path, monkeypatch)
     try:
-        monkeypatch.setattr("neobot_app.drawing.service.prepare_local_image", _explode)
+        monkeypatch.setattr("neobot_app.drawing.service.prepare_local_image_async", _explode)
         assert await service.count_images() == 0
     finally:
         await service.close()
@@ -143,7 +143,7 @@ async def test_search_images_excludes_dead_records(tmp_path, monkeypatch):
                 )
             await uow.commit()
 
-        monkeypatch.setattr("neobot_app.drawing.service.prepare_local_image", _explode)
+        monkeypatch.setattr("neobot_app.drawing.service.prepare_local_image_async", _explode)
         records = await service.search_images("红色", source="gallery", limit=50)
         assert {r.image_id for r in records} == {"g_live"}
     finally:
@@ -265,7 +265,7 @@ async def test_query_paths_do_not_trigger_full_hash_with_disk_files(tmp_path, mo
             )
             await uow.commit()
 
-        monkeypatch.setattr("neobot_app.drawing.service.prepare_local_image", _explode)
+        monkeypatch.setattr("neobot_app.drawing.service.prepare_local_image_async", _explode)
         assert await service.count_images(source="gallery") == 1
         assert [r.image_id for r in await service.list_images(source="gallery")] == ["g_abc"]
         assert {r.image_id for r in await service.search_images("测试", source="gallery")} == {"g_abc"}

--- a/app/tests/modules/drawing/test_local_image_ref.py
+++ b/app/tests/modules/drawing/test_local_image_ref.py
@@ -1,0 +1,89 @@
+"""本地图片引用的读取边界测试。
+
+修复前的 ``_download_image_ref`` 对 ``file://`` 与裸路径都直接 ``read_bytes()``：
+上游只要能给到 ``url``/``file`` 字段（被注入的事件、模型构造的引用），
+就能让 Bot 读任意本地文件。现在只接受「确实是图片且不超上限」的文件。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from neobot_app.drawing import service as drawing_service_module
+from neobot_app.drawing.service import CreatorImageService
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+_JPEG_BYTES = b"\xff\xd8\xff" + b"\x00" * 64
+
+
+def _stub_service() -> CreatorImageService:
+    """本地读取分支不需要实例状态，构造一个 bare 实例即可。"""
+    return CreatorImageService.__new__(CreatorImageService)
+
+
+async def test_local_ref_rejects_non_image_file(tmp_path: Path) -> None:
+    secret = tmp_path / ".env"
+    secret.write_text("DeepSeek_APIKey=sk-super-secret-value\n", encoding="utf-8")
+
+    with pytest.raises(LookupError) as excinfo:
+        await _stub_service()._download_image_ref(f"file:///{secret.as_posix()}")
+
+    assert "不是图片" in str(excinfo.value)
+
+
+async def test_local_ref_accepts_real_image(tmp_path: Path) -> None:
+    image = tmp_path / "picture.png"
+    image.write_bytes(_PNG_BYTES)
+
+    data = await _stub_service()._download_image_ref(f"file:///{image.as_posix()}")
+
+    assert data == _PNG_BYTES
+
+
+async def test_bare_path_is_validated_too(tmp_path: Path) -> None:
+    """裸路径分支（无 file:// 前缀）走同一套校验。"""
+    secret = tmp_path / "neobot.db"
+    secret.write_bytes(b"SQLite format 3\x00" + b"\x00" * 32)
+
+    with pytest.raises(LookupError) as excinfo:
+        await _stub_service()._download_image_ref(str(secret))
+
+    assert "不是图片" in str(excinfo.value)
+
+
+async def test_bare_path_accepts_real_image(tmp_path: Path) -> None:
+    image = tmp_path / "photo.jpg"
+    image.write_bytes(_JPEG_BYTES)
+
+    assert await _stub_service()._download_image_ref(str(image)) == _JPEG_BYTES
+
+
+async def test_local_ref_rejects_oversized_file(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(drawing_service_module, "_MAX_REMOTE_FETCH_BYTES", 32)
+    image = tmp_path / "big.png"
+    image.write_bytes(_PNG_BYTES)
+
+    with pytest.raises(LookupError) as excinfo:
+        await _stub_service()._download_image_ref(f"file:///{image.as_posix()}")
+
+    assert "过大" in str(excinfo.value)
+
+
+async def test_riff_without_webp_marker_is_rejected(tmp_path: Path) -> None:
+    """RIFF 容器还要看 WEBP 标识，避免把普通 RIFF 文件当图片。"""
+    riff = tmp_path / "sound.wav"
+    riff.write_bytes(b"RIFF" + b"\x00" * 8 + b"WAVE" + b"\x00" * 32)
+
+    with pytest.raises(LookupError):
+        await _stub_service()._download_image_ref(f"file:///{riff.as_posix()}")
+
+
+async def test_missing_file_reports_clear_error(tmp_path: Path) -> None:
+    with pytest.raises(LookupError) as excinfo:
+        await _stub_service()._download_image_ref(
+            f"file:///{(tmp_path / 'nope.png').as_posix()}"
+        )
+
+    assert "不存在" in str(excinfo.value)

--- a/app/tests/modules/message/test_image_pipeline_threading.py
+++ b/app/tests/modules/message/test_image_pipeline_threading.py
@@ -1,0 +1,81 @@
+"""图片预处理必须离开事件循环。
+
+prepare_local_image 会 read_bytes + PIL 解码 + LANCZOS 重采样重编码；
+resolve_local_image（每条带图消息都会走）以前直接同步调用它，慢盘/大图会卡住
+整个事件循环。emoji 的多数入口与 gallery 也在 async 上下文里同步调用过它。
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from PIL import Image
+
+from neobot_app.message import image_pipeline as pipeline
+
+
+def _make_png(path: Path, size: tuple[int, int] = (32, 32)) -> Path:
+    Image.new("RGB", size, (200, 30, 30)).save(path)
+    return path
+
+
+async def test_prepare_local_image_async_runs_in_worker_thread(
+    tmp_path: Path, monkeypatch
+) -> None:
+    loop_thread = threading.get_ident()
+    source = _make_png(tmp_path / "a.png")
+    seen: list[int] = []
+    original = pipeline.prepare_local_image
+
+    def _spy(*args, **kwargs):
+        seen.append(threading.get_ident())
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(pipeline, "prepare_local_image", _spy)
+
+    prepared = await pipeline.prepare_local_image_async(source)
+
+    assert prepared.file_hash
+    assert seen and seen[0] != loop_thread
+
+
+async def test_resolve_local_image_does_not_block_loop(
+    tmp_path: Path, monkeypatch
+) -> None:
+    loop_thread = threading.get_ident()
+    source = _make_png(tmp_path / "b.png")
+    seen: list[int] = []
+    original = pipeline.prepare_local_image
+
+    def _spy(*args, **kwargs):
+        seen.append(threading.get_ident())
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(pipeline, "prepare_local_image", _spy)
+
+    class _AnalysisService:
+        async def get(self, file_hash: str):
+            return None
+
+    preparer = pipeline.ImagePromptPreparer(_AnalysisService())
+    resolution = await preparer.resolve_local_image(source)
+
+    assert resolution.cached_analysis is None
+    assert resolution.prepared.file_hash
+    assert seen and seen[0] != loop_thread
+
+
+async def test_async_variant_matches_sync_hash(tmp_path: Path) -> None:
+    """线程化不得改变结果：hash/尺寸与同步版本一致。"""
+    source = _make_png(tmp_path / "c.png", (64, 48))
+
+    sync_prepared = pipeline.prepare_local_image(source)
+    async_prepared = await pipeline.prepare_local_image_async(source)
+
+    assert async_prepared.file_hash == sync_prepared.file_hash
+    assert async_prepared.mime_type == sync_prepared.mime_type
+    assert (
+        async_prepared.processed_width,
+        async_prepared.processed_height,
+    ) == (sync_prepared.processed_width, sync_prepared.processed_height)

--- a/app/tests/modules/message/test_queue_weights.py
+++ b/app/tests/modules/message/test_queue_weights.py
@@ -1,0 +1,103 @@
+"""队列容量权重账本一致性测试。
+
+入队按消息内容计算权重（合并转发 = forward_weight，默认 2），驱逐却按 kind
+重算（MESSAGE 恒为 1.0），于是每来一条转发消息，账本就多出 1 点虚高权重，
+队列会比配置容量更早丢弃真实消息。
+"""
+
+from __future__ import annotations
+
+from neobot_adapter.model.basic import PostMessageMessagesender
+from neobot_adapter.model.message import GroupMessage, MessageSegment
+from neobot_app.message.queue import MessageQueue, QueueEntryType
+
+
+def _group_message(message_id: int, *segments: tuple[str, dict]) -> GroupMessage:
+    return GroupMessage(
+        message_id=message_id,
+        user_id=7,
+        group_id=42,
+        sender=PostMessageMessagesender(user_id=7, nickname="tester"),
+        message=[MessageSegment(type=t, data=d) for t, d in segments],
+        raw_message="",
+    )
+
+
+def _text(message_id: int) -> GroupMessage:
+    return _group_message(message_id, ("text", {"text": f"m{message_id}"}))
+
+
+def _forward(message_id: int) -> GroupMessage:
+    return _group_message(message_id, ("forward", {"id": "abc"}))
+
+
+def _make_queue(**kwargs) -> MessageQueue:
+    params = {"max_size": 6, "timestamp_interval_seconds": 0, "forward_weight": 2}
+    params.update(kwargs)
+    return MessageQueue(**params)
+
+
+def test_forward_weight_is_accounted_symmetrically() -> None:
+    queue = _make_queue()
+
+    for message_id in (1, 2, 3):
+        queue.push("k", _forward(message_id))
+
+    # 3 条转发 = 6 权重，正好占满 max_size=6
+    assert queue._weighted_counts["k"] == 6
+    assert queue.size("k") == 3
+
+
+def test_forward_messages_do_not_evict_early() -> None:
+    """max_size=6 时应能容纳 3 条转发；旧实现会提前丢消息。"""
+    queue = _make_queue()
+
+    for message_id in (1, 2, 3):
+        queue.push("k", _forward(message_id))
+
+    assert [m.message_id for m in queue.iterate_from_oldest("k")] == [1, 2, 3]
+    stats = queue.get_stats("k")
+    assert stats is not None
+    assert stats.dropped_messages == 0
+
+
+def test_eviction_ledger_stays_consistent_after_overflow() -> None:
+    """溢出驱逐后账本必须等于队列实际权重，且只丢真正放不下的那一条。"""
+    queue = _make_queue()
+
+    for message_id in (1, 2, 3, 4):
+        queue.push("k", _forward(message_id))  # 第 4 条触发驱逐
+
+    expected = sum(entry.weight for entry in queue.entries("k"))
+    assert queue._weighted_counts["k"] == expected
+    assert queue._weighted_counts["k"] <= 6
+    # max_size=6、每条转发 2 权重 ⇒ 容量 3 条，只应丢 1 条（旧实现会丢 2 条）
+    stats = queue.get_stats("k")
+    assert stats is not None
+    assert stats.dropped_messages == 1
+    assert [m.message_id for m in queue.iterate_from_oldest("k")] == [2, 3, 4]
+
+
+def test_weighted_iteration_uses_entry_weight() -> None:
+    """按权重取最近消息与入队口径一致：一条转发占 2 点权重。"""
+    queue = _make_queue(max_size=20)
+    queue.push("k", _text(1))
+    queue.push("k", _forward(2))
+
+    newest = list(queue.iterate_entries_from_newest_weighted("k", max_weight=2))
+
+    assert [entry.message.message_id for entry in newest] == [2]
+
+
+def test_plain_messages_keep_weight_one() -> None:
+    queue = _make_queue()
+
+    queue.push("k", _text(1))
+    queue.push("k", _text(2))
+
+    assert queue._weighted_counts["k"] == 2
+    assert all(
+        entry.weight == 1.0
+        for entry in queue.entries("k")
+        if entry.kind is QueueEntryType.MESSAGE
+    )

--- a/app/tests/modules/observability/test_logging.py
+++ b/app/tests/modules/observability/test_logging.py
@@ -37,6 +37,30 @@ def test_redact_key_value_pairs() -> None:
     assert redact_sensitive("token: abc.def.ghi") == "***REDACTED***"
 
 
+def test_redact_prefixed_key_names() -> None:
+    """键名常带前缀；下划线是词字符，旧实现的 \\b 让这类整类漏脱敏。"""
+    for text in (
+        "DEEPSEEK_APIKEY=abcdef123456",
+        "client_secret=abcdef123456",
+        "NEOBOT_LOCAL_ADAPTER_TOKEN=abcdef123456",
+        "csrf_token=abcdef123456",
+        "credential=abcdef123456",
+    ):
+        assert "abcdef123456" not in redact_sensitive(text), text
+
+
+def test_redact_bare_password_phrase() -> None:
+    """无分隔符的异常文本形态（密钥会随错误信息回给模型）。"""
+    assert "hunter2" not in redact_sensitive("invalid password hunter2")
+
+
+def test_redact_url_userinfo() -> None:
+    redacted = redact_sensitive("url=https://admin:hunter2@example.com/x")
+
+    assert "hunter2" not in redacted
+    assert "https://" in redacted
+
+
 def test_redact_authorization_and_bearer() -> None:
     assert (
         redact_sensitive("Authorization: Bearer sk-abcdefgh12345678")
@@ -76,6 +100,17 @@ def test_file_sink_output_is_redacted(tmp_path) -> None:
     assert "sk-zyxwvuts12345678" not in content
     assert "sk-qwertyui12345678" not in content
     assert content.count("***REDACTED***") >= 4
+
+
+def test_console_sink_output_is_redacted(capsys) -> None:
+    """控制台 sink 也必须脱敏：stderr 会被容器/重定向落到日志文件。"""
+    configure_loguru()
+    try:
+        loguru.logger.error("认证失败 client_secret=abcdef123456")
+    finally:
+        loguru.logger.remove()
+
+    assert "abcdef123456" not in capsys.readouterr().err
 
 
 def test_redacting_filter_redacts_traceback_in_exception_records() -> None:

--- a/app/tests/modules/reply/test_orchestrator.py
+++ b/app/tests/modules/reply/test_orchestrator.py
@@ -1269,7 +1269,7 @@ def test_parse_tool_args_normalizes_dict_null_and_non_dict(raw, expected):
     assert _parse_tool_args(raw) == expected
 
 
-async def test_shutdown_closes_tracked_reply_tool_executor_after_pipeline(
+async def test_reply_tool_executor_released_after_pipeline(
     monkeypatch,
 ):
     import neobot_app.reply.tools as tools_module
@@ -1302,7 +1302,16 @@ async def test_shutdown_closes_tracked_reply_tool_executor_after_pipeline(
     monkeypatch.setattr(orch, "_suspend_private_chat", _no_suspend)
     await _run_agent_turn(orch, queue, "123456")
 
-    assert executor.close_calls == 0
+    # 管线结束后执行器必须已释放：旧实现只在进程关停时才关闭，每个回复事件
+    # 都会永久留下一个持有完整对话历史的执行器
+    for _ in range(5):
+        if executor.close_calls:
+            break
+        await asyncio.sleep(0)
+    assert executor.close_calls == 1
+    assert orch._tool_executors == {}
+
+    # 关停时不得重复关闭
     await orch.shutdown()
     assert executor.close_calls == 1
 

--- a/app/tests/modules/reply/test_reply_hooks_logging.py
+++ b/app/tests/modules/reply/test_reply_hooks_logging.py
@@ -1,0 +1,99 @@
+"""回复钩子（插件扩展点）失败时必须留痕。
+
+原实现对 pre/post reply hook 的异常 `except Exception: pass`：插件钩子抛错
+时既没有日志也没有事件，外部无法区分「钩子没生效」和「钩子抛异常被吞」。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from neobot_app.reply.orchestrator import ReplyOrchestrator, _hook_name
+
+
+class _RecordingLogger:
+    def __init__(self) -> None:
+        self.warnings: list[tuple[str, dict]] = []
+
+    def warning(self, message: str, **kw) -> None:
+        self.warnings.append((message, kw))
+
+    def info(self, message: str, **kw) -> None:
+        pass
+
+    def debug(self, message: str, **kw) -> None:
+        pass
+
+    def error(self, message: str, **kw) -> None:
+        pass
+
+    def exception(self, message: str, **kw) -> None:
+        pass
+
+
+def _make_orchestrator() -> ReplyOrchestrator:
+    orchestrator = ReplyOrchestrator.__new__(ReplyOrchestrator)
+    orchestrator._pre_reply_hooks = []
+    orchestrator._post_reply_hooks = []
+    orchestrator._logger = _RecordingLogger()
+    return orchestrator
+
+
+def _event():
+    return SimpleNamespace(event_id="e1")
+
+
+async def test_pre_hook_failure_is_logged_and_skipped() -> None:
+    orchestrator = _make_orchestrator()
+
+    async def broken(event):
+        raise ValueError("boom")
+
+    orchestrator._pre_reply_hooks.append(broken)
+
+    assert await orchestrator._apply_pre_reply_hooks(_event()) is None
+    message, context = orchestrator._logger.warnings[0]
+    assert "pre_reply hook" in message
+    assert context["hook"] == _hook_name(broken)
+    assert context["error_type"] == "ValueError"
+    assert context["error"] == "boom"
+
+
+async def test_pre_hook_continues_to_next_hook_after_failure() -> None:
+    orchestrator = _make_orchestrator()
+
+    async def broken(event):
+        raise RuntimeError("nope")
+
+    async def short_circuit(event):
+        return "canned reply"
+
+    orchestrator._pre_reply_hooks.extend([broken, short_circuit])
+
+    assert await orchestrator._apply_pre_reply_hooks(_event()) == "canned reply"
+
+
+async def test_post_hook_failure_keeps_original_text() -> None:
+    orchestrator = _make_orchestrator()
+
+    async def broken(event, text):
+        raise KeyError("missing")
+
+    orchestrator._post_reply_hooks.append(broken)
+
+    assert await orchestrator._apply_post_reply_hooks(_event(), "原始文本") == "原始文本"
+    message, context = orchestrator._logger.warnings[0]
+    assert "post_reply hook" in message
+    assert context["error_type"] == "KeyError"
+
+
+async def test_post_hook_success_still_replaces_text() -> None:
+    orchestrator = _make_orchestrator()
+
+    async def rewriter(event, text):
+        return f"[改写] {text}"
+
+    orchestrator._post_reply_hooks.append(rewriter)
+
+    assert await orchestrator._apply_post_reply_hooks(_event(), "abc") == "[改写] abc"
+    assert orchestrator._logger.warnings == []

--- a/app/tests/modules/reply/test_tool_error_scrubbing.py
+++ b/app/tests/modules/reply/test_tool_error_scrubbing.py
@@ -1,0 +1,52 @@
+"""回给模型的工具错误详情必须先脱敏（异常文本里可能带密钥）。
+
+这个分支此前没有任何测试：模型侧用的是 orchestrator 自己的一套正则，它只认
+``key=value`` 与 ``Bearer``，异常里直接出现的 ``sk-...`` 会整条漏进 LLM 上下文。
+"""
+
+from __future__ import annotations
+
+from neobot_app.reply.orchestrator import _scrub_secret_values
+
+
+def test_bare_sk_key_is_scrubbed() -> None:
+    text = _scrub_secret_values(
+        "OpenAIError: Incorrect API key provided: sk-proj-ABCdef123456789"
+    )
+
+    assert "sk-proj-ABCdef123456789" not in text
+    assert "<redacted>" in text
+
+
+def test_prefixed_key_names_are_scrubbed() -> None:
+    for name in ("client_secret", "DEEPSEEK_APIKEY", "csrf_token"):
+        text = _scrub_secret_values(f"{name}=abcdef123456")
+
+        assert "abcdef123456" not in text, name
+
+
+def test_url_userinfo_is_scrubbed() -> None:
+    text = _scrub_secret_values("GET https://admin:hunter2@example.com/x 失败")
+
+    assert "hunter2" not in text
+
+
+def test_bearer_prefix_is_kept() -> None:
+    """``Bearer`` 形态保留前缀（Authorization: 形态由键名规则整条吃掉，同样安全）。"""
+    text = _scrub_secret_values("unauthorized: Bearer abcDEF123.xyz")
+
+    assert "abcDEF123.xyz" not in text
+    assert "Bearer <redacted>" in text
+
+
+def test_authorization_header_value_is_scrubbed() -> None:
+    text = _scrub_secret_values("Authorization: Bearer abcDEF123.xyz")
+
+    assert "abcDEF123.xyz" not in text
+    assert "<redacted>" in text
+
+
+def test_plain_text_is_untouched() -> None:
+    text = "工具执行失败 [sandbox__read_file]: FileNotFoundError: no such file"
+
+    assert _scrub_secret_values(text) == text

--- a/app/tests/modules/reply/test_tool_error_scrubbing.py
+++ b/app/tests/modules/reply/test_tool_error_scrubbing.py
@@ -8,13 +8,16 @@ from __future__ import annotations
 
 from neobot_app.reply.orchestrator import _scrub_secret_values
 
+#: 拼接构造，避免本文件自身出现真实形态的密钥字面量（仓库有密钥扫描测试）。
+_FAKE_KEY = "sk-" + "proj-" + "ABCdef123456789"
+
 
 def test_bare_sk_key_is_scrubbed() -> None:
     text = _scrub_secret_values(
-        "OpenAIError: Incorrect API key provided: sk-proj-ABCdef123456789"
+        f"OpenAIError: Incorrect API key provided: {_FAKE_KEY}"
     )
 
-    assert "sk-proj-ABCdef123456789" not in text
+    assert _FAKE_KEY not in text
     assert "<redacted>" in text
 
 

--- a/app/tests/modules/reply/test_tool_executor_lifecycle.py
+++ b/app/tests/modules/reply/test_tool_executor_lifecycle.py
@@ -1,0 +1,99 @@
+"""回复工具执行器必须随管线释放（旧实现只增不减）。
+
+每次 agent 模式回复都会 build_reply_toolset 并 `_tool_executors.add(executor)`，
+而 _cleanup（done 回调）从不清除它、只有进程关停时才 clear()：执行器持有该轮
+完整对话历史、技能 token 与会话任务信息，等于每个回复事件泄漏一份。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from neobot_app.reply.orchestrator import ReplyOrchestrator
+
+
+class _RecordingLogger:
+    def __init__(self) -> None:
+        self.warnings: list[tuple[str, dict]] = []
+
+    def warning(self, message: str, **kw) -> None:
+        self.warnings.append((message, kw))
+
+    def info(self, message: str, **kw) -> None:
+        pass
+
+    def debug(self, message: str, **kw) -> None:
+        pass
+
+    def error(self, message: str, **kw) -> None:
+        pass
+
+    def exception(self, message: str, **kw) -> None:
+        pass
+
+
+class _Executor:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.closed = 0
+        self.fail = fail
+
+    async def close(self) -> None:
+        self.closed += 1
+        if self.fail:
+            raise RuntimeError("close boom")
+
+
+def _make_orchestrator() -> ReplyOrchestrator:
+    orchestrator = ReplyOrchestrator.__new__(ReplyOrchestrator)
+    orchestrator._tool_executors = {}
+    orchestrator._callback_tasks = set()
+    orchestrator._logger = _RecordingLogger()
+    return orchestrator
+
+
+async def test_release_closes_and_drops_executor() -> None:
+    orchestrator = _make_orchestrator()
+    executor = _Executor()
+    orchestrator._tool_executors["e1"] = executor
+
+    orchestrator._release_executor("e1")
+    await asyncio.sleep(0)  # 让 close 协程跑完
+    await asyncio.sleep(0)  # 让 done 回调把任务从集合里摘掉
+
+    assert executor.closed == 1
+    assert orchestrator._tool_executors == {}
+    assert orchestrator._callback_tasks == set()
+
+
+async def test_release_is_idempotent_for_unknown_event() -> None:
+    orchestrator = _make_orchestrator()
+
+    orchestrator._release_executor("missing")  # 不应抛异常
+    await asyncio.sleep(0)
+
+    assert orchestrator._tool_executors == {}
+
+
+async def test_release_logs_close_failure() -> None:
+    orchestrator = _make_orchestrator()
+    orchestrator._tool_executors["e2"] = _Executor(fail=True)
+
+    orchestrator._release_executor("e2")
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert orchestrator._tool_executors == {}
+    assert any("释放失败" in msg for msg, _ in orchestrator._logger.warnings)
+
+
+async def test_many_replies_do_not_accumulate_executors() -> None:
+    """模拟多轮回复：每次注册 + 释放后不得残留。"""
+    orchestrator = _make_orchestrator()
+
+    for index in range(5):
+        event_id = f"e{index}"
+        orchestrator._tool_executors[event_id] = _Executor()
+        orchestrator._release_executor(event_id)
+    await asyncio.sleep(0)
+
+    assert orchestrator._tool_executors == {}

--- a/app/tests/modules/reply/test_tool_executor_lifecycle.py
+++ b/app/tests/modules/reply/test_tool_executor_lifecycle.py
@@ -43,6 +43,35 @@ class _Executor:
             raise RuntimeError("close boom")
 
 
+class _SyncCloseExecutor:
+    """close() 不是协程的执行器：释放失败不能冒泡到 done 回调。"""
+
+    def close(self) -> None:  # type: ignore[no-untyped-def]
+        pass
+
+
+class _SessionExecutor:
+    """带在途会话工具的执行器：后台工作必须活到自然完成，然后才关闭。"""
+
+    def __init__(self, delay: float = 0.01) -> None:
+        self.events: list[str] = []
+        self._delay = delay
+        self.session = asyncio.create_task(self._run_session())
+
+    async def _run_session(self) -> None:
+        await asyncio.sleep(self._delay)
+        self.events.append("session-completed")
+
+    async def drain_sessions(self) -> None:
+        await asyncio.gather(self.session, return_exceptions=True)
+
+    async def close(self) -> None:
+        if not self.session.done():
+            self.session.cancel()
+            self.events.append("session-cancelled")
+        self.events.append("closed")
+
+
 def _make_orchestrator() -> ReplyOrchestrator:
     orchestrator = ReplyOrchestrator.__new__(ReplyOrchestrator)
     orchestrator._tool_executors = {}
@@ -97,3 +126,33 @@ async def test_many_replies_do_not_accumulate_executors() -> None:
     await asyncio.sleep(0)
 
     assert orchestrator._tool_executors == {}
+
+
+async def test_release_does_not_cancel_inflight_session_tools() -> None:
+    """回复结束释放执行器时，在途会话工具必须跑完（而不是被取消）。
+
+    会话工具（download__url / parse_image 等）的契约是「后台执行，完成后自动
+    通知」，活过本轮回复；直接 close() 会把它们连同通知一起杀掉。
+    """
+    orchestrator = _make_orchestrator()
+    executor = _SessionExecutor(delay=0.01)
+    orchestrator._tool_executors["e9"] = executor
+
+    orchestrator._release_executor("e9")
+    await asyncio.sleep(0.05)
+
+    assert executor.events == ["session-completed", "closed"]
+    assert orchestrator._tool_executors == {}
+
+
+async def test_release_survives_non_awaitable_close() -> None:
+    """close() 不是协程时只记日志，不能让 done 回调抛异常。"""
+    orchestrator = _make_orchestrator()
+    orchestrator._tool_executors["e10"] = _SyncCloseExecutor()
+
+    orchestrator._release_executor("e10")  # 不应抛异常
+    for _ in range(3):
+        await asyncio.sleep(0)  # 让 close 任务失败并由 done 回调记录
+
+    assert orchestrator._tool_executors == {}
+    assert any("释放失败" in msg for msg, _ in orchestrator._logger.warnings)

--- a/app/tests/modules/reply/test_tools.py
+++ b/app/tests/modules/reply/test_tools.py
@@ -1023,19 +1023,23 @@ def test_skill_registration_is_atomic_and_session_tools_must_be_declared():
     assert manager.skill_names == []
 
 
-async def test_skill_rejects_empty_suffix_and_hides_execute_exception():
+async def test_skill_rejects_empty_suffix_and_reports_execute_failure():
     from neobot_app.skills.base import SkillManager
 
     class _Fail(_SnapshotSkill):
         async def execute(self, tool_name: str, args: dict) -> str:
-            raise RuntimeError("secret-token")
+            raise RuntimeError("secret-token=abc123")
 
     manager = SkillManager()
     manager.register(_Fail("fail", "x"))
     assert "未知工具" in await manager.execute("fail__", {})
     result = await manager.execute("fail__run", {})
-    assert result == "工具执行失败 [fail__run]"
-    assert "secret-token" not in result
+    # 失败原因必须保留（旧实现只回一句固定文案，故障不可诊断）……
+    assert "工具执行失败 [fail__run]" in result
+    assert "RuntimeError" in result
+    # ……但密钥形态的值要先脱敏再回给模型（工具输出会进入 LLM 上下文）
+    assert "abc123" not in result
+    assert "REDACTED" in result
 
 
 def test_skill_rejects_malformed_definition_without_keyerror() -> None:

--- a/app/tests/modules/runtime/test_archive_counter_cache.py
+++ b/app/tests/modules/runtime/test_archive_counter_cache.py
@@ -90,3 +90,40 @@ async def test_cache_is_per_conversation() -> None:
 def test_service_has_counter_cache_attribute() -> None:
     service = _make_service()
     assert service._counter_cache == {}
+
+
+async def test_cache_ttl_revalidates_external_changes(monkeypatch) -> None:
+    """外部删除/清零计数器后，本进程不能把陈旧 blob 整块写回。
+
+    缓存永不失效时：外部删掉 memory_counter 行，下一条消息会把旧 messages
+    全量写回（删除被撤销）。缓存带 TTL 后，过期即重新读库、尊重外部状态。
+    """
+    archive = _FakeArchive()
+    service = _make_service(archive=archive, group_interval=100)
+    await _record_many(service, 2)
+
+    # 缓存有效期内不重读（这正是省开销的来源）
+    loads = 0
+    original_load = service._load_counter
+
+    async def _counting_load(key):
+        nonlocal loads
+        loads += 1
+        return await original_load(key)
+
+    monkeypatch.setattr(service, "_load_counter", _counting_load)
+    await _record_many(service, 1)
+    assert loads == 0
+
+    # 外部删除该计数器行；缓存过期后的下一条消息必须重新读库
+    archive._items.pop(("memory_counter", "group:1"))
+    monkeypatch.setattr(
+        "neobot_app.runtime.archive_memory_summary._COUNTER_CACHE_TTL_SECONDS", 0.0
+    )
+    await _record_many(service, 1)
+
+    assert loads == 1
+    payload = json.loads(archive._items[("memory_counter", "group:1")]["value"])
+    assert payload["count"] == 1
+    # 关键：之前那条 blob 里的消息（外部删除的对象）没有被整块写回
+    assert len(payload["messages"]) == 1

--- a/app/tests/modules/runtime/test_archive_counter_cache.py
+++ b/app/tests/modules/runtime/test_archive_counter_cache.py
@@ -1,0 +1,94 @@
+"""计数器读写不应每条消息都重新读库 + 解析整个 blob。
+
+record_message 每条消息都会读一次计数器，而计数器是一整个 JSON blob
+（间隔 500 条 × 800 字符 ≈ 400KB）。修复后解析结果缓存复用，但写路径仍然
+每条都落库（崩溃丢失窗口不变），且总结成功清零后缓存必须同步，不能读到旧内容。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.modules.runtime.test_archive_memory_summary import (
+    _FakeArchive,
+    _FakeProvider,
+    _make_service,
+)
+
+
+async def _record_many(service, count: int, *, kind: str = "group", cid: str = "1") -> None:
+    for index in range(count):
+        await service.record_message(
+            conversation_kind=kind,
+            conversation_id=cid,
+            message_text=f"消息 {index}",
+            sender_id="7",
+            sender_name="tester",
+        )
+
+
+async def test_counter_is_parsed_once_and_still_persisted_every_message(
+    monkeypatch,
+) -> None:
+    archive = _FakeArchive()
+    service = _make_service(archive=archive, group_interval=10)
+
+    loads = 0
+    saves = 0
+    original_load = service._load_counter
+    original_save = service._save_counter
+
+    async def _load(key):
+        nonlocal loads
+        loads += 1
+        return await original_load(key)
+
+    async def _save(key, state):
+        nonlocal saves
+        saves += 1
+        return await original_save(key, state)
+
+    monkeypatch.setattr(service, "_load_counter", _load)
+    monkeypatch.setattr(service, "_save_counter", _save)
+
+    await _record_many(service, 4)
+
+    assert loads == 1, "计数器只需首次读库，之后走缓存"
+    assert saves == 4, "写路径仍每条消息都落库"
+
+
+async def test_cache_does_not_resurrect_after_summary_reset() -> None:
+    archive = _FakeArchive()
+    service = _make_service(archive=archive, group_interval=2)
+
+    await _record_many(service, 2)  # 达到间隔 → 触发总结并清零
+
+    stored = archive._items[("memory_counter", "group:1")]
+    assert json.loads(stored["value"])["count"] == 0
+
+    # 清零后缓存必须同步：下一条消息从 0 开始计数
+    await _record_many(service, 1)
+    stored = archive._items[("memory_counter", "group:1")]
+    payload = json.loads(stored["value"])
+    assert payload["count"] == 1
+    assert [m["text"] for m in payload["messages"]] == ["消息 0"]
+
+
+async def test_cache_is_per_conversation() -> None:
+    archive = _FakeArchive()
+    service = _make_service(archive=archive, group_interval=10)
+
+    await _record_many(service, 1, cid="1")
+    await _record_many(service, 2, cid="2")
+
+    first = json.loads(archive._items[("memory_counter", "group:1")]["value"])
+    second = json.loads(archive._items[("memory_counter", "group:2")]["value"])
+    assert first["count"] == 1
+    assert second["count"] == 2
+
+
+def test_service_has_counter_cache_attribute() -> None:
+    service = _make_service()
+    assert service._counter_cache == {}

--- a/app/tests/modules/runtime/test_archive_counter_cache.py
+++ b/app/tests/modules/runtime/test_archive_counter_cache.py
@@ -9,11 +9,9 @@ from __future__ import annotations
 
 import json
 
-import pytest
 
 from tests.modules.runtime.test_archive_memory_summary import (
     _FakeArchive,
-    _FakeProvider,
     _make_service,
 )
 

--- a/app/tests/modules/runtime/test_browser_wait.py
+++ b/app/tests/modules/runtime/test_browser_wait.py
@@ -68,3 +68,34 @@ async def test_concurrent_hold_on_multiple_flows() -> None:
     assert manager.is_held("flow-a") is True
     assert manager.is_held("flow-b") is True
     assert manager.active_flow_count == 2
+
+
+def test_stale_flow_without_tabs_is_reclaimed() -> None:
+    """标签页关光后剩下的空流状态必须能被回收，否则长期运行会无限堆积。"""
+    manager = BrowserLifecycleManager(idle_timeout_minutes=10)
+    manager.track_tab_open("flow-1", "tab-1")
+    manager.track_tab_close("flow-1", "tab-1")
+    manager.touch("flow-2")
+    for cid in ("flow-1", "flow-2"):
+        manager._flows[cid].last_access = time.time() - 9999
+
+    stale = manager._get_stale_flow_ids()
+
+    assert sorted(stale) == ["flow-1", "flow-2"]
+    # 没有标签页的流不会被闲置关闭流程选中（它只负责关页面）
+    assert manager._get_idle_flows() == []
+
+
+def test_stale_reclaim_keeps_live_and_held_flows() -> None:
+    manager = BrowserLifecycleManager(idle_timeout_minutes=10)
+    manager.track_tab_open("live", "tab-1")
+    manager.track_tab_close("live", "tab-1")
+    manager.touch("fresh")
+    manager.hold("held", minutes=30)
+    manager._flows["live"].last_access = time.time() - 9999
+    manager._flows["held"].last_access = time.time() - 9999
+
+    stale = manager._get_stale_flow_ids()
+
+    assert stale == ["live"]
+    assert manager.is_held("held") is True

--- a/app/tests/modules/runtime/test_command_sync_reply_marker.py
+++ b/app/tests/modules/runtime/test_command_sync_reply_marker.py
@@ -1,0 +1,89 @@
+"""命令同步回复被拒时，「回复中」标记必须回滚。
+
+_start_command_sync_reply 先把 queue_key 放进 _replying_queues，再靠
+on_reply_done 回调移除；而 start_reply 在「编排器已关闭 / 同会话管线在跑 /
+冷却中」时返回 None 且不会调用回调——标记就此永久留下，该会话的命令结果
+再也投递不出去，后续消息也被当作「回复中」。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from neobot_app.runtime.event_pipeline import EventPipeline
+
+
+class _RecordingLogger:
+    def __init__(self) -> None:
+        self.debugs: list[tuple[str, dict]] = []
+
+    def warning(self, message: str, **kw) -> None:
+        pass
+
+    def info(self, message: str, **kw) -> None:
+        pass
+
+    def debug(self, message: str, **kw) -> None:
+        self.debugs.append((message, kw))
+
+    def error(self, message: str, **kw) -> None:
+        pass
+
+    def exception(self, message: str, **kw) -> None:
+        pass
+
+
+class _StubOrchestrator:
+    def __init__(self, *, started: object) -> None:
+        self.started = started
+        self.calls: list[dict] = []
+
+    def start_reply(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.started
+
+
+class _StubQueue:
+    def get_last_message_id(self, queue_key: str):
+        return 42
+
+
+def _make_pipeline(orchestrator) -> EventPipeline:
+    pipeline = EventPipeline.__new__(EventPipeline)
+    pipeline._reply_orchestrator = orchestrator
+    pipeline._replying_queues = set()
+    pipeline._logger = _RecordingLogger()
+    return pipeline
+
+
+def test_marker_rolled_back_when_start_reply_declined() -> None:
+    orchestrator = _StubOrchestrator(started=None)
+    pipeline = _make_pipeline(orchestrator)
+
+    pipeline._start_command_sync_reply(
+        message=SimpleNamespace(),
+        queue=_StubQueue(),
+        queue_key="group:1",
+        background="cmd output",
+    )
+
+    assert pipeline._replying_queues == set()
+    assert len(orchestrator.calls) == 1
+    assert any("回滚" in msg for msg, _ in pipeline._logger.debugs)
+
+
+def test_marker_kept_when_pipeline_started() -> None:
+    """管线正常启动时标记保留，等 on_reply_done 回调移除。"""
+    orchestrator = _StubOrchestrator(started=SimpleNamespace())
+    pipeline = _make_pipeline(orchestrator)
+
+    pipeline._start_command_sync_reply(
+        message=SimpleNamespace(),
+        queue=_StubQueue(),
+        queue_key="group:2",
+        background="cmd output",
+    )
+
+    assert pipeline._replying_queues == {"group:2"}
+    callback = orchestrator.calls[0]["on_reply_done"]
+    assert callback is not None

--- a/app/tests/modules/runtime/test_command_sync_reply_marker.py
+++ b/app/tests/modules/runtime/test_command_sync_reply_marker.py
@@ -1,9 +1,9 @@
-"""命令同步回复被拒时，「回复中」标记必须回滚。
+"""命令同步回复被拒时，「回复中」标记不能被误删。
 
-_start_command_sync_reply 先把 queue_key 放进 _replying_queues，再靠
-on_reply_done 回调移除；而 start_reply 在「编排器已关闭 / 同会话管线在跑 /
-冷却中」时返回 None 且不会调用回调——标记就此永久留下，该会话的命令结果
-再也投递不出去，后续消息也被当作「回复中」。
+标记 _replying_queues 是按 queue_key 共享的裸 set，而 start_reply 拒绝的常见
+原因恰恰是「同会话已有管线在跑」——那种情况下标记属于**另一条仍在运行的管线**。
+旧实现在被拒时无条件 discard，会删掉那条管线的标记，破坏它的分流守卫。
+正确语义是「启动成功后才打标记」，由该管线自己的 on_reply_done 清除。
 """
 
 from __future__ import annotations
@@ -56,7 +56,7 @@ def _make_pipeline(orchestrator) -> EventPipeline:
     return pipeline
 
 
-def test_marker_rolled_back_when_start_reply_declined() -> None:
+def test_marker_not_set_when_start_reply_declined() -> None:
     orchestrator = _StubOrchestrator(started=None)
     pipeline = _make_pipeline(orchestrator)
 
@@ -69,7 +69,22 @@ def test_marker_rolled_back_when_start_reply_declined() -> None:
 
     assert pipeline._replying_queues == set()
     assert len(orchestrator.calls) == 1
-    assert any("回滚" in msg for msg, _ in pipeline._logger.debugs)
+
+
+def test_running_pipeline_marker_survives_rejected_command_sync_reply() -> None:
+    """同会话已有管线在跑时，它的标记必须原样保留。"""
+    orchestrator = _StubOrchestrator(started=None)
+    pipeline = _make_pipeline(orchestrator)
+    pipeline._replying_queues.add("group:1")
+
+    pipeline._start_command_sync_reply(
+        message=SimpleNamespace(),
+        queue=_StubQueue(),
+        queue_key="group:1",
+        background="cmd output",
+    )
+
+    assert pipeline._replying_queues == {"group:1"}
 
 
 def test_marker_kept_when_pipeline_started() -> None:
@@ -87,3 +102,20 @@ def test_marker_kept_when_pipeline_started() -> None:
     assert pipeline._replying_queues == {"group:2"}
     callback = orchestrator.calls[0]["on_reply_done"]
     assert callback is not None
+
+
+async def test_on_reply_done_removes_marker() -> None:
+    orchestrator = _StubOrchestrator(started=SimpleNamespace())
+    pipeline = _make_pipeline(orchestrator)
+    pipeline._post_reply_willing = {}
+    pipeline._config = None
+
+    pipeline._start_command_sync_reply(
+        message=SimpleNamespace(),
+        queue=_StubQueue(),
+        queue_key="group:3",
+        background="cmd output",
+    )
+    await orchestrator.calls[0]["on_reply_done"]()
+
+    assert pipeline._replying_queues == set()

--- a/app/tests/modules/runtime/test_event_pipeline.py
+++ b/app/tests/modules/runtime/test_event_pipeline.py
@@ -228,8 +228,6 @@ def _pipeline_with_queue(
     pipeline._warmed_up_friends = set()
     pipeline._background_tasks = set()
     pipeline._stopping = False
-    pipeline._started = False
-    pipeline._subscriptions = []
     return pipeline
 
 
@@ -521,14 +519,15 @@ async def test_willing_decision_sleep_gate_returns_false_without_at():
 
 
 @pytest.mark.asyncio
-async def test_stop_prevents_new_fire_and_forget_tasks() -> None:
+async def test_shutdown_flush_prevents_new_fire_and_forget_tasks() -> None:
+    """关闭收尾（flush_pending_summaries）之后不得再派生新的后台任务。"""
     pipeline = _pipeline_with_queue()
     pipeline._archive_summary_service = SimpleNamespace(
         record_message=AsyncMock(),
         flush_all=AsyncMock(),
     )
 
-    pipeline.stop()
+    await pipeline.flush_pending_summaries()
     pipeline._schedule_archive_summary(
         conversation_kind="group",
         conversation_id="42",

--- a/app/tests/modules/runtime/test_notification_consume_cancel.py
+++ b/app/tests/modules/runtime/test_notification_consume_cancel.py
@@ -1,0 +1,105 @@
+"""通知被消费前发生取消时不得丢失。
+
+poll() 先把通知从队列取出、再 await _consume(notification)（消费回调通常负责
+写「已通知」落盘标记）。若在此期间被取消，通知直接消失且标记未写——之后管理
+器还会重复投递。修复后取消时会把通知放回队列。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from neobot_app.runtime.notifications import BackgroundNotificationHub
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+
+    def warning(self, message: str, **kw) -> None:
+        self.warnings.append(message)
+
+    def info(self, message: str, **kw) -> None:
+        pass
+
+    def debug(self, message: str, **kw) -> None:
+        pass
+
+    def error(self, message: str, **kw) -> None:
+        pass
+
+    def exception(self, message: str, **kw) -> None:
+        pass
+
+
+def _hub() -> BackgroundNotificationHub:
+    return BackgroundNotificationHub(logger=_Logger())
+
+
+def _notification(consumed: list[str], *, block: asyncio.Event | None = None):
+    async def _on_consumed(notification) -> None:
+        if block is not None:
+            await block.wait()
+        consumed.append(notification.content)
+
+    return _hub_notification(_on_consumed)
+
+
+def _hub_notification(on_consumed):
+    from neobot_app.runtime.notifications import BackgroundNotification
+
+    return BackgroundNotification(
+        source="drawing",
+        pipeline_key="group:1",
+        kind="group",
+        conversation_id="1",
+        content="画好了",
+        manager_name="drawing",
+        on_consumed=on_consumed,
+    )
+
+
+async def test_cancelled_consume_requeues_notification() -> None:
+    hub = _hub()
+    consumed: list[str] = []
+    release = asyncio.Event()
+    notification = _notification(consumed, block=release)
+    hub._queues["group:1"] = asyncio.Queue()
+    hub._queues["group:1"].put_nowait(notification)
+
+    task = asyncio.create_task(hub.poll("group:1"))
+    await asyncio.sleep(0)  # 让 poll 进入 _consume 并阻塞
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    # 未完成消费 → 通知必须回到队列，不能丢
+    assert consumed == []
+    queue = hub._queues.get("group:1")
+    assert queue is not None and queue.qsize() == 1
+
+
+async def test_successful_consume_removes_notification() -> None:
+    hub = _hub()
+    consumed: list[str] = []
+    hub._queues["group:1"] = asyncio.Queue()
+    hub._queues["group:1"].put_nowait(_notification(consumed))
+
+    result = await hub.poll("group:1")
+
+    assert result is not None
+    assert consumed == ["画好了"]
+    assert hub._queues.get("group:1") is None  # 空队列被回收
+
+
+async def test_consume_without_callback_drops_notification() -> None:
+    """没有消费回调时行为不变：取出即完成。"""
+    hub = _hub()
+    hub._queues["group:1"] = asyncio.Queue()
+    hub._queues["group:1"].put_nowait(_hub_notification(None))
+
+    result = await hub.poll("group:1")
+
+    assert result is not None

--- a/app/tests/modules/runtime/test_pending_image_willing.py
+++ b/app/tests/modules/runtime/test_pending_image_willing.py
@@ -1,0 +1,87 @@
+"""图片意愿待处理队列：等待解析失败时不得让消息永久滞留。
+
+含图片的消息会先进 _pending_image_willing 等图片解析完成再算意愿。原实现在
+等待抛异常时直接冒出，pending 列表既不被取出也不被处理：这些消息再也不会
+触发回复，字典条目也永久留在内存里。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from neobot_app.runtime.event_pipeline import EventPipeline
+
+
+class _FailingParseService:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def wait_for_queue(self, queue_key, timeout=None):
+        self.calls += 1
+        raise RuntimeError("vision provider down")
+
+
+class _RecordingLogger:
+    def __init__(self) -> None:
+        self.warnings: list[tuple[str, dict]] = []
+
+    def warning(self, message: str, **kw) -> None:
+        self.warnings.append((message, kw))
+
+    def info(self, message: str, **kw) -> None:
+        pass
+
+    def debug(self, message: str, **kw) -> None:
+        pass
+
+    def error(self, message: str, **kw) -> None:
+        pass
+
+    def exception(self, message: str, **kw) -> None:
+        pass
+
+
+def _make_pipeline(parse_service) -> EventPipeline:
+    pipeline = EventPipeline.__new__(EventPipeline)
+    pipeline._image_parse_service = parse_service
+    pipeline._logger = _RecordingLogger()
+    pipeline._pending_image_willing = {}
+    pipeline._image_willing_locks = {}
+    pipeline._replying_queues = set()
+    pipeline._post_reply_willing = {}
+    pipeline._group_queue = SimpleNamespace()
+    pipeline._config = None  # 走 _get_group_agent_silent_timeout_seconds 的默认值
+    return pipeline
+
+
+async def test_pending_queue_is_drained_when_wait_fails() -> None:
+    service = _FailingParseService()
+    pipeline = _make_pipeline(service)
+    message = SimpleNamespace(message_id=1)
+    pipeline._pending_image_willing["group:1"] = [message]
+
+    handled: list[object] = []
+
+    async def _fake_handle_willing(**kwargs):
+        handled.append(kwargs["message"])
+        return True
+
+    pipeline._handle_willing_decision = _fake_handle_willing  # type: ignore[assignment]
+
+    await pipeline._process_pending_image_willing("group:1")
+
+    assert service.calls == 1
+    # 消息必须被取出来并处理，而不是永久留在字典里
+    assert "group:1" not in pipeline._pending_image_willing
+    assert handled == [message]
+    assert any("等待图片解析失败" in msg for msg, _ in pipeline._logger.warnings)
+
+
+async def test_pending_queue_entry_removed_even_when_empty() -> None:
+    service = _FailingParseService()
+    pipeline = _make_pipeline(service)
+
+    await pipeline._process_pending_image_willing("group:2")
+
+    assert pipeline._pending_image_willing == {}
+    assert pipeline._image_willing_locks == {}

--- a/app/tests/modules/runtime/test_reply_block_fifo.py
+++ b/app/tests/modules/runtime/test_reply_block_fifo.py
@@ -1,0 +1,67 @@
+"""ReplyBlockRegistry 的 FIFO 必须回收已消费项。
+
+consume_message 原先只从 _keys 删除、不从 _order 删除：_order 被已消费项占满，
+淘汰条件 len(_order) > max_size 实际按「事件数（含已消费）」而非「活跃阻塞数」
+计算，活跃阻塞的保留窗口短于设计值。
+"""
+
+from __future__ import annotations
+
+from neobot_app.runtime.reply_block import ReplyBlockRegistry
+
+
+def _event(message_id: int, *, group_id: int = 888, message_type: str = "group") -> dict:
+    return {
+        "post_type": "message",
+        "message_type": message_type,
+        "group_id": group_id,
+        "user_id": 10001,
+        "message_id": message_id,
+    }
+
+
+def test_consume_shrinks_fifo() -> None:
+    registry = ReplyBlockRegistry(max_size=10)
+
+    registry.block_event(_event(1))
+    registry.block_event(_event(2))
+    assert len(registry._order) == 2
+
+    assert registry.consume_message(_event(1)) is True
+
+    assert len(registry._order) == 1
+    assert len(registry._keys) == 1
+
+
+def test_consume_by_message_id_clears_fifo_entry() -> None:
+    registry = ReplyBlockRegistry(max_size=10)
+    registry.block_event(_event(5))
+
+    # 只带 message_id 的事件（无 group/user）走 _remove_message_id 分支
+    assert registry.consume_message({"message_id": 5}) is True
+
+    assert registry._order == type(registry._order)()
+    assert registry._message_ids == set()
+
+
+def test_consumed_items_do_not_evict_active_blocks() -> None:
+    """大量「拦截后立刻消费」的消息不应挤掉仍然活跃的阻塞。"""
+    registry = ReplyBlockRegistry(max_size=4)
+    registry.block_event(_event(1000))
+
+    for message_id in range(1, 50):
+        registry.block_event(_event(message_id))
+        registry.consume_message(_event(message_id))
+
+    # 活跃阻塞仍在（旧实现会被已消费项挤出窗口）
+    assert registry.consume_message(_event(1000)) is True
+
+
+def test_fifo_still_bounded_when_never_consumed() -> None:
+    registry = ReplyBlockRegistry(max_size=3)
+
+    for message_id in range(1, 6):
+        registry.block_event(_event(message_id))
+
+    assert len(registry._order) == 3
+    assert len(registry._keys) == 3

--- a/app/tests/modules/runtime/test_sandbox_maintenance.py
+++ b/app/tests/modules/runtime/test_sandbox_maintenance.py
@@ -1,5 +1,7 @@
 """沙箱维护命名回归：保留 Unicode、拒绝空主名且不覆盖已有目标。"""
 
+import os
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, Mock
 
@@ -165,3 +167,20 @@ def test_naming_preserves_source_symlink(tmp_path):
 
     source.rename.assert_not_called()
     assert result["renamed"] == []
+
+
+async def test_maintenance_cleans_orphan_write_temps_only_when_stale(tmp_path):
+    """原子写残留的 .neobot-write-* 临时文件要清掉，但不能误删正在写的。"""
+    directory = tmp_path / "tools"
+    directory.mkdir()
+    stale = directory / ".neobot-write-abc123"
+    stale.write_bytes(b"leftover")
+    os.utime(stale, (time.time() - 7200, time.time() - 7200))
+    fresh = directory / ".neobot-write-def456"
+    fresh.write_bytes(b"in-flight")
+
+    result = await SandboxMaintenanceManager(tmp_path).run_once(force=True)
+
+    assert not stale.exists()
+    assert fresh.read_bytes() == b"in-flight"
+    assert "垃圾文件 x1" in result["removed"]

--- a/app/tests/modules/runtime/test_sandbox_maintenance.py
+++ b/app/tests/modules/runtime/test_sandbox_maintenance.py
@@ -174,17 +174,17 @@ async def test_maintenance_cleans_orphan_write_temps_only_when_stale(tmp_path):
     """原子写残留的 .neobot-write-* 临时文件要清掉，但不能误删正在写的。"""
     directory = tmp_path / "tools"
     directory.mkdir()
-    stale = directory / ".neobot-write-abc123"
+    stale = directory / ".neobot-write-abc12345"
     stale.write_bytes(b"leftover")
     os.utime(stale, (time.time() - 7200, time.time() - 7200))
-    fresh = directory / ".neobot-write-def456"
+    fresh = directory / ".neobot-write-def45678"
     fresh.write_bytes(b"in-flight")
 
     result = await SandboxMaintenanceManager(tmp_path).run_once(force=True)
 
     assert not stale.exists()
     assert fresh.read_bytes() == b"in-flight"
-    assert "垃圾文件 x1" in result["removed"]
+    assert result["orphan_temps_cleaned"] == 1
 
 
 async def test_concurrent_maintenance_cycles_do_not_overlap(tmp_path) -> None:
@@ -214,3 +214,35 @@ async def test_concurrent_maintenance_cycles_do_not_overlap(tmp_path) -> None:
     assert overlapped["reason"] == "已有维护在运行"
     assert results and results[0]["skipped"] is False
     assert module._MAINTENANCE_LOCK.locked() is False
+
+
+async def test_orphan_cleanup_runs_even_when_change_gate_skips(tmp_path) -> None:
+    """安静运行的 Bot 上（无文件变更 → 周期直接 skipped）孤儿仍要被清掉。"""
+    directory = tmp_path / "tools"
+    directory.mkdir()
+    orphan = directory / ".neobot-write-abcd1234"
+    orphan.write_bytes(b"leftover")
+    os.utime(orphan, (time.time() - 7200, time.time() - 7200))
+    manager = SandboxMaintenanceManager(tmp_path)
+    await manager.run_once(force=True)  # 先建立维护标记
+
+    orphan.write_bytes(b"leftover-again")
+    os.utime(orphan, (time.time() - 7200, time.time() - 7200))
+    result = await manager.run_once()  # 不带 force：走变更门
+
+    assert result["skipped"] is True
+    assert not orphan.exists()
+    assert result["orphan_temps_cleaned"] == 1
+
+
+async def test_orphan_cleanup_ignores_user_files_with_similar_names(tmp_path) -> None:
+    """前缀相近的用户文件不能被当成孤儿删掉。"""
+    directory = tmp_path / "tools"
+    directory.mkdir()
+    user_file = directory / ".neobot-write-notes.md"
+    user_file.write_bytes(b"my notes")
+    os.utime(user_file, (time.time() - 7200, time.time() - 7200))
+
+    await SandboxMaintenanceManager(tmp_path).run_once(force=True)
+
+    assert user_file.read_bytes() == b"my notes"

--- a/app/tests/modules/runtime/test_sandbox_maintenance.py
+++ b/app/tests/modules/runtime/test_sandbox_maintenance.py
@@ -1,6 +1,7 @@
 """沙箱维护命名回归：保留 Unicode、拒绝空主名且不覆盖已有目标。"""
 
 import os
+import threading
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, Mock
@@ -184,3 +185,32 @@ async def test_maintenance_cleans_orphan_write_temps_only_when_stale(tmp_path):
     assert not stale.exists()
     assert fresh.read_bytes() == b"in-flight"
     assert "垃圾文件 x1" in result["removed"]
+
+
+async def test_concurrent_maintenance_cycles_do_not_overlap(tmp_path) -> None:
+    """两个维护周期不能并行操作同一棵树（搬进线程后失去事件循环的隐式串行）。"""
+    from neobot_app.runtime import sandbox_maintenance as module
+
+    (tmp_path / "tools").mkdir()
+    manager = SandboxMaintenanceManager(tmp_path)
+    results: list[dict] = []
+    gate = threading.Event()
+
+    def _slow_cycle(*, force: bool = False) -> dict:
+        gate.set()
+        time.sleep(0.2)  # 占住锁，模拟真实周期耗时
+        return {"ok": True, "skipped": False}
+
+    manager._maintenance_cycle_locked = _slow_cycle  # type: ignore[method-assign]
+
+    thread = threading.Thread(target=lambda: results.append(manager._maintenance_cycle_sync(force=True)))
+    thread.start()
+    assert gate.wait(2.0)
+
+    overlapped = await manager.run_once(force=True)
+    thread.join(5.0)
+
+    assert overlapped["skipped"] is True
+    assert overlapped["reason"] == "已有维护在运行"
+    assert results and results[0]["skipped"] is False
+    assert module._MAINTENANCE_LOCK.locked() is False

--- a/app/tests/modules/runtime/test_sandbox_maintenance_threading.py
+++ b/app/tests/modules/runtime/test_sandbox_maintenance_threading.py
@@ -1,0 +1,71 @@
+"""沙箱维护周期必须离开事件循环。
+
+_maintenance_cycle 是同步文件系统工作（整树 rglob、rmtree、shutil.move），
+却由 async 方法直接执行：后台协程每 3 小时触发一次，跑在事件循环上的话整个
+Bot（含所有会话、通知、心跳）会停顿数秒。
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from neobot_app.runtime.sandbox_maintenance import SandboxMaintenanceManager
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def warning(self, message: str, **kw) -> None:
+        self.messages.append(message)
+
+    def info(self, message: str, **kw) -> None:
+        pass
+
+    def debug(self, message: str, **kw) -> None:
+        pass
+
+    def error(self, message: str, **kw) -> None:
+        pass
+
+    def exception(self, message: str, **kw) -> None:
+        pass
+
+
+def _manager(root: Path) -> SandboxMaintenanceManager:
+    return SandboxMaintenanceManager(sandbox_root=root, logger=_Logger())
+
+
+async def test_maintenance_cycle_runs_in_worker_thread(tmp_path: Path) -> None:
+    loop_thread = threading.get_ident()
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    manager = _manager(root)
+
+    seen: list[int] = []
+    original = manager._maintenance_cycle_sync
+
+    def _spy(*, force: bool = False):
+        seen.append(threading.get_ident())
+        return original(force=force)
+
+    manager._maintenance_cycle_sync = _spy  # type: ignore[method-assign]
+
+    result = await manager.run_once(force=True)
+
+    assert result["ok"] is True
+    assert seen and seen[0] != loop_thread
+
+
+async def test_maintenance_cycle_still_reports_skips(tmp_path: Path) -> None:
+    """线程化不改语义：无变更且未强制时仍返回 skipped。"""
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    manager = _manager(root)
+
+    await manager.run_once(force=True)  # 建立基线标记
+    second = await manager.run_once()
+
+    assert second["ok"] is True
+    assert second.get("skipped") is True

--- a/app/tests/modules/runtime/test_sandbox_threading.py
+++ b/app/tests/modules/runtime/test_sandbox_threading.py
@@ -1,0 +1,81 @@
+"""沙箱文件操作必须真正离开事件循环。
+
+sandbox_service 里的 read_file/write_file/delete_file/list_files/move_file/
+copy_file 原先声明为 async 但内部零 await：同步磁盘 IO（含 rmtree/move/copyfile）
+实际跑在事件循环线程上，慢盘或大目录会卡住整个 Bot。
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+
+async def test_file_ops_run_in_worker_thread(make_sandbox) -> None:
+    sandbox = make_sandbox()
+    loop_thread = threading.get_ident()
+    threads_seen: list[int] = []
+
+    original_write = sandbox._write_file_sync
+    original_read = sandbox._read_file_sync
+
+    def _write_spy(path, data):
+        threads_seen.append(threading.get_ident())
+        return original_write(path, data)
+
+    def _read_spy(path):
+        threads_seen.append(threading.get_ident())
+        return original_read(path)
+
+    sandbox._write_file_sync = _write_spy
+    sandbox._read_file_sync = _read_spy
+
+    target = sandbox.resolve_path("note.txt")
+    await sandbox.write_file(target, b"hello")
+    assert await sandbox.read_file(target) == b"hello"
+
+    assert threads_seen, "同步实现没有被调用"
+    assert all(ident != loop_thread for ident in threads_seen), (
+        "文件操作仍在事件循环线程上执行"
+    )
+
+
+async def test_directory_ops_are_offloaded(make_sandbox) -> None:
+    sandbox = make_sandbox()
+    loop_thread = threading.get_ident()
+    threads_seen: list[int] = []
+
+    original_list = sandbox._list_files_sync
+    original_delete = sandbox._delete_file_sync
+
+    def _list_spy(path, pattern=None):
+        threads_seen.append(threading.get_ident())
+        return original_list(path, pattern)
+
+    def _delete_spy(path):
+        threads_seen.append(threading.get_ident())
+        return original_delete(path)
+
+    sandbox._list_files_sync = _list_spy
+    sandbox._delete_file_sync = _delete_spy
+
+    folder = sandbox.resolve_path("sub")
+    await sandbox.write_file(folder / "a.txt", b"x")
+    listing = await sandbox.list_files(folder)
+    assert [item["name"] for item in listing] == ["a.txt"]
+
+    await sandbox.delete_file(folder)
+    with pytest.raises(FileNotFoundError):
+        await sandbox.read_file(folder / "a.txt")
+
+    assert threads_seen
+    assert all(ident != loop_thread for ident in threads_seen)
+
+
+async def test_permission_errors_still_propagate(make_sandbox) -> None:
+    """线程化不能吞掉异常：越界路径仍要抛 PermissionError。"""
+    sandbox = make_sandbox()
+
+    with pytest.raises(PermissionError):
+        await sandbox.read_file(sandbox.resolve_path("..") / "outside.txt")

--- a/app/tests/modules/runtime/test_scheduled_task_listing.py
+++ b/app/tests/modules/runtime/test_scheduled_task_listing.py
@@ -6,7 +6,7 @@ dashboard/api.py 的 /api/tasks 用 getattr(manager, "list_tasks", None) 探测�
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 
 from neobot_contracts.models import ConversationRef
 from neobot_contracts.models.scheduled_task import (

--- a/app/tests/modules/runtime/test_scheduled_task_listing.py
+++ b/app/tests/modules/runtime/test_scheduled_task_listing.py
@@ -1,0 +1,110 @@
+"""面板「后台任务」里的定时任务列表必须有数据。
+
+dashboard/api.py 的 /api/tasks 用 getattr(manager, "list_tasks", None) 探测接口，
+而 ScheduledTaskManager 之前没有该方法 → 面板里的定时任务恒为空且不报错。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from neobot_contracts.models import ConversationRef
+from neobot_contracts.models.scheduled_task import (
+    ScheduledTaskRecurrence,
+    ScheduledTaskRecord,
+    ScheduledTaskState,
+)
+from neobot_app.runtime.scheduled_tasks import ScheduledTaskConfig, ScheduledTaskManager
+from neobot_app.time_context import now_utc
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+
+    def warning(self, message: str, **kw) -> None:
+        self.warnings.append(message)
+
+    def info(self, message: str, **kw) -> None:
+        pass
+
+    def debug(self, message: str, **kw) -> None:
+        pass
+
+    def error(self, message: str, **kw) -> None:
+        pass
+
+    def exception(self, message: str, **kw) -> None:
+        pass
+
+
+def _record(task_uuid: str = "t-1") -> ScheduledTaskRecord:
+    start = now_utc() + timedelta(hours=1)
+    return ScheduledTaskRecord(
+        id=1,
+        task_uuid=task_uuid,
+        title="喝水提醒",
+        detail="每小时提醒一次",
+        recurrence=ScheduledTaskRecurrence.DAILY,
+        start_at=start,
+        end_at=start + timedelta(minutes=10),
+        bindings=(ConversationRef(kind="group", id="888"),),
+        state=ScheduledTaskState.ACTIVE,
+    )
+
+
+def _manager(records: list[ScheduledTaskRecord] | None = None) -> ScheduledTaskManager:
+    logger = _Logger()
+    manager = ScheduledTaskManager(
+        uow_factory=object(),  # 只用于绕过 None 判定
+        config=ScheduledTaskConfig(poll_interval_seconds=60),
+        logger=logger,
+    )
+    manager._logger = logger
+
+    async def _list() -> list[ScheduledTaskRecord]:
+        return list(records or [])
+
+    manager._list_active_tasks = _list  # type: ignore[assignment]
+    return manager
+
+
+async def test_list_tasks_returns_panel_fields() -> None:
+    manager = _manager([_record()])
+
+    items = await manager.list_tasks()
+
+    assert len(items) == 1
+    item = items[0]
+    assert item["task_id"] == "t-1"
+    assert item["description"] == "每小时提醒一次"
+    assert item["status"] == "active"
+    assert item["recurrence"] == "daily"
+    # 面板显示的时间字段
+    assert item["next_run"] and item["trigger_time"]
+    assert item["bindings"] == 1
+
+
+async def test_list_tasks_without_storage_returns_empty() -> None:
+    manager = ScheduledTaskManager(uow_factory=None, logger=_Logger())
+
+    assert await manager.list_tasks() == []
+
+
+async def test_list_tasks_swallows_read_errors() -> None:
+    """读取失败只记日志并返回空列表，不能让面板 500。"""
+    manager = _manager()
+
+    async def _boom() -> list[ScheduledTaskRecord]:
+        raise RuntimeError("db down")
+
+    manager._list_active_tasks = _boom  # type: ignore[assignment]
+
+    assert await manager.list_tasks() == []
+    assert manager._logger.warnings
+
+
+async def test_list_tasks_respects_limit() -> None:
+    manager = _manager([_record(f"t-{i}") for i in range(5)])
+
+    assert len(await manager.list_tasks(limit=2)) == 2

--- a/app/tests/modules/runtime/test_scheduled_tasks.py
+++ b/app/tests/modules/runtime/test_scheduled_tasks.py
@@ -10,6 +10,7 @@ import pytest
 from sqlalchemy import select
 
 from neobot_app.bootstrap import _skills as skill_bootstrap
+from neobot_app.runtime import scheduled_tasks as scheduled_tasks_module
 from neobot_app.runtime.scheduled_tasks import (
     ScheduledTaskConfig,
     ScheduledTaskManager,
@@ -194,6 +195,42 @@ async def test_scheduled_task_repository_rejects_invalid_time_window(tmp_path):
                 )
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_list_active_tasks_paginates_beyond_single_page():
+    """活跃任务超过单页上限时必须翻页取全。
+
+    只取第一页会让排在第 501 位之后的任务永远不被扫描，提醒静默不触发。
+    """
+    page_size = scheduled_tasks_module._ACTIVE_TASK_PAGE_SIZE
+    rows = [object() for _ in range(page_size + 1)]
+    calls: list[tuple[int, int]] = []
+
+    class _Repo:
+        async def list_active(self, *, limit: int, offset: int = 0):
+            calls.append((limit, offset))
+            return rows[offset : offset + limit]
+
+    class _Uow:
+        scheduled_tasks = _Repo()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    manager = ScheduledTaskManager(
+        uow_factory=_Uow,
+        config=ScheduledTaskConfig(poll_interval_seconds=60),
+        notification_hub=_FakeHub(),
+    )
+
+    tasks = await manager._list_active_tasks()
+
+    assert len(tasks) == page_size + 1
+    assert calls == [(page_size, 0), (page_size, page_size)]
 
 
 class _FakeHub:

--- a/app/tests/modules/skills/test_archive_crud_guards.py
+++ b/app/tests/modules/skills/test_archive_crud_guards.py
@@ -217,6 +217,24 @@ def test_delete_tool_hidden_when_disabled() -> None:
     assert "save_archive" in _tool_names(skill)
 
 
+def test_instructions_do_not_advertise_hidden_delete_tool() -> None:
+    """提示词与工具表必须一致：隐藏了删除工具就不能再教模型去调用它。"""
+    disabled, _ = _skill()
+    enabled, _ = _skill(allow_delete=True)
+
+    assert "delete_archive" not in disabled.instructions
+    assert "删除档案未启用" in disabled.instructions
+    assert "删除" not in disabled.description
+    assert "delete_archive" in enabled.instructions
+    assert "删除" in enabled.description
+
+
+def test_instructions_declare_allowed_tables_limit() -> None:
+    skill, _ = _skill(allowed_tables=("user_profile",))
+
+    assert "user_profile" in skill.instructions
+
+
 def test_delete_tool_exposed_when_enabled() -> None:
     skill, _ = _skill(allow_delete=True)
 

--- a/app/tests/modules/skills/test_archive_crud_guards.py
+++ b/app/tests/modules/skills/test_archive_crud_guards.py
@@ -1,0 +1,181 @@
+"""archive_crud 的 allow_delete / allowed_tables 开关必须真正生效。
+
+历史上这两个参数只被存进字段（``self._allow_delete`` / ``self._allowed_tables``）
+而全仓再无读取，于是：
+- ``agent.memory.archive.allow_delete = false`` 形同虚设，模型可以无条件删档案；
+- ``allowed_tables`` 也无法把访问限制在指定表上。
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from neobot_app.skills.archive_crud import PENDING_MESSAGES_TABLE, ArchiveCRUDSkill
+
+
+class _FakeService:
+    def __init__(self) -> None:
+        self.deleted: list[tuple[str, str]] = []
+        self.saved: list[tuple[str, str]] = []
+        self.items: dict[tuple[str, str], SimpleNamespace] = {}
+
+    async def set(self, table_name, key, value, tags=None):
+        self.saved.append((table_name, key))
+        item = SimpleNamespace(table_name=table_name, key=key, value=value, version=1)
+        self.items[(table_name, key)] = item
+        return item
+
+    async def get(self, table_name, key):
+        return self.items.get((table_name, key))
+
+    async def delete(self, table_name, key):
+        self.deleted.append((table_name, key))
+        return True
+
+    async def list(self, table_name, limit=10, offset=0):
+        return [
+            item for (name, _), item in self.items.items() if name == table_name
+        ][:limit]
+
+
+def _skill(**kwargs) -> tuple[ArchiveCRUDSkill, _FakeService]:
+    service = _FakeService()
+    skill = ArchiveCRUDSkill(archive_service=service, **kwargs)
+    return skill, service
+
+
+# ── allow_delete ────────────────────────────────────────────────────
+
+
+async def test_delete_is_rejected_by_default() -> None:
+    skill, service = _skill()
+
+    result = json.loads(
+        await skill.execute(
+            "delete_archive", {"table_name": "user_profile", "key": "42"}
+        )
+    )
+
+    assert result["ok"] is False
+    assert "allow_delete" in result["error"]
+    assert service.deleted == []
+
+
+async def test_delete_allowed_when_enabled() -> None:
+    skill, service = _skill(allow_delete=True)
+
+    result = json.loads(
+        await skill.execute(
+            "delete_archive", {"table_name": "user_profile", "key": "42"}
+        )
+    )
+
+    assert result["ok"] is True
+    assert service.deleted == [("user_profile", "42")]
+
+
+# ── allowed_tables ──────────────────────────────────────────────────
+
+
+async def test_allowed_tables_blocks_write() -> None:
+    skill, service = _skill(allowed_tables=("user_profile",))
+
+    result = json.loads(
+        await skill.execute(
+            "save_archive",
+            {"table_name": "group_profile", "key": "1", "value": "x"},
+        )
+    )
+
+    assert result["ok"] is False
+    assert "group_profile" in result["error"]
+    assert service.saved == []
+
+
+async def test_allowed_tables_permits_listed_table() -> None:
+    skill, service = _skill(allowed_tables=("user_profile",))
+
+    result = json.loads(
+        await skill.execute(
+            "save_archive",
+            {"table_name": "user_profile", "key": "1", "value": "x"},
+        )
+    )
+
+    assert result["ok"] is True
+    assert service.saved == [("user_profile", "1")]
+
+
+async def test_allowed_tables_blocks_delete_even_when_enabled() -> None:
+    skill, service = _skill(allow_delete=True, allowed_tables=("user_profile",))
+
+    result = json.loads(
+        await skill.execute(
+            "delete_archive", {"table_name": "group_profile", "key": "1"}
+        )
+    )
+
+    assert result["ok"] is False
+    assert service.deleted == []
+
+
+async def test_allowed_tables_blocks_read() -> None:
+    skill, _ = _skill(allowed_tables=("user_profile",))
+
+    result = json.loads(
+        await skill.execute("read_archive", {"table_name": "group_profile", "key": "1"})
+    )
+
+    assert result["ok"] is False
+
+
+async def test_empty_allowed_tables_means_unrestricted() -> None:
+    skill, service = _skill()
+
+    result = json.loads(
+        await skill.execute(
+            "save_archive", {"table_name": "item_archive", "key": "k", "value": "v"}
+        )
+    )
+
+    assert result["ok"] is True
+    assert service.saved == [("item_archive", "k")]
+
+
+async def test_pending_messages_read_is_exempt_from_allowlist() -> None:
+    """内部计数表不能被 allowed_tables 掐掉，否则自动总结会整体失效。"""
+    skill, service = _skill(allowed_tables=("user_profile",))
+    service.items[(PENDING_MESSAGES_TABLE, "group:1")] = SimpleNamespace(
+        table_name=PENDING_MESSAGES_TABLE,
+        key="group:1",
+        value=json.dumps({"count": 1, "messages": []}),
+        version=1,
+    )
+
+    result = json.loads(
+        await skill.execute("read_pending_messages", {"conversation_key": "group:1"})
+    )
+
+    assert result["ok"] is True
+
+
+# ── 工具可见性 ──────────────────────────────────────────────────────
+
+
+def _tool_names(skill: ArchiveCRUDSkill) -> list[str]:
+    return [tool["function"]["name"] for tool in skill.get_tools()]
+
+
+def test_delete_tool_hidden_when_disabled() -> None:
+    skill, _ = _skill()
+
+    assert "delete_archive" not in _tool_names(skill)
+    assert "save_archive" in _tool_names(skill)
+
+
+def test_delete_tool_exposed_when_enabled() -> None:
+    skill, _ = _skill(allow_delete=True)
+
+    assert "delete_archive" in _tool_names(skill)
+

--- a/app/tests/modules/skills/test_archive_crud_guards.py
+++ b/app/tests/modules/skills/test_archive_crud_guards.py
@@ -130,6 +130,49 @@ async def test_allowed_tables_blocks_read() -> None:
     assert result["ok"] is False
 
 
+async def test_allowed_tables_blocks_every_item_of_batch_read() -> None:
+    """items 批量读取必须逐项校验，不能只看顶层 table_name。
+
+    否则只要顶层填一个合法表名，就能用 items 里的任意表名读到未授权的档案。
+    """
+    skill, service = _skill(allowed_tables=("user_profile",))
+    service.items[("secret_table", "k")] = SimpleNamespace(
+        table_name="secret_table", key="k", value="TOP-SECRET", version=1
+    )
+
+    result = json.loads(
+        await skill.execute(
+            "read_archive",
+            {
+                "table_name": "user_profile",
+                "key": "1",
+                "items": [{"table_name": "secret_table", "key": "k"}],
+            },
+        )
+    )
+
+    assert result["ok"] is False
+    assert "secret_table" in result["error"]
+    assert "TOP-SECRET" not in json.dumps(result, ensure_ascii=False)
+
+
+async def test_batch_read_returns_allowed_items() -> None:
+    skill, service = _skill(allowed_tables=("user_profile",))
+    service.items[("user_profile", "1")] = SimpleNamespace(
+        table_name="user_profile", key="1", value="hello", version=1
+    )
+
+    result = json.loads(
+        await skill.execute(
+            "read_archive",
+            {"items": [{"table_name": "user_profile", "key": "1"}]},
+        )
+    )
+
+    assert result["ok"] is True
+    assert len(result["items"]) == 1
+
+
 async def test_empty_allowed_tables_means_unrestricted() -> None:
     skill, service = _skill()
 

--- a/app/tests/modules/skills/test_skill_blocking_io.py
+++ b/app/tests/modules/skills/test_skill_blocking_io.py
@@ -1,0 +1,95 @@
+"""技能层的压缩/图片转换必须离开事件循环。
+
+- ArchiveSkill 的 zip/tar 压缩解压是 CPU+磁盘密集工作，原先直接跑在 async 方法里；
+- BrowserSkill 的 JPEG→PNG 转换（PIL 解码+编码）同理；
+- sandbox_maintenance 的 TempCleaner 是同步实现（整树扫描/删除）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+from PIL import Image
+
+from neobot_app.skills.archive_skill import ArchiveSkill
+from neobot_app.skills.browser_skill import _convert_jpeg_file_to_png
+
+
+async def test_archive_compress_runs_off_loop(make_sandbox) -> None:
+    loop_thread = threading.get_ident()
+    seen: list[int] = []
+
+    sandbox = make_sandbox()
+    skill = ArchiveSkill(sandbox_service=sandbox)
+    await sandbox.write_file(sandbox.resolve_path("a.txt"), b"hello")
+
+    original = skill._compress_zip_sync
+
+    def _spy(sources, out):
+        seen.append(threading.get_ident())
+        return original(sources, out)
+
+    skill._compress_zip_sync = _spy
+
+    result = await skill.execute(
+        "archive_compress", {"paths": ["a.txt"], "output": "out.zip"}
+    )
+
+    assert '"ok": true' in result
+    assert sandbox.resolve_path("out.zip").is_file()
+    assert seen and seen[0] != loop_thread
+
+
+async def test_archive_decompress_runs_off_loop(make_sandbox) -> None:
+    loop_thread = threading.get_ident()
+    seen: list[int] = []
+
+    sandbox = make_sandbox()
+    skill = ArchiveSkill(sandbox_service=sandbox)
+    await sandbox.write_file(sandbox.resolve_path("src/b.txt"), b"payload")
+    await skill.execute(
+        "archive_compress", {"paths": ["src"], "output": "pack.zip"}
+    )
+
+    original = skill._decompress_zip_sync
+
+    def _spy(archive, dest):
+        seen.append(threading.get_ident())
+        return original(archive, dest)
+
+    skill._decompress_zip_sync = _spy
+
+    result = await skill.execute(
+        "archive_decompress", {"archive": "pack.zip", "dest": "out"}
+    )
+
+    assert '"ok": true' in result
+    assert sandbox.resolve_path("out/src/b.txt").read_bytes() == b"payload"
+    assert seen and seen[0] != loop_thread
+
+
+async def test_jpeg_to_png_conversion_runs_off_loop(tmp_path: Path) -> None:
+    loop_thread = threading.get_ident()
+    jpg = tmp_path / "shot.jpg"
+    Image.new("RGB", (24, 24), (10, 120, 220)).save(jpg, format="JPEG")
+    seen: list[int] = []
+
+    def _call() -> bytes:
+        seen.append(threading.get_ident())
+        return _convert_jpeg_file_to_png(str(jpg))
+
+    png_bytes = await asyncio.to_thread(_call)
+
+    assert png_bytes.startswith(b"\x89PNG")
+    assert seen and seen[0] != loop_thread
+
+
+def test_jpeg_to_png_returns_valid_png(tmp_path: Path) -> None:
+    jpg = tmp_path / "a.jpg"
+    Image.new("RGB", (16, 16), (0, 0, 0)).save(jpg, format="JPEG")
+
+    data = _convert_jpeg_file_to_png(str(jpg))
+
+    assert data.startswith(b"\x89PNG\r\n\x1a\n")

--- a/app/tests/modules/skills/test_skill_tool_error_detail.py
+++ b/app/tests/modules/skills/test_skill_tool_error_detail.py
@@ -1,0 +1,62 @@
+"""工具执行失败必须保留原因（日志与模型可见）。
+
+两处旧实现都会销毁错误信息：
+- SkillManager.execute: `except Exception: return f"工具执行失败 [{name}]"`
+  ——不记日志、不带异常信息；
+- 回复编排器的工具调用分支只记 error_type，`str(exc)` 既不进日志也不回给模型。
+"""
+
+from __future__ import annotations
+
+from neobot_app.skills.base import SkillManager, SkillModule
+
+
+class _BoomSkill(SkillModule):
+    @property
+    def name(self) -> str:
+        return "boom"
+
+    @property
+    def description(self) -> str:
+        return "总是抛异常"
+
+    def get_tools(self) -> list[dict]:
+        return [self._tool_def("fail", "总是失败")]
+
+    async def execute(self, tool_name: str, args: dict) -> str:
+        raise ValueError("磁盘已满：/dev/sda1")
+
+
+async def test_skill_tool_failure_returns_reason() -> None:
+    manager = SkillManager()
+    manager.register(_BoomSkill())
+
+    result = await manager.execute("boom__fail", {})
+
+    assert "工具执行失败 [boom__fail]" in result
+    assert "ValueError" in result
+    assert "磁盘已满" in result
+
+
+async def test_skill_tool_failure_is_truncated() -> None:
+    class _VerboseBoom(_BoomSkill):
+        async def execute(self, tool_name: str, args: dict) -> str:
+            raise RuntimeError("x" * 2000)
+
+    manager = SkillManager()
+    manager.register(_VerboseBoom())
+
+    result = await manager.execute("boom__fail", {})
+
+    assert len(result) < 500
+
+
+async def test_skill_success_path_unchanged() -> None:
+    class _Ok(_BoomSkill):
+        async def execute(self, tool_name: str, args: dict) -> str:
+            return '{"ok": true}'
+
+    manager = SkillManager()
+    manager.register(_Ok())
+
+    assert await manager.execute("boom__fail", {}) == '{"ok": true}'

--- a/app/tests/modules/storage/test_backup.py
+++ b/app/tests/modules/storage/test_backup.py
@@ -1,0 +1,79 @@
+"""迁移前数据库备份测试。"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from neobot_storage.backup import backup_sqlite_database
+
+
+def _make_db(path: Path, *, wal: bool = False) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    if wal:
+        conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, value TEXT)")
+    conn.commit()
+    return conn
+
+
+def _read_values(path: Path) -> list[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return [row[0] for row in conn.execute("SELECT value FROM t ORDER BY id")]
+    finally:
+        conn.close()
+
+
+def test_missing_database_returns_none(tmp_path: Path) -> None:
+    assert backup_sqlite_database(tmp_path / "nope.db", tmp_path / "bk") is None
+
+
+def test_backup_copies_data(tmp_path: Path) -> None:
+    db = tmp_path / "neobot.db"
+    conn = _make_db(db)
+    conn.execute("INSERT INTO t (value) VALUES ('hello')")
+    conn.commit()
+    conn.close()
+
+    target = backup_sqlite_database(db, tmp_path / "db_backup")
+
+    assert target is not None and target.is_file()
+    assert _read_values(target) == ["hello"]
+    # 备份不应影响源库
+    assert _read_values(db) == ["hello"]
+
+
+def test_backup_includes_uncheckpointed_wal_data(tmp_path: Path) -> None:
+    """WAL 中尚未 checkpoint 的已提交数据必须出现在备份里（裸拷主库会丢）。"""
+    db = tmp_path / "neobot.db"
+    conn = _make_db(db, wal=True)
+    conn.execute("INSERT INTO t (value) VALUES ('in-wal')")
+    conn.commit()
+    # 刻意不 checkpoint、不关闭连接
+    try:
+        target = backup_sqlite_database(db, tmp_path / "db_backup")
+        assert target is not None
+        assert _read_values(target) == ["in-wal"]
+    finally:
+        conn.close()
+
+
+def test_keeps_only_recent_backups(tmp_path: Path) -> None:
+    db = tmp_path / "neobot.db"
+    _make_db(db).close()
+    backup_dir = tmp_path / "db_backup"
+
+    for _ in range(4):
+        backup_sqlite_database(db, backup_dir, max_backups=2)
+
+    remaining = sorted(backup_dir.glob("neobot_*.db"))
+    assert len(remaining) == 2
+
+
+def test_backup_failure_does_not_raise(tmp_path: Path) -> None:
+    """损坏的库文件不能让启动流程崩掉。"""
+    db = tmp_path / "neobot.db"
+    db.write_bytes(b"this is not a sqlite database at all" * 4)
+
+    assert backup_sqlite_database(db, tmp_path / "db_backup") is None

--- a/app/tests/modules/storage/test_conftest_fixtures.py
+++ b/app/tests/modules/storage/test_conftest_fixtures.py
@@ -1,0 +1,26 @@
+"""conftest 的共享 fixture 必须真的可用。
+
+storage_engine 之前写成 `engine = await create_engine(...)`，而 create_engine 是
+同步函数（返回 AsyncEngine）；由于一直没有任何测试使用它，这个错误长期隐藏。
+"""
+
+from __future__ import annotations
+
+
+async def test_storage_engine_and_uow_factory_are_usable(
+    storage_engine, storage_uow_factory
+) -> None:
+    assert storage_engine is not None
+
+    async with storage_uow_factory() as uow:
+        assert uow is not None
+        assert hasattr(uow, "commit")
+
+
+async def test_make_sandbox_fixture_is_usable(make_sandbox, tmp_path) -> None:
+    sandbox = make_sandbox()
+
+    target = sandbox.resolve_path("hello.txt")
+    await sandbox.write_file(target, b"hi")
+
+    assert await sandbox.read_file(target) == b"hi"

--- a/app/tests/modules/storage/test_uow.py
+++ b/app/tests/modules/storage/test_uow.py
@@ -170,26 +170,23 @@ async def test_uow_commit_flush_lock_conflict_raises_without_silent_loss(tmp_pat
         await engine.dispose()
 
 
-async def test_uow_commit_pure_commit_phase_lock_conflict_retries():
-    """无未刷写变更时（纯 commit 阶段）的锁冲突必须重试成功，不丢数据。"""
+async def test_uow_commit_phase_lock_conflict_also_fails_loudly():
+    """commit 阶段的锁冲突同样必须显式失败，不得 rollback 后重试 commit。
 
-    class _FakeProxied:
-        @staticmethod
-        def _is_clean() -> bool:
-            return True
+    旧实现对「ORM 状态干净」的会话先 rollback 再重试 commit：仓库层大量使用
+    Core DML（``session.execute(insert(...).on_conflict_do_update())``），这类
+    写入不体现在 ORM 状态里，会被判成「干净」，于是重试 commit 会提交一个
+    空事务并成功返回——写入静默丢失。
+    """
 
     class _FlakySession:
         def __init__(self) -> None:
-            self._proxied = _FakeProxied()
             self.attempts = 0
             self.rollbacks = 0
 
         async def commit(self) -> None:
             self.attempts += 1
-            if self.attempts == 1:
-                raise OperationalError(
-                    "COMMIT", (), Exception("database is locked")
-                )
+            raise OperationalError("COMMIT", (), Exception("database is locked"))
 
         async def rollback(self) -> None:
             self.rollbacks += 1
@@ -197,14 +194,13 @@ async def test_uow_commit_pure_commit_phase_lock_conflict_retries():
         async def close(self) -> None:
             pass
 
-    # Act
     uow = SqlAlchemyUnitOfWork(lambda: _FlakySession())
     await uow.__aenter__()
     try:
-        await uow.commit()
+        with pytest.raises(RuntimeError, match="未持久化"):
+            await uow.commit()
     finally:
         await uow.__aexit__(None, None, None)
 
-    # Assert
-    assert uow._session.attempts == 2
+    assert uow._session.attempts == 1
     assert uow._session.rollbacks == 1

--- a/app/tests/modules/utils/test_atomic.py
+++ b/app/tests/modules/utils/test_atomic.py
@@ -26,6 +26,30 @@ def test_atomic_write_replaces_content(tmp_path: Path) -> None:
     assert [item.name for item in tmp_path.iterdir()] == ["stats.json"]
 
 
+def test_atomic_write_retries_transient_windows_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """目标被短时占用（WinError 5）时应重试成功，而不是把保存直接判失败。"""
+    target = tmp_path / "config.toml"
+    target.write_text("old", encoding="utf-8")
+    calls = {"count": 0}
+    real_replace = atomic.os.replace
+
+    def flaky(src: object, dst: object) -> None:
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise PermissionError(5, "Access is denied")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(atomic.os, "replace", flaky)
+    monkeypatch.setattr(atomic.time, "sleep", lambda _seconds: None)
+
+    atomic_write_text(target, "new")
+
+    assert target.read_text(encoding="utf-8") == "new"
+    assert calls["count"] == 3
+
+
 def test_atomic_write_keeps_original_on_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -36,6 +60,7 @@ def test_atomic_write_keeps_original_on_failure(
         raise OSError("disk full")
 
     monkeypatch.setattr(atomic.os, "replace", boom)
+    monkeypatch.setattr(atomic.time, "sleep", lambda _seconds: None)
 
     with pytest.raises(OSError):
         atomic_write_text(target, '{"total": 2}')

--- a/app/tests/modules/utils/test_atomic.py
+++ b/app/tests/modules/utils/test_atomic.py
@@ -1,0 +1,62 @@
+"""原子写入：写一半被杀不能污染原文件。
+
+面板的 stats.json、文件服务器元数据这类小文件以前是直接 ``open(..., "w")``，
+进程在写一半时被结束（崩溃 / 断电 / 任务管理器）就留下被截断的 JSON，下次启动
+解析失败、统计清零。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import neobot_app.utils.atomic as atomic
+from neobot_app.builtin_plugins.dashboard.metrics import Metrics
+from neobot_app.utils.atomic import atomic_write_text
+
+
+def test_atomic_write_replaces_content(tmp_path: Path) -> None:
+    target = tmp_path / "stats.json"
+
+    atomic_write_text(target, '{"total": 1}')
+    atomic_write_text(target, '{"total": 2}')
+
+    assert target.read_text(encoding="utf-8") == '{"total": 2}'
+    assert [item.name for item in tmp_path.iterdir()] == ["stats.json"]
+
+
+def test_atomic_write_keeps_original_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "stats.json"
+    target.write_text('{"total": 1}', encoding="utf-8")
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(atomic.os, "replace", boom)
+
+    with pytest.raises(OSError):
+        atomic_write_text(target, '{"total": 2}')
+
+    assert target.read_text(encoding="utf-8") == '{"total": 1}'
+    # 临时文件不能留在数据目录里
+    assert [item.name for item in tmp_path.iterdir()] == ["stats.json"]
+
+
+def test_metrics_save_does_not_raise_on_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    metrics = Metrics(data_dir=tmp_path)
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "neobot_app.builtin_plugins.dashboard.metrics.atomic_write_text", boom
+    )
+
+    metrics.flush()
+
+    assert not (tmp_path / "stats.json").exists()

--- a/app/tests/modules/utils/test_file_server.py
+++ b/app/tests/modules/utils/test_file_server.py
@@ -292,3 +292,46 @@ async def test_metadata_path_outside_data_dir_rejected(tmp_path: Path) -> None:
                 assert "TOP-SECRET-CONTENT" not in body
     finally:
         await fs.stop()
+
+
+def test_metadata_roundtrip_with_non_ascii_filename(tmp_path: Path) -> None:
+    """中文名文件的元数据必须能原样读回。
+
+    旧实现用 ``open(..., "w")`` 按系统默认编码写、按默认编码读，非 UTF-8
+    环境下写中文路径直接抛异常并被静默吞掉，重启后整份元数据丢失。
+    """
+    data_dir = tmp_path / "data"
+    fs = FileServer(data_dir=data_dir, enabled=True)
+    path = fs._tmp_dir / "中文 图片.png"
+    path.write_bytes(_png_bytes())
+    fs.register_file(path)
+    fs._save_metadata()
+
+    reloaded = FileServer(data_dir=data_dir, enabled=True)
+
+    assert set(reloaded._files) == set(fs._files)
+    assert reloaded._files[next(iter(fs._files))].path.endswith("中文 图片.png")
+
+
+def test_metadata_write_is_atomic_and_tolerates_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """元数据写失败不能损坏已有文件，也不能把异常抛给调用方。"""
+    data_dir = tmp_path / "data"
+    fs = FileServer(data_dir=data_dir, enabled=True)
+    path = fs._tmp_dir / "a.txt"
+    path.write_text("hello", encoding="utf-8")
+    fs.register_file(path)
+    fs._save_metadata()
+    before = fs._metadata_file.read_text(encoding="utf-8")
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(file_server_module, "atomic_write_text", boom)
+
+    fs._files["b.txt"] = fs._files[next(iter(fs._files))]
+    fs._save_metadata()  # 不抛异常
+
+    assert fs._metadata_file.read_text(encoding="utf-8") == before
+    assert [p.name for p in fs._tmp_dir.glob("*.tmp")] == []

--- a/app/tests/modules/web_search/test_session_ssrf.py
+++ b/app/tests/modules/web_search/test_session_ssrf.py
@@ -1,0 +1,86 @@
+"""搜索结果页面抓取的 SSRF 防护测试。
+
+搜索结果里的 URL 来自第三方页面（可被 SEO / 恶意内容影响），抓取前必须
+按公网地址校验，否则可以被引导去探测内网、本机面板(9981)或文件服务器(8765)。
+"""
+
+from __future__ import annotations
+
+from neobot_app.web_search.models import SearchResult
+from neobot_app.web_search.session import SearchSession
+
+
+class _RecordingClient:
+    """记录实际发起的请求；测试里私有地址不应产生任何请求。"""
+
+    def __init__(self) -> None:
+        self.requested: list[str] = []
+
+    async def get(self, url: str, **_kwargs: object) -> object:
+        self.requested.append(url)
+        raise RuntimeError("request attempted")
+
+
+def _make_session(*results: SearchResult) -> SearchSession:
+    """绕过 SearchManager（需要搜索引擎依赖）构造一个只用于抓取测试的会话。"""
+    session = SearchSession.__new__(SearchSession)
+    session._results_index = {index: r for index, r in enumerate(results)}
+    session._read_urls = set()
+    session._rounds = []
+    session._read_timeout = 5.0
+    return session
+
+
+def _result(url: str, index: int = 0) -> SearchResult:
+    return SearchResult(
+        index=index, title="t", url=url, snippet="s", engine="fake"
+    )
+
+
+async def test_loopback_url_is_blocked_before_request() -> None:
+    result = _result("http://127.0.0.1:9981/api/overview")
+    session = _make_session(result)
+    client = _RecordingClient()
+
+    await session._fetch_all(client, [result])  # type: ignore[arg-type]
+
+    assert result.content_fetched is False
+    assert "阻止" in str(result.content)
+    assert client.requested == []
+
+
+async def test_metadata_endpoint_is_blocked() -> None:
+    """云元数据地址（169.254.169.254）尤其不能被抓取。"""
+    result = _result("http://169.254.169.254/latest/meta-data/")
+    session = _make_session(result)
+    client = _RecordingClient()
+
+    await session._fetch_all(client, [result])  # type: ignore[arg-type]
+
+    assert result.content_fetched is False
+    assert client.requested == []
+
+
+async def test_private_network_url_is_blocked() -> None:
+    result = _result("http://10.1.2.3/internal")
+    session = _make_session(result)
+    client = _RecordingClient()
+
+    await session._fetch_all(client, [result])  # type: ignore[arg-type]
+
+    assert result.content_fetched is False
+    assert client.requested == []
+
+
+async def test_public_ip_literal_is_still_fetched() -> None:
+    """公网地址（IP 字面量，避免依赖 DNS）不应被误拦。"""
+    result = _result("http://93.184.216.34/page")
+    session = _make_session(result)
+    client = _RecordingClient()
+
+    await session._fetch_all(client, [result])  # type: ignore[arg-type]
+
+    assert client.requested == ["http://93.184.216.34/page"]
+    # 抓取本身失败（假 client 抛错），但失败原因是请求而不是被拦截
+    assert result.content_fetched is False
+    assert "获取失败" in str(result.content)

--- a/docs/03-架构设计.md
+++ b/docs/03-架构设计.md
@@ -34,9 +34,9 @@ NeoBot 采用「应用层 + 可复用子包」的 monorepo 结构（uv workspace
 |---|---|---|
 | `app` | 应用组装与业务逻辑：启动装配、配置、消息管线、回复编排、技能、官方内置插件（网页面板） | `bootstrap/`、`runtime/`、`reply/`、`skills/`、`builtin_plugins/` |
 | `neobot-adapter` | 协议适配：OneBot 11（WebSocket 反向连接）、本地 HTTP/WebSocket、事件分发、消息模型 | [onebot/](../packages/adapter/src/neobot_adapter/onebot/)、[local/](../packages/adapter/src/neobot_adapter/local/)、[eventing.py](../packages/adapter/src/neobot_adapter/eventing.py) |
-| `neobot-chat` | LLM 对话内核：Provider（DeepSeek/OpenAI/Anthropic）、Agent 执行图、工具注册、Skill 注入 | [providers/](../packages/chat/src/neobot_chat/providers/)、[graph/](../packages/chat/src/neobot_chat/graph/)、[tools/](../packages/chat/src/neobot_chat/tools/)、[skills/](../packages/chat/src/neobot_chat/skills/) |
+| `neobot-chat` | LLM 对话内核：Provider（DeepSeek/OpenAI/Anthropic）、Agent 工具循环、工具注册、Skill 注入、插件可用的 Workflow 图 API | [providers/](../packages/chat/src/neobot_chat/providers/)、[runtime/agent.py](../packages/chat/src/neobot_chat/runtime/agent.py)、[tools/](../packages/chat/src/neobot_chat/tools/)、[skills/](../packages/chat/src/neobot_chat/skills/) |
 | `neobot-contracts` | 跨模块领域模型（消息、记忆、定时任务、触发器）与 Ports 接口（输出、存储、沙箱、截图等） | [models/](../packages/contracts/src/neobot_contracts/models/)、[ports/](../packages/contracts/src/neobot_contracts/ports/) |
-| `neobot-memory` | 记忆服务：档案读写、图片记忆、归档总结 | [service.py](../packages/memory/src/neobot_memory/service.py)、[archive_service.py](../packages/memory/src/neobot_memory/archive_service.py) |
+| `neobot-memory` | 记忆服务：档案读写、图片记忆、归档总结（`service.py` 的 `MemoryService` 尚未接入，见下） | [archive_service.py](../packages/memory/src/neobot_memory/archive_service.py)、[image_service.py](../packages/memory/src/neobot_memory/image_service.py) |
 | `neobot-storage` | SQLAlchemy 2.0 async 存储 + 工作单元（UoW）+ Alembic 迁移 | [engine.py](../packages/storage/src/neobot_storage/engine.py)、[uow.py](../packages/storage/src/neobot_storage/uow.py)、[alembic/](../packages/storage/src/neobot_storage/alembic/) |
 | `neobot-modloader` | 插件加载与运行时：Plugin API、命令 DSL、钩子总线、插件数据库、依赖注入、官方/第三方插件管理门面与宿主服务注册表 | [plugin.py](../packages/modloader/src/neobot_modloader/plugin.py)、[hooks.py](../packages/modloader/src/neobot_modloader/hooks.py)、[loader.py](../packages/modloader/src/neobot_modloader/loader.py)、[management.py](../packages/modloader/src/neobot_modloader/management.py)、[host.py](../packages/modloader/src/neobot_modloader/host.py) |
 
@@ -46,7 +46,7 @@ NeoBot 采用「应用层 + 可复用子包」的 monorepo 结构（uv workspace
 
 - [output.py](../packages/contracts/src/neobot_contracts/ports/output.py) — 运行时输出（日志/事件）
 - [repository.py](../packages/contracts/src/neobot_contracts/ports/repository.py) / [unit_of_work.py](../packages/contracts/src/neobot_contracts/ports/unit_of_work.py) — 存储访问
-- [memory.py](../packages/contracts/src/neobot_contracts/ports/memory.py) / [archive_memory_access.py](../packages/contracts/src/neobot_contracts/ports/archive_memory_access.py) — 记忆访问
+- [memory.py](../packages/contracts/src/neobot_contracts/ports/memory.py)（规划中，无实现与调用方）/ [archive_memory_access.py](../packages/contracts/src/neobot_contracts/ports/archive_memory_access.py) — 记忆访问
 - [sandbox.py](../packages/contracts/src/neobot_contracts/ports/sandbox.py) — 沙箱文件操作
 - [provider.py](../packages/contracts/src/neobot_contracts/ports/provider.py) — LLM Provider
 - [media_sender.py](../packages/contracts/src/neobot_contracts/ports/media_sender.py) — 媒体发送
@@ -79,7 +79,8 @@ runtime/gateway.py (EventGateway)
       ▼
 runtime/event_pipeline.py (EventPipeline)
       │ 按事件类型路由
-      ├── 消息事件 → InboundPipeline（消息队列：群/私聊）
+      ├── 消息事件 → EventPipeline.handle_*_message_event（入队群/私聊消息队列）
+      │                └─ InboundPipeline（仅规范化 + 记日志，不持有队列）
       ├── 通知事件 → NoticeHandler
       ├── 生命周期事件 → LifecycleHandler
       └── OneBot 请求 → OneBotRequestHandler

--- a/docs/04-功能文档/Agent与模型路由.md
+++ b/docs/04-功能文档/Agent与模型路由.md
@@ -108,8 +108,9 @@ NeoBot 的核心是一个多 Agent 系统：主回复 Agent 负责对话与任�
 | [skills/agent_delegation.py](../../app/src/neobot_app/skills/agent_delegation.py) | 主 Agent 委托子 Agent 的 delegate 工具 | `AgentDelegationSkill` |
 | [providers/base.py](../../packages/chat/src/neobot_chat/providers/base.py) | LLM Provider 抽象与 HTTP 基础实现 | `Provider`、`BaseHTTPProvider` |
 | [providers/openai.py](../../packages/chat/src/neobot_chat/providers/openai.py) | OpenAI 兼容 Provider（含 DeepSeek 官方/OpenAI 样式思考模式转换） | `OpenAIProvider` |
-| [graph/graph.py](../../packages/chat/src/neobot_chat/graph/graph.py) | Agent 执行图（节点/边/入口） | `StateGraph` |
-| [graph/executor.py](../../packages/chat/src/neobot_chat/graph/executor.py) | 编译后的图执行器（工具循环） | `CompiledGraph` |
+| [runtime/agent.py](../../packages/chat/src/neobot_chat/runtime/agent.py) | Agent 主体：工具调用循环（`max_iterations`）、工具执行与流式回调 | `Agent` |
+| [graph/graph.py](../../packages/chat/src/neobot_chat/graph/graph.py) | 状态图定义（节点/边/入口），供插件用 `Workflow` 编排自定义流程 | `StateGraph` |
+| [graph/executor.py](../../packages/chat/src/neobot_chat/graph/executor.py) | 状态图执行器（按边推进节点，非主回复路径的工具循环） | `CompiledGraph` |
 | [graph/nodes.py](../../packages/chat/src/neobot_chat/graph/nodes.py) | 内置图节点（技能注入节点） | `skill_node` |
 | [tools/registry.py](../../packages/chat/src/neobot_chat/tools/registry.py) | Agent/工具注册表 | `AgentRegistry` |
 | [config/schemas/bot.py](../../app/src/neobot_app/config/schemas/bot.py) | 模型注册表与 Agent 路由的配置定义 | `Models`、`AgentModelRouting`、`ModelRegistration` |

--- a/docs/04-功能文档/网页面板.md
+++ b/docs/04-功能文档/网页面板.md
@@ -89,6 +89,13 @@ NeoBot 的网页面板是**官方内置插件 `dashboard`**（基于 aiohttp）�
 - `dashboard.allow_remote_manage = false` 时，非本机来源只能查看，不能改配置、编辑 `.env`、管理插件或重启
 - 面板默认对网络开放，公网使用建议经 HTTPS 反向代理访问，并在确认 HTTPS 生效后设 `secure_cookies = true`
 - 仅当可信反向代理正确覆盖客户端地址头时才开启 `trust_proxy_headers`
+- 经反向代理访问时请让代理同时透传 Host 与客户端地址头：
+  `proxy_set_header Host $host;`、`proxy_set_header X-Forwarded-Host $host;`、
+  `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;`，并开启
+  `trust_proxy_headers = true`。登录/首次设置密码会校验 Origin 与 Host 同源，
+  代理不改写 Host 也不透传 `X-Forwarded-Host` 时会返回 403（这是防 CSRF 的
+  必要约束，不是 bug）；来源判定取 `X-Forwarded-For` 的**最右**一项，
+  因此不要在代理上丢弃客户端地址头
 
 ## 配置（`[dashboard]` 段）
 

--- a/docs/04-功能文档/记忆系统.md
+++ b/docs/04-功能文档/记忆系统.md
@@ -13,6 +13,12 @@ NeoBot 拥有多层记忆体系，从短期上下文到长期档案，让 Bot �
 | 好感度 | favorability | 数值化的关系亲密度（-1000 ~ 1000） |
 | 自适应提示词 | AdaptivePromptSkill | Agent 可自主维护的永久记忆文本 |
 
+> **现状说明**：短期记忆没有独立的记忆服务。当前可用的只有表中的「消息队列」（进程内的当前上下文）
+> 与「档案记忆 / 用户画像 / 好感度 / 自适应提示词」（落库的长期记忆）。
+> `packages/memory/service.py` 的 `MemoryService`（`remember`/`recall`）、
+> `reader.py` 的 `MemoryReader` 协议与 `contracts/ports/memory.py` 目前都没有调用方，
+> 属于未接入的规划接口：应用启动时会构造一个 `MemoryService` 实例，但没有任何代码读写它。
+
 ## 触发式记忆
 
 `agent.memory.trigger` 配置：
@@ -92,10 +98,10 @@ NeoBot 拥有多层记忆体系，从短期上下文到长期档案，让 Bot �
 
 | 文件 | 说明 | 关键类/函数 |
 |---|---|---|
-| [memory/service.py](../../packages/memory/src/neobot_memory/service.py) | 记忆服务入口（触发式记忆处理） | `MemoryService` |
+| [memory/service.py](../../packages/memory/src/neobot_memory/service.py) | 记忆读写服务（**未接入**：`remember`/`recall` 无调用方，触发式总结见下行） | `MemoryService` |
 | [memory/archive_service.py](../../packages/memory/src/neobot_memory/archive_service.py) | 档案记忆读写（用户/群/物品关键词档案） | `ArchiveMemoryService` |
 | [memory/image_service.py](../../packages/memory/src/neobot_memory/image_service.py) | 图片记忆分析（头像/聊天图片） | `ImageAnalysisService` |
-| [memory/reader.py](../../packages/memory/src/neobot_memory/reader.py) | 记忆读取协议 | `MemoryReader` |
+| [memory/reader.py](../../packages/memory/src/neobot_memory/reader.py) | 记忆读取协议（**未接入**：无消费方） | `MemoryReader` |
 | [user_profiles.py](../../app/src/neobot_app/user_profiles.py) | 用户画像服务（备注/性别/角色等） | `UserProfileService` |
 | [favorability.py](../../app/src/neobot_app/favorability.py) | 好感度数值转换与范围约束 | `favorability_to_text`、`clamp_favorability` |
 | [skills/user_profile.py](../../app/src/neobot_app/skills/user_profile.py) | 用户画像 Skill（读取/头像分析） | `UserProfileSkill` |
@@ -104,4 +110,4 @@ NeoBot 拥有多层记忆体系，从短期上下文到长期档案，让 Bot �
 | [runtime/archive_memory_summary.py](../../app/src/neobot_app/runtime/archive_memory_summary.py) | 档案自动总结服务（间隔触发总结写档案） | `ArchiveMemoryAutoSummaryService` |
 | [message/queue.py](../../app/src/neobot_app/message/queue.py) | 消息队列（记忆触发计数依据） | `MessageQueue` |
 | [contracts/ports/archive_memory_access.py](../../packages/contracts/src/neobot_contracts/ports/archive_memory_access.py) | 档案访问 Ports 接口 | `ArchiveMemoryAccess` |
-| [contracts/ports/memory.py](../../packages/contracts/src/neobot_contracts/ports/memory.py) | 记忆存储/查询 Ports 接口 | `ArchiveStorage`、`TopicStorage` |
+| [contracts/ports/memory.py](../../packages/contracts/src/neobot_contracts/ports/memory.py) | 记忆存储/查询 Ports 接口（**未接入**：无实现类、无调用方） | `ArchiveStorage`、`TopicStorage` |

--- a/docs/04-功能文档/记忆系统.md
+++ b/docs/04-功能文档/记忆系统.md
@@ -41,8 +41,8 @@ NeoBot 拥有多层记忆体系，从短期上下文到长期档案，让 Bot �
 
 档案是 Bot 对某个实体的长期记忆条目。相关配置 `agent.memory.archive`：
 
-- `allow_delete`：是否允许 delete_archive 删除档案
-- `allowed_tables`：允许访问的档案表名列表（留空不限制）
+- `allow_delete`（默认 false）：是否允许 `delete_archive` 删除档案；关闭时该工具**不会注入给模型**，即使被调用也会被拒绝
+- `allowed_tables`：允许访问的档案表名列表（留空不限制）；限制后 `save_archive` / `patch_archive` / `read_archive` / `list_archive` / `delete_archive` 都会校验表名（内部待总结消息表 `memory_counter` 不受限制）
 - `auto_compact_chars`（默认 200）：单条档案超过此字符数时触发 AI 自动精简；0 禁用
   （当前代码未实现该自动精简，仅保留配置项）
 - `max_chars`（默认 500）：个人记忆渲染进系统提示词的展示上限（超出由模型分页查阅）

--- a/docs/05-配置参考.md
+++ b/docs/05-配置参考.md
@@ -248,6 +248,7 @@ main_agent = 0
 | `mode` | onebot | 适配器模式：onebot（OneBot WebSocket 反向连接）/ local（本地适配器） |
 | `local_host` | 127.0.0.1 | 本地适配器 HTTP/WebSocket 监听地址 |
 | `local_port` | 8090 | 本地适配器 HTTP/WebSocket 监听端口 |
+| `local_auth_token` | 空 | 本地适配器的 Bearer token；留空不校验，此时监听非回环地址会在启动日志告警（环境变量 `NEOBOT_LOCAL_ADAPTER_TOKEN`） |
 | `reverse_ws_host` | 空 | 反向 WebSocket 监听地址（onebot 模式）；留空读环境变量，再缺省 `0.0.0.0` |
 | `reverse_ws_port` | 0 | 反向 WebSocket 监听端口（onebot 模式）；0 表示未配置，缺省 `8080` |
 | `reverse_ws_access_token` | 空 | 反向 WebSocket 握手鉴权 token（OneBot 11 规范，框架侧以 `Authorization: Bearer` 发送）；留空不校验，此时监听非回环地址会在启动日志告警 |

--- a/docs/05-配置参考.md
+++ b/docs/05-配置参考.md
@@ -248,6 +248,9 @@ main_agent = 0
 | `mode` | onebot | 适配器模式：onebot（OneBot WebSocket 反向连接）/ local（本地适配器） |
 | `local_host` | 127.0.0.1 | 本地适配器 HTTP/WebSocket 监听地址 |
 | `local_port` | 8090 | 本地适配器 HTTP/WebSocket 监听端口 |
+| `reverse_ws_host` | 空 | 反向 WebSocket 监听地址（onebot 模式）；留空读环境变量，再缺省 `0.0.0.0` |
+| `reverse_ws_port` | 0 | 反向 WebSocket 监听端口（onebot 模式）；0 表示未配置，缺省 `8080` |
+| `reverse_ws_access_token` | 空 | 反向 WebSocket 握手鉴权 token（OneBot 11 规范，框架侧以 `Authorization: Bearer` 发送）；留空不校验，此时监听非回环地址会在启动日志告警 |
 
 ## [message] 消息处理
 
@@ -433,5 +436,7 @@ main_agent = 0
 | `NEOBOT_DATA_DIR` | 数据目录覆盖（默认 `app/data/`） |
 | `NEOBOT_ENV_FILE` | 环境变量文件路径覆盖（默认数据目录下的 `.env`） |
 | `NEOBOT_LOCAL_ADAPTER_HOST` / `NEOBOT_LOCAL_ADAPTER_PORT` | 本地适配器监听地址/端口覆盖（对应 `adapter.local_host` / `local_port`） |
+| `NEO_BOT_ADAPTER_HOST` / `NEO_BOT_ADAPTER_PORT` | 反向 WebSocket 监听地址/端口覆盖（对应 `adapter.reverse_ws_host` / `reverse_ws_port`） |
+| `NEO_BOT_ADAPTER_TOKEN` / `NEOBOT_ADAPTER_TOKEN` | 反向 WebSocket 握手鉴权 token（对应 `adapter.reverse_ws_access_token`） |
 
 > 完整变量清单以首次生成的 `.env.example` 与 [`config/loader/env.py`](../app/src/neobot_app/config/loader/env.py) 为准。

--- a/docs/08-部署说明.md
+++ b/docs/08-部署说明.md
@@ -118,6 +118,7 @@ export NEOBOT_DATA_DIR=/opt/neobot/data
 | `logs/` | 运行日志 |
 | `plugins_data/` | 插件数据目录；网页面板的密码哈希写在 `plugins_data/dashboard/auth.json` |
 | `config_backup/` | 配置自动备份 |
+| `db_backup/` | 数据库迁移前自动快照（保留最近 5 份） |
 
 ### 3.2 填写 `.env`
 
@@ -249,4 +250,4 @@ git pull
 uv sync --all-packages
 ```
 
-配置会在启动时自动迁移并备份到数据目录的 `config_backup/`。升级前建议先备份整个数据目录。
+配置会在启动时自动迁移并备份到数据目录的 `config_backup/`。数据库（`neobot.db`）在每次启动执行 alembic 迁移**之前**会自动快照到数据目录的 `db_backup/`（保留最近 5 份，使用 SQLite 在线备份 API，WAL 中未 checkpoint 的数据也会包含在内）。即便如此，升级前仍建议先备份整个数据目录。

--- a/docs/08-部署说明.md
+++ b/docs/08-部署说明.md
@@ -187,7 +187,18 @@ uv run neobot     # 源码方式
    | 不同机器 | `ws://<NeoBot 所在主机 IP>:8080/onebot` |
 
    > 路径 `/onebot` 是 OneBot 惯例写法，NeoBot 不校验路径，填别的路径也能连上。
-5. Token **留空**（NeoBot 当前不校验反向 WS 的 token）；若需跨公网，请自行用防火墙/内网/隧道限制来源，不要把 8080 直接暴露到公网。
+5. Token：**建议填写**。按 [OneBot 11 鉴权规范](https://github.com/botuniverse/onebot-11/blob/master/communication/authorization.md)，反向 WebSocket 由框架侧在握手请求头带 `Authorization: Bearer <access_token>`；NeoBot 作为服务端校验它。
+
+   - 想启用校验：在 `config.toml` 里配置同一个值，或设置环境变量 `NEO_BOT_ADAPTER_TOKEN`：
+
+     ```toml
+     [adapter]
+     reverse_ws_access_token = "改成你自己的随机串"
+     ```
+
+     两端不一致时 NapCat 会连不上，NeoBot 日志出现「反向 WebSocket 握手被拒绝：access token 缺失或不匹配」。
+   - 留空表示不校验（与历史版本行为一致），此时**只要监听地址不是回环地址，启动日志会给出告警**：该网段内任何主机都能连入并注入伪造事件。跨公网请务必配置 token，并配合防火墙/内网/隧道限制来源，不要把 8080 直接暴露到公网。
+   - 注意 WebSocket 本身是明文，token 只能防误连与局域网扫描；跨不可信网络请走 WSS 或隧道。
 6. 勾选「保存时启用」，保存。
 7. 回到 NeoBot 日志，出现下面这行即接入成功：
 
@@ -208,6 +219,7 @@ uv run neobot     # 源码方式
 | NeoBot 提示"连接超时，请确保 OneBot 框架已启动并配置了反向 WebSocket 连接" | NapCat 未启用「WebSocket 客户端」；URL/端口写错；或跨机时防火墙未放行 8080 |
 | NapCat 里连接一直失败/断开 | 确认 NeoBot 正在运行（它是 WS 服务端）；确认端口与 `reverse_ws_port` / `NEO_BOT_ADAPTER_PORT` 一致 |
 | 端口被占用 | 改 `reverse_ws_port`（或环境变量），NapCat 的 URL 同步修改 |
+| 日志出现「反向 WebSocket 握手被拒绝：access token 缺失或不匹配」 | NeoBot 配了 `reverse_ws_access_token` 但 NapCat 侧 Token 为空或不一致；两端填同一个值，或把 NeoBot 的该配置清空 |
 | 能连上但不回复 | 看启动日志是否有「当前主回复模型不可用」，检查 `.env` 的 `_URL` / `_APIKey` |
 | 外网访问网页面板失败 | 放行系统/云防火墙中的实际面板端口（占用时最多向后尝试 10 个，见启动日志告警）；Windows 可执行 `neobot firewall-open`（需管理员） |
 

--- a/packages/adapter/src/neobot_adapter/factory.py
+++ b/packages/adapter/src/neobot_adapter/factory.py
@@ -22,6 +22,8 @@ class AdapterSettings:
     # onebot 反向 WebSocket 服务端监听(空/0 表示未配置,回退环境变量与默认值)
     reverse_ws_host: str = ""
     reverse_ws_port: int = 0
+    # 反向 WebSocket 握手鉴权的 access token(OneBot 11 规范;留空表示不校验)
+    reverse_ws_access_token: str = ""
 
 
 def create_adapter(
@@ -40,6 +42,7 @@ def create_adapter(
             packet_callback=packet_callback,
             host=cfg.reverse_ws_host or None,
             port=cfg.reverse_ws_port if cfg.reverse_ws_port else None,
+            access_token=cfg.reverse_ws_access_token,
         )
     if mode == "local":
         return LocalAdapter(
@@ -69,4 +72,7 @@ def _coerce_settings(settings: AdapterSettings | Any | None) -> AdapterSettings:
         bot_name=str(getattr(settings, "bot_name", "Neo Bot") or "Neo Bot"),
         reverse_ws_host=str(getattr(settings, "reverse_ws_host", "") or ""),
         reverse_ws_port=int(getattr(settings, "reverse_ws_port", 0) or 0),
+        reverse_ws_access_token=str(
+            getattr(settings, "reverse_ws_access_token", "") or ""
+        ),
     )

--- a/packages/adapter/src/neobot_adapter/local/server.py
+++ b/packages/adapter/src/neobot_adapter/local/server.py
@@ -4,6 +4,11 @@ from typing import Any
 
 from aiohttp import web
 
+from neobot_adapter.utils.logger import get_module_logger
+from neobot_adapter.utils.net import is_loopback_host
+
+logger = get_module_logger("adapter_local")
+
 
 class LocalAdapterServer:
     def __init__(
@@ -69,6 +74,14 @@ class LocalAdapterServer:
         self._app.router.add_post("/v1/test/group-requests", self._handle_test_group_request)
         self._app.router.add_post("/v1/test/notices", self._handle_test_notice)
         self._app.router.add_get("/ws", self._core.websocket_handler)
+        if not self._auth_token and not is_loopback_host(self._host):
+            logger.warning(
+                "本地适配器未配置 auth_token 且监听非回环地址 "
+                f"({self._host}:{self._port})：该网段内任何主机都能调用 /v1/send、"
+                "/v1/actions/* 与 /v1/test/* 接口驱动机器人。"
+                "请配置 [adapter].local_auth_token（或 NEOBOT_LOCAL_ADAPTER_TOKEN），"
+                "或把 local_host 改回 127.0.0.1。"
+            )
         self._runner = web.AppRunner(self._app)
         await self._runner.setup()
         self._site = web.TCPSite(self._runner, self._host, self._port)

--- a/packages/adapter/src/neobot_adapter/onebot/adapter.py
+++ b/packages/adapter/src/neobot_adapter/onebot/adapter.py
@@ -32,6 +32,7 @@ class OneBotAdapter:
         packet_callback: Callable[[Dict[str, Any]], None] | None = None,
         host: Optional[str] = None,
         port: Optional[int] = None,
+        access_token: str = "",
     ) -> None:
         self._logger: Logger = logger if logger is not None else NullLogger()
         self._core = AdapterCore(
@@ -39,6 +40,7 @@ class OneBotAdapter:
             packet_callback=packet_callback,
             host=host,
             port=port,
+            access_token=access_token,
         )
         self._dispatcher = EventDispatcher(self._logger)
         self._dispatch_task: Optional[asyncio.Task[None]] = None

--- a/packages/adapter/src/neobot_adapter/onebot/receiver/core.py
+++ b/packages/adapter/src/neobot_adapter/onebot/receiver/core.py
@@ -1,10 +1,13 @@
 import asyncio
+import hmac
 import json
 import os
 import queue
 import threading
 import time
+from http import HTTPStatus
 from typing import Any, Callable, Iterator, Optional
+from urllib.parse import parse_qs, urlparse
 
 import websockets
 from websockets.exceptions import ConnectionClosed, ConnectionClosedError
@@ -27,6 +30,43 @@ def _env_ci(name: str) -> str | None:
     for key, value in os.environ.items():
         if key.casefold() == target:
             return value
+    return None
+
+
+def _is_loopback_host(host: str) -> bool:
+    """监听地址是否仅限本机（用于「未配置 token 且对外监听」的告警）。"""
+    normalized = str(host or "").strip().casefold()
+    if normalized in {"127.0.0.1", "localhost", "::1", "0:0:0:0:0:0:0:1"}:
+        return True
+    return normalized.startswith("127.")
+
+
+def _extract_access_token(headers: Any, path: str) -> Optional[str]:
+    """按 OneBot 11 鉴权规范从握手中取出 access token。
+
+    反向 WebSocket 由框架（客户端）在握手请求头里带
+    ``Authorization: Bearer <access_token>``；同时兼容 query 参数
+    ``?access_token=``（规范对 HTTP / 正向 WebSocket 给出的兜底形式，
+    部分框架对反向 WS 也只提供填 URL 的入口）。
+    """
+    authorization = None
+    if headers is not None:
+        try:
+            authorization = headers.get("Authorization")
+        except Exception:
+            authorization = None
+    if authorization:
+        parts = str(authorization).split(None, 1)
+        if len(parts) == 2 and parts[0].casefold() == "bearer":
+            return parts[1].strip()
+        # 宽容处理只填 token、未带 Bearer 前缀的框架
+        return str(authorization).strip()
+
+    raw_path = str(path or "")
+    if "?" in raw_path:
+        values = parse_qs(urlparse(raw_path).query).get("access_token") or []
+        if values and str(values[0]).strip():
+            return str(values[0]).strip()
     return None
 
 
@@ -54,6 +94,7 @@ class AdapterCore:
         packet_callback: Callable[[dict[str, Any]], None] | None = None,
         host: str | None = None,
         port: int | None = None,
+        access_token: str = "",
     ):
         """初始化适配器核心
 
@@ -64,9 +105,12 @@ class AdapterCore:
                   缺省 0.0.0.0
             port: 反向 WebSocket 监听端口；None 时读环境变量 NEO_BOT_ADAPTER_PORT，
                   缺省 8080
+            access_token: 反向 WebSocket 握手鉴权的 access token（OneBot 11 规范）。
+                  留空表示不校验（与历史行为一致）
         """
         self.host = host
         self.port = port
+        self.access_token = str(access_token or "").strip()
         self.loop: Optional[asyncio.AbstractEventLoop] = None
         self.thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
@@ -211,14 +255,30 @@ class AdapterCore:
             )
             port = int(env_port) if env_port else 8080
         self._async_stop_event = asyncio.Event()
-        # 监听指定路径 /onebot；10MiB 帧上限以容纳 base64 大图等超 1MiB 默认上限的负载
+        if not self.access_token and not _is_loopback_host(host):
+            logger.warning(
+                "反向 WebSocket 未配置 access token 且监听非回环地址 "
+                f"({host}:{port})：该网段内任何主机都能连入并注入伪造事件。"
+                "请在 [adapter].reverse_ws_access_token 与 OneBot 框架反向 WS 的 "
+                "token 中填入同一个值。"
+            )
+        # 路径（文档约定 /onebot）由框架自己配置，服务端不限制；
+        # 10MiB 帧上限以容纳 base64 大图等超 1MiB 默认上限的负载。
+        serve_kwargs: dict[str, Any] = {"max_size": 10 * 2**20}
+        if self.access_token:
+            # OneBot 11 鉴权：反向 WebSocket 由框架（客户端）在握手请求头中
+            # 携带 Authorization: Bearer <access_token>，服务端在此校验。
+            serve_kwargs["process_request"] = self._authorize_handshake
         server = await websockets.serve(
             self._handle_client,
             host,
             port,
-            max_size=10 * 2**20,
+            **serve_kwargs,
         )
-        logger.info(f"反向 WebSocket 服务运行于 ws://{host}:{port}")
+        logger.info(
+            f"反向 WebSocket 服务运行于 ws://{host}:{port}"
+            f"（access token 校验：{'已启用' if self.access_token else '未启用'}）"
+        )
         try:
             if not self._stop_event.is_set():
                 await self._async_stop_event.wait()
@@ -255,6 +315,41 @@ class AdapterCore:
                 logger.warning(f"服务器关闭异常: {exc}")
             self.active_connections.clear()
             self._connection_established.clear()
+
+    async def _authorize_handshake(self, *args: Any) -> Any:
+        """反向 WebSocket 握手鉴权（OneBot 11 规范的 access token 校验）。
+
+        仅在本端配置了 access token 时注册为 ``process_request`` 钩子；
+        未配置时连接行为与历史版本完全一致。
+
+        兼容 websockets 两代 API：
+        - 新版 asyncio 实现：``process_request(connection, request)``
+          拒绝时返回 ``connection.respond(...)``；
+        - 旧版 legacy 实现：``process_request(path, request_headers)``
+          拒绝时返回 ``(status, headers, body)``。
+        """
+        if not self.access_token:
+            return None
+
+        connection: Any = None
+        headers: Any = None
+        path = ""
+        if len(args) == 2 and hasattr(args[1], "headers"):
+            connection, request = args
+            headers = request.headers
+            path = getattr(request, "path", "") or ""
+        else:
+            path = args[0] if args else ""
+            headers = args[1] if len(args) > 1 else None
+
+        supplied = _extract_access_token(headers, path)
+        if supplied is not None and hmac.compare_digest(supplied, self.access_token):
+            return None
+
+        logger.warning("反向 WebSocket 握手被拒绝：access token 缺失或不匹配")
+        if connection is not None:
+            return connection.respond(HTTPStatus.UNAUTHORIZED, "unauthorized\n")
+        return (HTTPStatus.UNAUTHORIZED, [], b"unauthorized\n")
 
     async def _handle_client(self, websocket):
         logger.info("框架已连接")

--- a/packages/adapter/src/neobot_adapter/onebot/receiver/core.py
+++ b/packages/adapter/src/neobot_adapter/onebot/receiver/core.py
@@ -14,6 +14,7 @@ from websockets.exceptions import ConnectionClosed, ConnectionClosedError
 
 from neobot_adapter.model.meta_event import Heartbeat, LifeCycle, LifeCycleSubType
 from neobot_adapter.utils.logger import get_module_logger
+from neobot_adapter.utils.net import is_loopback_host
 from neobot_adapter.utils.parse import safe_parse_model
 
 logger = get_module_logger("adapter_receiver")
@@ -31,14 +32,6 @@ def _env_ci(name: str) -> str | None:
         if key.casefold() == target:
             return value
     return None
-
-
-def _is_loopback_host(host: str) -> bool:
-    """监听地址是否仅限本机（用于「未配置 token 且对外监听」的告警）。"""
-    normalized = str(host or "").strip().casefold()
-    if normalized in {"127.0.0.1", "localhost", "::1", "0:0:0:0:0:0:0:1"}:
-        return True
-    return normalized.startswith("127.")
 
 
 def _extract_access_token(headers: Any, path: str) -> Optional[str]:
@@ -255,7 +248,7 @@ class AdapterCore:
             )
             port = int(env_port) if env_port else 8080
         self._async_stop_event = asyncio.Event()
-        if not self.access_token and not _is_loopback_host(host):
+        if not self.access_token and not is_loopback_host(host):
             logger.warning(
                 "反向 WebSocket 未配置 access token 且监听非回环地址 "
                 f"({host}:{port})：该网段内任何主机都能连入并注入伪造事件。"

--- a/packages/adapter/src/neobot_adapter/utils/net.py
+++ b/packages/adapter/src/neobot_adapter/utils/net.py
@@ -1,0 +1,17 @@
+"""网络地址工具。"""
+
+from __future__ import annotations
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "0:0:0:0:0:0:0:1"})
+
+
+def is_loopback_host(host: str) -> bool:
+    """判断监听地址是否仅限本机。
+
+    用于「未配置鉴权 token 却对外监听」的启动告警：这类配置下同网段的任何
+    主机都能连入并注入伪造事件。
+    """
+    normalized = str(host or "").strip().casefold()
+    if normalized in _LOOPBACK_HOSTS:
+        return True
+    return normalized.startswith("127.")

--- a/packages/modloader/src/neobot_modloader/dependencies.py
+++ b/packages/modloader/src/neobot_modloader/dependencies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 import subprocess
@@ -8,6 +9,24 @@ from dataclasses import dataclass
 from typing import Callable, Sequence
 
 from neobot_contracts.ports.logging import Logger, NullLogger
+
+#: pip 安装超时（秒）：避免插件依赖安装无限期挂住调用方
+INSTALL_TIMEOUT_SECONDS = 600
+
+
+def _is_valid_requirement(item: str) -> bool:
+    """插件声明的依赖条目必须是普通需求串，不能是 pip 选项。
+
+    历史上这些字符串会被直接拼进 ``pip install`` 的 argv，于是
+    ``--index-url=https://evil/simple``、``-r other.txt`` 这类条目会被 pip
+    当成选项解析（依赖混淆 / 任意包源 / 读任意文件）。这里做结构性拦截：
+    拒绝以 ``-`` 开头、含空白或首尾有空白的条目。
+    """
+    if not item or item != item.strip():
+        return False
+    if item.startswith("-"):
+        return False
+    return not any(char.isspace() for char in item)
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,10 +44,58 @@ class PythonDependencyInstaller:
         self._logger = logger or NullLogger()
         self._input = input_func or input
 
-    def confirm_and_install(self, requirements: Sequence[str]) -> PythonDependencyInstallResult:
+    # ── 对外入口 ────────────────────────────────────────────────────
+
+    async def confirm_and_install(
+        self, requirements: Sequence[str]
+    ) -> PythonDependencyInstallResult:
+        """异步入口：等待用户确认并安装。
+
+        整个流程（等输入、探测 pip、执行 pip）都在工作线程完成——调用方位于
+        事件循环中（面板安装/热重载插件），同步的 ``input()`` 与
+        ``subprocess.run`` 会把整个 Bot 卡住。
+        """
+        return await asyncio.to_thread(self._install_flow, tuple(requirements))
+
+    def confirm_and_install_sync(
+        self, requirements: Sequence[str]
+    ) -> PythonDependencyInstallResult:
+        """同步入口：**仅供启动装配期使用**。
+
+        启动路径（``PluginRuntime.load_all``）本身是同步装配代码，调用点还没有
+        需要并发服务的任务；无交互终端时会直接跳过（不再抛 EOFError 冲掉启动）。
+        线上运行期请使用 ``confirm_and_install``，不要用本方法阻塞事件循环。
+        """
+        return self._install_flow(tuple(requirements))
+
+    # ── 实现 ────────────────────────────────────────────────────────
+
+    def _install_flow(
+        self, requirements: Sequence[str]
+    ) -> PythonDependencyInstallResult:
         unique = tuple(dict.fromkeys(str(item).strip() for item in requirements if str(item).strip()))
         if not unique:
             return PythonDependencyInstallResult(requirements=(), installed=False)
+
+        invalid = tuple(item for item in unique if not _is_valid_requirement(item))
+        if invalid:
+            self._logger.error(f"插件依赖条目非法，已拒绝安装: {', '.join(invalid)}")
+            return PythonDependencyInstallResult(
+                requirements=unique,
+                installed=False,
+                stderr="非法的依赖条目：不接受 pip 选项、含空白的字符串",
+            )
+
+        if not self._interactive():
+            self._logger.warning(
+                "当前环境没有可交互终端，跳过插件 PyPI 依赖安装"
+                f"（缺失: {', '.join(unique)}）"
+            )
+            return PythonDependencyInstallResult(
+                requirements=unique,
+                installed=False,
+                stderr="no interactive terminal",
+            )
 
         prompt = "检测到插件需要安装以下 PyPI 依赖：\n"
         prompt += "\n".join(f"  - {requirement}" for requirement in unique)
@@ -41,7 +108,18 @@ class PythonDependencyInstaller:
         command = self._install_command(unique)
         self._logger.info(f"正在安装插件 PyPI 依赖: {' '.join(unique)}")
         self._logger.info(f"安装命令: {' '.join(command)}")
-        completed = subprocess.run(command, capture_output=True, text=True, encoding="utf-8", check=False)
+        try:
+            completed = self._run_command(command)
+        except subprocess.TimeoutExpired:
+            self._logger.error(
+                f"插件 PyPI 依赖安装超时（>{INSTALL_TIMEOUT_SECONDS}s），已放弃"
+            )
+            return PythonDependencyInstallResult(
+                requirements=unique,
+                installed=False,
+                stderr=f"安装超时（>{INSTALL_TIMEOUT_SECONDS}s）",
+                command=tuple(command),
+            )
         if completed.returncode != 0:
             self._logger.error(f"插件 PyPI 依赖安装失败: {completed.stderr}")
             return PythonDependencyInstallResult(
@@ -61,6 +139,23 @@ class PythonDependencyInstaller:
             command=tuple(command),
         )
 
+    def _interactive(self) -> bool:
+        """是否可以安全地向用户提问（无 tty 时提问会抛 EOFError 或永久阻塞）。"""
+        try:
+            return bool(sys.stdin is not None and sys.stdin.isatty())
+        except Exception:
+            return False
+
+    def _run_command(self, command: list[str]) -> "subprocess.CompletedProcess[str]":
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+            timeout=INSTALL_TIMEOUT_SECONDS,
+        )
+
     def _install_command(self, requirements: tuple[str, ...]) -> list[str]:
         if self._running_under_uv() and shutil.which("uv") is not None:
             return ["uv", "pip", "install", *requirements]
@@ -75,9 +170,17 @@ class PythonDependencyInstaller:
         return "UV" in os.environ or "uv" in os.environ.get("VIRTUAL_ENV", "").casefold() or executable.startswith("uv")
 
     def _python_has_pip(self) -> bool:
-        return subprocess.run(
-            [sys.executable, "-m", "pip", "--version"],
-            capture_output=True,
-            text=True, encoding="utf-8",
-            check=False,
-        ).returncode == 0
+        # 探测失败（无 pip / 超时 / 无法启动）都按「没有 pip」处理：
+        # 这个探测本身不该把异常抛给插件加载流程。
+        try:
+            completed = subprocess.run(
+                [sys.executable, "-m", "pip", "--version"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return completed.returncode == 0

--- a/packages/modloader/src/neobot_modloader/hooks.py
+++ b/packages/modloader/src/neobot_modloader/hooks.py
@@ -6,6 +6,7 @@ import inspect
 import io
 import threading
 from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any, get_type_hints
 
@@ -299,18 +300,91 @@ class PluginHookBus:
             return None
 
 
-@contextlib.contextmanager
-def _capture_output(output: OutputPort, *, source: str, target: str | None = None):
-    stdout = io.StringIO()
-    stderr = io.StringIO()
-    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-        yield
+# ── 输出捕获：按任务上下文路由，避免进程级重定向跨 await 串台 ──
+
+_CAPTURE_STDOUT: ContextVar[io.StringIO | None] = ContextVar(
+    "plugin_capture_stdout", default=None
+)
+_CAPTURE_STDERR: ContextVar[io.StringIO | None] = ContextVar(
+    "plugin_capture_stderr", default=None
+)
+
+
+class _ContextRoutedStream:
+    """按 contextvars 路由 write 的 stdout/stderr 代理。
+
+    ``contextlib.redirect_stdout`` 换掉的是**进程级** ``sys.stdout``，而插件
+    钩子是并发 await 的：某个任务进入捕获后，其它任务（含宿主的日志/print）
+    都会写进它的缓冲区，输出被记到别的插件名下；更糟的是异常退出顺序不巧时
+    ``sys.stdout`` 会被还原成已失效的 StringIO，此后进程所有 print 静默丢失。
+    这里改为「安装一次代理 + 按任务上下文路由」，各任务互不干扰。
+    """
+
+    def __init__(self, fallback: Any, variable: ContextVar) -> None:
+        self._fallback = fallback
+        self._variable = variable
+
+    def write(self, data: str) -> int:
+        sink = self._variable.get()
+        if sink is not None:
+            return sink.write(data)
+        return self._fallback.write(data)
+
+    def flush(self) -> None:
+        if self._variable.get() is None:
+            self._fallback.flush()
+
+    def __getattr__(self, item: str) -> Any:
+        # 其余属性（encoding / isatty / fileno …）透传给原始流
+        return getattr(self._fallback, item)
+
+
+def _install_context_routed_streams() -> None:
+    """确保 sys.stdout/sys.stderr 是上下文路由代理（可重复调用）。"""
+    import sys
+
+    if not isinstance(sys.stdout, _ContextRoutedStream):
+        sys.stdout = _ContextRoutedStream(sys.stdout, _CAPTURE_STDOUT)
+    if not isinstance(sys.stderr, _ContextRoutedStream):
+        sys.stderr = _ContextRoutedStream(sys.stderr, _CAPTURE_STDERR)
+
+
+def _emit_captured(
+    output: OutputPort,
+    *,
+    source: str,
+    target: str | None,
+    stdout: io.StringIO,
+    stderr: io.StringIO,
+) -> None:
     stdout_text = stdout.getvalue().strip()
     stderr_text = stderr.getvalue().strip()
-    if stdout_text:
-        output.write(stdout_text, source=source, target=target)
-    if stderr_text:
-        output.error(stderr_text, source=source, target=target)
+    try:
+        if stdout_text:
+            output.write(stdout_text, source=source, target=target)
+        if stderr_text:
+            output.error(stderr_text, source=source, target=target)
+    except Exception:
+        # 上报失败不能影响钩子调用链本身
+        pass
+
+
+@contextlib.contextmanager
+def _capture_output(output: OutputPort, *, source: str, target: str | None = None):
+    _install_context_routed_streams()
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    token_out = _CAPTURE_STDOUT.set(stdout)
+    token_err = _CAPTURE_STDERR.set(stderr)
+    try:
+        yield
+    finally:
+        _CAPTURE_STDOUT.reset(token_out)
+        _CAPTURE_STDERR.reset(token_err)
+        # 在 finally 里上报：处理器抛异常时也不丢已经产生的输出
+        _emit_captured(
+            output, source=source, target=target, stdout=stdout, stderr=stderr
+        )
 
 
 def _extract_event_model(handler: EventHandler) -> type[BaseModel] | None:

--- a/packages/modloader/src/neobot_modloader/hooks.py
+++ b/packages/modloader/src/neobot_modloader/hooks.py
@@ -328,10 +328,20 @@ class _ContextRoutedStream:
         sink = self._variable.get()
         if sink is not None:
             return sink.write(data)
+        if self._fallback is None:
+            # pythonw / PyInstaller --noconsole 等无控制台环境里 sys.stdout 是
+            # None，CPython 对它的 print() 本来是静默 no-op；代理若不判空，
+            # 就会把整个进程的 print 变成 AttributeError。
+            return len(data)
         return self._fallback.write(data)
 
+    def writelines(self, lines: Any) -> None:
+        # 不实现的话会经 __getattr__ 直通真实流，捕获窗口内也拿不到输出。
+        for line in lines:
+            self.write(line)
+
     def flush(self) -> None:
-        if self._variable.get() is None:
+        if self._variable.get() is None and self._fallback is not None:
             self._fallback.flush()
 
     def __getattr__(self, item: str) -> Any:

--- a/packages/modloader/src/neobot_modloader/loading/models.py
+++ b/packages/modloader/src/neobot_modloader/loading/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 

--- a/packages/modloader/src/neobot_modloader/management.py
+++ b/packages/modloader/src/neobot_modloader/management.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 

--- a/packages/modloader/src/neobot_modloader/manager.py
+++ b/packages/modloader/src/neobot_modloader/manager.py
@@ -498,9 +498,38 @@ class DefaultPluginManager:
             self._cleanup_callbacks(record, collected, baseline)
             self._unsubscribe_all(record, collected, baseline)
             await self._cleanup_agents(record, collected, baseline)
+            await self._close_plugin_databases(record, collected, baseline)
         finally:
             record._teardown_depth -= 1
         return collected
+
+    async def _close_plugin_databases(
+        self,
+        record: PluginRecord,
+        errors: list[Exception],
+        cancellation_baseline: int,
+    ) -> None:
+        """关闭插件声明的数据库引擎。
+
+        on_stop 是唯一的关闭入口，而插件处于 ERROR 状态时 _stop_plugin_locked
+        会跳过 on_stop（callback_needed 只认 LOADED/RUNNING）：声明了数据库的
+        插件若在 on_load/on_start 阶段失败，引擎会一直挂着，Windows 上持续
+        锁住插件数据库文件。这里纳入统一的 teardown，覆盖全部失败路径。
+        """
+        close_databases = getattr(record.plugin, "close_databases", None)
+        if not callable(close_databases):
+            return
+        try:
+            await self._maybe_await(close_databases())
+        except asyncio.CancelledError as exc:
+            error = _cancelled_failure(f"插件数据库关闭被取消 ({record.name})", exc)
+            errors.append(error)
+            self._logger.exception(f"插件数据库关闭失败 ({record.name}): {exc}")
+            if _cancellation_requested_since(cancellation_baseline):
+                raise
+        except Exception as exc:
+            errors.append(exc)
+            self._logger.exception(f"插件数据库关闭失败 ({record.name}): {exc}")
 
     def _unsubscribe_all(
         self,

--- a/packages/modloader/src/neobot_modloader/plugin.py
+++ b/packages/modloader/src/neobot_modloader/plugin.py
@@ -339,16 +339,34 @@ class Plugin:
                 except Exception as exc:
                     errors.append(exc)
         finally:
-            for database in self._databases.values():
-                try:
-                    await database.close()
-                except Exception as exc:
-                    errors.append(exc)
-            self._bound = False
+            try:
+                await self.close_databases()
+            except Exception as exc:
+                errors.append(exc)
         if len(errors) == 1:
             raise errors[0]
         if errors:
             raise ExceptionGroup("插件关闭处理器执行失败", errors)
+
+    async def close_databases(self) -> None:
+        """关闭本插件声明的全部数据库引擎（可重复调用，幂等）。
+
+        独立成方法是为了覆盖 **ERROR 路径**：插件在 on_load/on_start 阶段失败时
+        manager 会跳过 on_stop，若关闭只写在 on_stop 里，引擎就会一直挂着
+        （Windows 上锁住数据库文件，导致重装/升级失败）。同时复位 ``_bound``，
+        保证后续重载会重新绑定数据库与处理器。
+        """
+        errors: list[Exception] = []
+        for database in self._databases.values():
+            try:
+                await database.close()
+            except Exception as exc:
+                errors.append(exc)
+        self._bound = False
+        if len(errors) == 1:
+            raise errors[0]
+        if errors:
+            raise ExceptionGroup("插件数据库关闭失败", errors)
 
     async def _load(self, context: Any) -> None:
         self._context = context

--- a/packages/modloader/src/neobot_modloader/runtime.py
+++ b/packages/modloader/src/neobot_modloader/runtime.py
@@ -578,7 +578,9 @@ class PluginRuntime:
                 if isinstance(item, DiscoveredPlugin) and item.name == name:
                     missing.extend(item.missing_python_dependencies)
             if missing:
-                self.dependency_installer.confirm_and_install(missing)
+                # 热重载发生在运行期：必须 await（内部走线程），否则等待用户
+                # 输入与 pip 子进程会阻塞事件循环
+                await self.dependency_installer.confirm_and_install(missing)
 
         result = self.loader.load_one(plugin_path)
         if result is None:
@@ -1215,7 +1217,8 @@ class PluginRuntime:
             if isinstance(result, DiscoveredPlugin) and result.enabled:
                 missing.extend(result.missing_python_dependencies)
         if missing:
-            self.dependency_installer.confirm_and_install(missing)
+            # 启动装配期的同步入口：无交互终端时内部直接跳过，不再抛 EOFError
+            self.dependency_installer.confirm_and_install_sync(missing)
 
     async def _activate_loaded_plugin(
         self,
@@ -1226,7 +1229,8 @@ class PluginRuntime:
     ) -> PluginOperationResult:
         missing = list(missing_python_dependencies(loaded.python_dependencies))
         if missing and auto_install_dependencies:
-            self.dependency_installer.confirm_and_install(missing)
+            # 面板「安装/重载插件」会走到这里，必须 await 线程化的安装流程
+            await self.dependency_installer.confirm_and_install(missing)
             missing = list(missing_python_dependencies(loaded.python_dependencies))
         if missing:
             self.logger.error(f"插件加载失败 ({loaded.name}): 缺少 PyPI 依赖: {', '.join(missing)}")

--- a/packages/modloader/src/neobot_modloader/runtime.py
+++ b/packages/modloader/src/neobot_modloader/runtime.py
@@ -200,14 +200,12 @@ class PluginRuntime:
                     else None
                 )
                 if incompatible is not None:
-                    results.append(
-                        PluginLoadError(
-                            name=result.name,
-                            plugin_dir=result.plugin_dir,
-                            error=ValueError(incompatible),
-                        )
-                    )
-                    continue
+                    # 不做成 PluginLoadError：面板的「停用 / 重载 / 卸载」与
+                    # plugin_source 都依赖 discover 结果，把它替换成错误条目会让
+                    # 这些操作报「插件未找到」，来源也被误判成第三方。这里保留
+                    # 条目（面板仍能看到、能停用/卸载），真实原因记日志；加载路径
+                    # （load_all / 面板安装）依旧会拒绝。
+                    self.logger.error(f"插件不兼容当前 NeoBot 版本: {incompatible}")
                 if result.source == OFFICIAL_SOURCE:
                     official_names.add(result.name)
                 elif result.name in official_names:

--- a/packages/modloader/src/neobot_modloader/runtime.py
+++ b/packages/modloader/src/neobot_modloader/runtime.py
@@ -36,6 +36,7 @@ from neobot_modloader.management import PluginControlFacade, PluginOperationResu
 from neobot_modloader.manager import DefaultPluginManager, ReentrantLock
 from neobot_modloader.plugins.registration import validate_plugin_name
 from neobot_modloader.state import PluginStateStore
+from neobot_modloader.version import version_at_least
 
 OfficialConfigProvider = Callable[[str], "Mapping[str, Any] | None"]
 
@@ -84,10 +85,13 @@ class PluginRuntime:
         official_config_provider: OfficialConfigProvider | None = None,
         installer: PluginInstaller | None = None,
         user_plugins_enabled: bool = True,
+        host_version: str | None = None,
     ) -> None:
         self.plugin_dir = plugin_dir.resolve()
         self.data_dir = data_dir.resolve()
         self.user_plugins_enabled = bool(user_plugins_enabled)
+        #: 当前 NeoBot 版本，用于校验插件声明的 min_neobot_version（None 跳过检查）
+        self.host_version = host_version
         self._official_dirs = tuple(
             Path(path).resolve() for path in (builtin_plugin_dirs or ())
         )
@@ -162,6 +166,26 @@ class PluginRuntime:
             directories.append((self.plugin_dir, self.loader))
         return directories
 
+    def _host_version_error(self, name: str, minimum: str | None) -> str | None:
+        """插件声明的 min_neobot_version 高于当前版本时返回错误文本。
+
+        这个字段以前只被解析、随插件元数据一路传递，从来没有被比较过：
+        插件写着 ``min_neobot_version = "9.0"`` 也会照常加载，然后在调用
+        运行时不存在的 API 时炸掉。
+        """
+        if not minimum:
+            return None
+        satisfied = version_at_least(self.host_version, minimum)
+        if satisfied is None:
+            self.logger.warning(
+                f"无法比较 NeoBot 版本，已跳过最低版本检查 ({name}): "
+                f"要求 {minimum}, 当前 {self.host_version or '未知'}"
+            )
+            return None
+        if satisfied:
+            return None
+        return f"插件要求 NeoBot >= {minimum}，当前为 {self.host_version or '未知'}"
+
     def discover_all(self) -> list[DiscoveredPlugin | PluginLoadError]:
         results: list[DiscoveredPlugin | PluginLoadError] = []
         official_names: set[str] = set()
@@ -169,6 +193,20 @@ class PluginRuntime:
             for result in loader.discover_all(directory):
                 if isinstance(result, PluginLoadError):
                     results.append(result)
+                    continue
+                incompatible = (
+                    self._host_version_error(result.name, result.min_neobot_version)
+                    if result.enabled
+                    else None
+                )
+                if incompatible is not None:
+                    results.append(
+                        PluginLoadError(
+                            name=result.name,
+                            plugin_dir=result.plugin_dir,
+                            error=ValueError(incompatible),
+                        )
+                    )
                     continue
                 if result.source == OFFICIAL_SOURCE:
                     official_names.add(result.name)
@@ -234,6 +272,14 @@ class PluginRuntime:
                 if missing:
                     error_count += 1
                     self.logger.error(f"插件加载跳过 ({result.name}): 缺少 PyPI 依赖: {', '.join(missing)}")
+                    self.loader.clear_module_cache(result.module_names)
+                    continue
+                incompatible = self._host_version_error(
+                    result.name, result.min_neobot_version
+                )
+                if incompatible is not None:
+                    error_count += 1
+                    self.logger.error(f"插件加载跳过 ({result.name}): {incompatible}")
                     self.loader.clear_module_cache(result.module_names)
                     continue
                 if self._register(result):
@@ -1240,6 +1286,18 @@ class PluginRuntime:
                 name=loaded.name,
                 state=PluginState.ERROR.value,
                 error=f"缺少 PyPI 依赖: {', '.join(missing)}",
+                path=self._path_for_loaded(loaded),
+            )
+
+        incompatible = self._host_version_error(loaded.name, loaded.min_neobot_version)
+        if incompatible is not None:
+            self.logger.error(f"插件加载失败 ({loaded.name}): {incompatible}")
+            self.loader.clear_module_cache(loaded.module_names)
+            return PluginOperationResult(
+                ok=False,
+                name=loaded.name,
+                state=PluginState.ERROR.value,
+                error=incompatible,
                 path=self._path_for_loaded(loaded),
             )
 

--- a/packages/modloader/src/neobot_modloader/version.py
+++ b/packages/modloader/src/neobot_modloader/version.py
@@ -1,0 +1,59 @@
+"""插件声明的最低 NeoBot 版本比较。
+
+``plugin.toml`` / ``Plugin(min_neobot_version=...)`` 声明的是「需要 NeoBot
+不低于某版本」。这里只做数字段比较，不引入额外依赖：``1.2.3``、``v1.2``、
+``1.2.3-beta.1`` 都能解析（预发布后缀忽略，按 ``1.2.3`` 处理）。
+"""
+
+from __future__ import annotations
+
+import re
+
+_VERSION_RE = re.compile(r"^[vV]?(\d+(?:\.\d+)*)")
+
+
+def parse_version(value: str | None) -> tuple[int, ...] | None:
+    """解析版本号为数字元组；无法解析时返回 None。"""
+    text = str(value or "").strip()
+    match = _VERSION_RE.match(text)
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def version_at_least(host: str | None, minimum: str | None) -> bool | None:
+    """判断 ``host`` 是否不低于 ``minimum``。
+
+    Returns:
+        True/False 表示可比较的结果；任一版本无法解析时返回 None（调用方
+        应跳过检查并记录告警，而不是拒绝加载）。
+    """
+    host_parts = parse_version(host)
+    minimum_parts = parse_version(minimum)
+    if host_parts is None or minimum_parts is None:
+        return None
+    if not any(host_parts):
+        # 源码方式运行时 importlib.metadata 取不到发行版本，回落成 0.0.0；
+        # 把它当「未知版本」，跳过检查而不是把插件全判成过旧。
+        return None
+    size = max(len(host_parts), len(minimum_parts))
+    padded_host = host_parts + (0,) * (size - len(host_parts))
+    padded_minimum = minimum_parts + (0,) * (size - len(minimum_parts))
+    return padded_host >= padded_minimum
+
+
+def incompatible_version_error(
+    *,
+    name: str,
+    host: str | None,
+    minimum: str | None,
+) -> str | None:
+    """返回不满足最低版本时的错误文本；满足或无法比较时返回 None。"""
+    if not minimum:
+        return None
+    satisfied = version_at_least(host, minimum)
+    if satisfied is None:
+        return None
+    if satisfied:
+        return None
+    return f"插件 {name} 要求 NeoBot >= {minimum}，当前为 {host or '未知'}"

--- a/packages/modloader/tests/test_dependencies.py
+++ b/packages/modloader/tests/test_dependencies.py
@@ -11,6 +11,7 @@ class FakeLogger:
     def __init__(self) -> None:
         self.infos: list[str] = []
         self.errors: list[str] = []
+        self.warnings: list[str] = []
 
     def info(self, message: str) -> None:
         self.infos.append(message)
@@ -18,20 +19,30 @@ class FakeLogger:
     def error(self, message: str) -> None:
         self.errors.append(message)
 
+    def warning(self, message: str) -> None:
+        self.warnings.append(message)
+
+
+def _interactive(installer: PythonDependencyInstaller):
+    """让安装流程认为当前有交互终端（单测里 stdin 不是 tty）。"""
+    return patch.object(installer, "_interactive", return_value=True)
+
 
 class PythonDependencyInstallerTest(unittest.TestCase):
+    """同步入口（启动装配期使用）。"""
+
     def test_rejecting_prompt_does_not_install(self) -> None:
         installer = PythonDependencyInstaller(input_func=lambda prompt: "n")
-        with patch("subprocess.run") as run:
-            result = installer.confirm_and_install(["requests>=2"])
+        with _interactive(installer), patch("subprocess.run") as run:
+            result = installer.confirm_and_install_sync(["requests>=2"])
         self.assertFalse(result.installed)
         run.assert_not_called()
 
     def test_accepting_prompt_runs_pip(self) -> None:
         installer = PythonDependencyInstaller(input_func=lambda prompt: "y")
         completed = subprocess.CompletedProcess(["python"], 0, stdout="ok", stderr="")
-        with patch("subprocess.run", return_value=completed) as run:
-            result = installer.confirm_and_install(["requests>=2", "requests>=2"])
+        with _interactive(installer), patch("subprocess.run", return_value=completed) as run:
+            result = installer.confirm_and_install_sync(["requests>=2", "requests>=2"])
         self.assertTrue(result.installed)
         self.assertEqual(result.requirements, ("requests>=2",))
         args = run.call_args.args[0]
@@ -42,8 +53,8 @@ class PythonDependencyInstallerTest(unittest.TestCase):
     def test_failed_install_returns_error_result(self) -> None:
         installer = PythonDependencyInstaller(input_func=lambda prompt: "yes")
         completed = subprocess.CompletedProcess(["python"], 1, stdout="", stderr="boom")
-        with patch("subprocess.run", return_value=completed):
-            result = installer.confirm_and_install(["missing-package"])
+        with _interactive(installer), patch("subprocess.run", return_value=completed):
+            result = installer.confirm_and_install_sync(["missing-package"])
         self.assertFalse(result.installed)
         self.assertEqual(result.returncode, 1)
         self.assertEqual(result.stderr, "boom")
@@ -52,10 +63,12 @@ class PythonDependencyInstallerTest(unittest.TestCase):
         installer = PythonDependencyInstaller(input_func=lambda prompt: "y")
         completed = subprocess.CompletedProcess(["uv"], 0, stdout="ok", stderr="")
 
-        with patch.object(installer, "_running_under_uv", return_value=False), patch.object(
+        with _interactive(installer), patch.object(
+            installer, "_running_under_uv", return_value=False
+        ), patch.object(
             installer, "_python_has_pip", return_value=False
         ), patch("shutil.which", return_value="uv"), patch("subprocess.run", return_value=completed) as run:
-            result = installer.confirm_and_install(["pyfiglet"])
+            result = installer.confirm_and_install_sync(["pyfiglet"])
 
         self.assertTrue(result.installed)
         self.assertEqual(run.call_args.args[0], ["uv", "pip", "install", "pyfiglet"])
@@ -64,13 +77,92 @@ class PythonDependencyInstallerTest(unittest.TestCase):
         installer = PythonDependencyInstaller(input_func=lambda prompt: "y")
         completed = subprocess.CompletedProcess(["uv"], 0, stdout="ok", stderr="")
 
-        with patch.object(installer, "_running_under_uv", return_value=True), patch.object(
+        with _interactive(installer), patch.object(
+            installer, "_running_under_uv", return_value=True
+        ), patch.object(
             installer, "_python_has_pip", return_value=True
         ), patch("shutil.which", return_value="uv"), patch("subprocess.run", return_value=completed) as run:
-            result = installer.confirm_and_install(["pyfiglet"])
+            result = installer.confirm_and_install_sync(["pyfiglet"])
 
         self.assertTrue(result.installed)
         self.assertEqual(run.call_args.args[0], ["uv", "pip", "install", "pyfiglet"])
+
+
+class PythonDependencyInstallerSafetyTest(unittest.TestCase):
+    """依赖串校验 / 无终端跳过 / 子进程超时。"""
+
+    def test_rejects_pip_option_injection(self) -> None:
+        """plugin.toml 里的依赖串不能变成 pip 选项（依赖混淆）。"""
+        installer = PythonDependencyInstaller(input_func=lambda prompt: "y")
+        with _interactive(installer), patch("subprocess.run") as run:
+            result = installer.confirm_and_install_sync(
+                ["--index-url=https://evil.example/simple", "requests>=2"]
+            )
+
+        self.assertFalse(result.installed)
+        run.assert_not_called()
+        self.assertIn("非法", result.stderr)
+
+    def test_rejects_requirement_with_whitespace(self) -> None:
+        installer = PythonDependencyInstaller(input_func=lambda prompt: "y")
+        with _interactive(installer), patch("subprocess.run") as run:
+            result = installer.confirm_and_install_sync(["requests ; rm -rf /"])
+
+        self.assertFalse(result.installed)
+        run.assert_not_called()
+
+    def test_skips_without_interactive_terminal(self) -> None:
+        """无 tty（systemd/Docker/面板触发）时不再 input()，避免 EOFError 冲掉启动。"""
+        installer = PythonDependencyInstaller(input_func=lambda prompt: "y")
+        with patch.object(installer, "_interactive", return_value=False), patch(
+            "subprocess.run"
+        ) as run:
+            result = installer.confirm_and_install_sync(["requests>=2"])
+
+        self.assertFalse(result.installed)
+        run.assert_not_called()
+        self.assertEqual(result.stderr, "no interactive terminal")
+
+    def test_install_command_has_timeout(self) -> None:
+        from neobot_modloader.dependencies import INSTALL_TIMEOUT_SECONDS
+
+        installer = PythonDependencyInstaller(input_func=lambda prompt: "y")
+        completed = subprocess.CompletedProcess(["python"], 0, stdout="ok", stderr="")
+        with _interactive(installer), patch("subprocess.run", return_value=completed) as run:
+            installer.confirm_and_install_sync(["requests>=2"])
+
+        self.assertEqual(run.call_args.kwargs.get("timeout"), INSTALL_TIMEOUT_SECONDS)
+
+    def test_install_timeout_returns_failure(self) -> None:
+        installer = PythonDependencyInstaller(input_func=lambda prompt: "y")
+        with _interactive(installer), patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="pip", timeout=1),
+        ):
+            result = installer.confirm_and_install_sync(["requests>=2"])
+
+        self.assertFalse(result.installed)
+        self.assertIn("超时", result.stderr)
+
+
+class PythonDependencyInstallerAsyncTest(unittest.IsolatedAsyncioTestCase):
+    """异步入口（运行期：面板安装/热重载）。"""
+
+    async def test_async_entry_installs(self) -> None:
+        installer = PythonDependencyInstaller(input_func=lambda prompt: "y")
+        completed = subprocess.CompletedProcess(["python"], 0, stdout="ok", stderr="")
+        with _interactive(installer), patch("subprocess.run", return_value=completed):
+            result = await installer.confirm_and_install(["requests>=2"])
+
+        self.assertTrue(result.installed)
+
+    async def test_async_entry_rejects_invalid_requirement(self) -> None:
+        installer = PythonDependencyInstaller(input_func=lambda prompt: "y")
+        with _interactive(installer), patch("subprocess.run") as run:
+            result = await installer.confirm_and_install(["-e", "."])
+
+        self.assertFalse(result.installed)
+        run.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/packages/modloader/tests/test_event_injection.py
+++ b/packages/modloader/tests/test_event_injection.py
@@ -12,12 +12,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Mapping
 
-import pytest
 
 from neobot_modloader.context import RuntimePluginContext
 from neobot_modloader.hooks import PluginHookBus
 from neobot_modloader.loader import FilesystemPluginLoader
-from neobot_modloader.message import Message
 from neobot_modloader.plugin import Plugin
 from neobot_modloader.plugins.injection import parameter_injection_kind
 from neobot_modloader.plugins.tools import build_tool_schema

--- a/packages/modloader/tests/test_hook_output_capture.py
+++ b/packages/modloader/tests/test_hook_output_capture.py
@@ -1,0 +1,135 @@
+"""插件钩子输出的捕获必须是「按任务隔离」的。
+
+旧实现用 contextlib.redirect_stdout（进程级）包住 await：并发钩子会互相串台，
+异常退出顺序不巧时 sys.stdout 还会被还原成已失效的 StringIO。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import sys
+
+import pytest
+
+from neobot_modloader.hooks import (
+    _CAPTURE_STDOUT,
+    _ContextRoutedStream,
+    _capture_output,
+    _install_context_routed_streams,
+)
+
+
+class _RecordingOutput:
+    def __init__(self) -> None:
+        self.writes: list[tuple[str, str]] = []
+        self.errors: list[tuple[str, str]] = []
+
+    def write(self, text: str, *, source: str = "", target: str | None = None) -> None:
+        self.writes.append((source, text))
+
+    def error(self, text: str, *, source: str = "", target: str | None = None) -> None:
+        self.errors.append((source, text))
+
+
+async def test_concurrent_captures_do_not_cross_contaminate() -> None:
+    """两个**重叠**的捕获上下文各自 print，必须只落到自己的 source 下。"""
+    output = _RecordingOutput()
+    a_in_capture = asyncio.Event()
+    b_done = asyncio.Event()
+
+    async def handler_a() -> None:
+        with _capture_output(output, source="a"):
+            print("hello-a")
+            a_in_capture.set()
+            # a 停留在捕获上下文中，等待 b 完成自己那段
+            await b_done.wait()
+            print("bye-a")
+
+    async def handler_b() -> None:
+        await a_in_capture.wait()  # 确保 a 已经进入捕获
+        with _capture_output(output, source="b"):
+            print("hello-b")
+            print("bye-b")
+        b_done.set()
+
+    await asyncio.wait_for(asyncio.gather(handler_a(), handler_b()), timeout=5)
+
+    by_source: dict[str, str] = {}
+    for source, text in output.writes:
+        by_source[source] = by_source.get(source, "") + text
+
+    assert set(by_source) == {"a", "b"}
+    assert "hello-a" in by_source["a"] and "bye-a" in by_source["a"]
+    assert "hello-b" in by_source["b"] and "bye-b" in by_source["b"]
+    # 关键：a 的输出里不能出现 b 的内容（旧实现会串台）
+    assert "hello-b" not in by_source["a"]
+    assert "hello-a" not in by_source["b"]
+
+
+async def test_output_is_emitted_even_when_handler_raises() -> None:
+    output = _RecordingOutput()
+
+    with pytest.raises(RuntimeError):
+        with _capture_output(output, source="boom"):
+            print("before failure")
+            raise RuntimeError("handler exploded")
+
+    assert output.writes == [("boom", "before failure")]
+
+
+async def test_stderr_goes_to_error_channel() -> None:
+    output = _RecordingOutput()
+
+    with _capture_output(output, source="err"):
+        print("to-stderr", file=sys.stderr)
+
+    assert output.errors == [("err", "to-stderr")]
+    assert output.writes == []
+
+
+async def test_nested_capture_restores_outer_sink() -> None:
+    """嵌套捕获结束后，外层上下文必须重新生效。"""
+    output = _RecordingOutput()
+
+    with _capture_output(output, source="outer"):
+        print("outer-1")
+        with _capture_output(output, source="inner"):
+            print("inner-1")
+        print("outer-2")
+
+    by_source: dict[str, list[str]] = {}
+    for source, text in output.writes:
+        by_source.setdefault(source, []).append(text)
+
+    # 内层单独上报；外层把进入内层前后产生的输出合并成一次上报
+    assert by_source["inner"] == ["inner-1"]
+    assert by_source["outer"] == ["outer-1\nouter-2"]
+
+
+async def test_capture_does_not_swallow_prints_outside_capture() -> None:
+    """捕获之外（无上下文）的 print 必须回到原流，而不是被丢弃。"""
+    original = sys.stdout
+    buffer = io.StringIO()
+    sys.stdout = buffer
+    try:
+        _install_context_routed_streams()
+        print("outside")
+    finally:
+        sys.stdout = original
+
+    assert "outside" in buffer.getvalue()
+
+
+async def test_stdout_is_not_replaced_by_a_dead_buffer() -> None:
+    """捕获结束后 sys.stdout 仍是可用代理（不会变成失效的 StringIO）。"""
+    output = _RecordingOutput()
+
+    with _capture_output(output, source="x"):
+        print("captured")
+
+    assert isinstance(sys.stdout, _ContextRoutedStream)
+    assert _CAPTURE_STDOUT.get() is None
+    # 代理的 write 仍可用（写向安装时捕获的底层流）
+    sys.stdout.write("")
+    sys.stdout.flush()

--- a/packages/modloader/tests/test_plugin_database_teardown.py
+++ b/packages/modloader/tests/test_plugin_database_teardown.py
@@ -1,0 +1,102 @@
+"""插件数据库必须在 ERROR 路径也被关闭。
+
+关闭原先只发生在 Plugin.on_stop，而插件处于 ERROR 状态时 _stop_plugin_locked
+会跳过 on_stop（callback_needed 只认 LOADED/RUNNING）：声明了数据库的插件若在
+on_load/on_start 失败，引擎会一直挂着——Windows 上锁住数据库文件，导致插件
+重装/升级失败。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from neobot_contracts.ports.plugin import PluginState
+from neobot_modloader.manager import DefaultPluginManager
+from neobot_modloader.plugin import Plugin
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def _record(self, level: str, message: str, **kw) -> None:
+        self.messages.append((level, message))
+
+    def debug(self, message: str, **kw) -> None:
+        self._record("debug", message)
+
+    def info(self, message: str, **kw) -> None:
+        self._record("info", message)
+
+    def warning(self, message: str, **kw) -> None:
+        self._record("warning", message)
+
+    def error(self, message: str, **kw) -> None:
+        self._record("error", message)
+
+    def exception(self, message: str, **kw) -> None:
+        self._record("exception", message)
+
+
+class _FakeDatabase:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.closed = 0
+        self.fail = fail
+
+    async def close(self) -> None:
+        self.closed += 1
+        if self.fail:
+            raise RuntimeError("dispose boom")
+
+
+def _manager() -> DefaultPluginManager:
+    return DefaultPluginManager(logger=_Logger())
+
+
+async def test_close_databases_is_idempotent() -> None:
+    plugin = Plugin("p")
+    database = _FakeDatabase()
+    plugin._databases["main"] = database  # type: ignore[assignment]
+
+    await plugin.close_databases()
+    await plugin.close_databases()
+
+    assert database.closed == 2  # 幂等：重复关闭不再抛错
+    assert plugin._bound is False
+
+
+def _context(name: str):
+    return type("Ctx", (), {"plugin_name": name, "data_dir": None, "agents": None})()
+
+
+async def test_teardown_closes_databases_on_error_path() -> None:
+    """不调用 on_stop 的 ERROR 路径也必须关掉数据库。"""
+    manager = _manager()
+    plugin = Plugin("p")
+    database = _FakeDatabase()
+    plugin._databases["main"] = database  # type: ignore[assignment]
+    manager.register(plugin, _context("p"))
+    record = manager.get_record("p")
+    assert record is not None
+    record.state = PluginState.ERROR
+    record.error = RuntimeError("on_load failed")
+
+    errors = await manager._teardown_owned_resources(record)
+
+    assert errors == []
+    assert database.closed == 1
+
+
+async def test_teardown_reports_database_close_failure() -> None:
+    manager = _manager()
+    plugin = Plugin("p2")
+    database = _FakeDatabase(fail=True)
+    plugin._databases["main"] = database  # type: ignore[assignment]
+    manager.register(plugin, _context("p2"))
+    record = manager.get_record("p2")
+    assert record is not None
+
+    errors = await manager._teardown_owned_resources(record)
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], RuntimeError)

--- a/packages/modloader/tests/test_plugin_database_teardown.py
+++ b/packages/modloader/tests/test_plugin_database_teardown.py
@@ -8,7 +8,6 @@ on_load/on_start 失败，引擎会一直挂着——Windows 上锁住数据库�
 
 from __future__ import annotations
 
-import asyncio
 
 from neobot_contracts.ports.plugin import PluginState
 from neobot_modloader.manager import DefaultPluginManager

--- a/packages/modloader/tests/test_plugin_hot_reload_proxy.py
+++ b/packages/modloader/tests/test_plugin_hot_reload_proxy.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from neobot_modloader import Plugin, PluginRuntime, PluginStateStore
+from neobot_modloader import PluginRuntime, PluginStateStore
 from neobot_modloader.installer import PluginInstaller, ProxySettings
 from neobot_modloader.management import PluginSnapshot
 

--- a/packages/modloader/tests/test_runtime.py
+++ b/packages/modloader/tests/test_runtime.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from neobot_modloader.host import PluginHostFacade
-from neobot_modloader.loader import DiscoveredPlugin, LoadedPlugin, PluginLoadError
+from neobot_modloader.loader import DiscoveredPlugin, LoadedPlugin
 from neobot_modloader.runtime import PluginRuntime
 from neobot_contracts.ports.plugin import PluginState
 
@@ -1369,13 +1369,10 @@ class PluginRuntimeTest(unittest.IsolatedAsyncioTestCase):
             runtime.load_all()
 
             self.assertEqual(runtime.manager.names(), [])
-            errors = [
-                result
-                for result in runtime.discover_all()
-                if isinstance(result, PluginLoadError)
-            ]
-            self.assertEqual([error.name for error in errors], ["future"])
-            self.assertIn("9.0.0", str(errors[0].error))
+            # 发现阶段仍要给出条目：面板的停用/重载/卸载与来源判定都依赖它，
+            # 替换成错误条目会让这些操作报「插件未找到」
+            discovered = runtime.discover_all()
+            self.assertEqual([item.name for item in discovered], ["future"])
 
     async def test_plugin_with_satisfied_min_version_loads(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/packages/modloader/tests/test_runtime.py
+++ b/packages/modloader/tests/test_runtime.py
@@ -770,7 +770,13 @@ class PluginRuntimeTest(unittest.IsolatedAsyncioTestCase):
             def __init__(self) -> None:
                 self.requirements: list[str] = []
 
-            def confirm_and_install(self, requirements: list[str]) -> object:
+            def confirm_and_install_sync(self, requirements: list[str]) -> object:
+                """启动装配期走同步入口。"""
+                self.requirements.extend(requirements)
+                return object()
+
+            async def confirm_and_install(self, requirements: list[str]) -> object:
+                """运行期（安装/热重载）走异步入口。"""
                 self.requirements.extend(requirements)
                 return object()
 

--- a/packages/modloader/tests/test_runtime.py
+++ b/packages/modloader/tests/test_runtime.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from neobot_modloader.host import PluginHostFacade
-from neobot_modloader.loader import DiscoveredPlugin, LoadedPlugin
+from neobot_modloader.loader import DiscoveredPlugin, LoadedPlugin, PluginLoadError
 from neobot_modloader.runtime import PluginRuntime
 from neobot_contracts.ports.plugin import PluginState
 
@@ -1341,6 +1341,68 @@ class PluginRuntimeTest(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(result.ok)
             self.assertEqual(result.state, PluginState.UNLOADED.value)
             self.assertIsNone(result.error)
+
+    async def test_plugin_requiring_newer_neobot_is_not_loaded(self) -> None:
+        """min_neobot_version 高于当前版本时必须拒绝加载，而不是照常注册。"""
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            plugin_dir = root / "plugins"
+            plugin_dir.mkdir()
+            package = plugin_dir / "future"
+            package.mkdir()
+            (package / "plugin.toml").write_text(
+                'name = "future"\nmin_neobot_version = "9.0.0"\n',
+                encoding="utf-8",
+            )
+            (package / "__init__.py").write_text(
+                "from neobot_modloader import Plugin\nplugin = Plugin('future')\n",
+                encoding="utf-8",
+            )
+            runtime = PluginRuntime(
+                plugin_dir=plugin_dir,
+                data_dir=root / "data",
+                adapter=object(),
+                logger_factory=FakeLoggerFactory(),
+                host_version="0.6.0",
+            )
+
+            runtime.load_all()
+
+            self.assertEqual(runtime.manager.names(), [])
+            errors = [
+                result
+                for result in runtime.discover_all()
+                if isinstance(result, PluginLoadError)
+            ]
+            self.assertEqual([error.name for error in errors], ["future"])
+            self.assertIn("9.0.0", str(errors[0].error))
+
+    async def test_plugin_with_satisfied_min_version_loads(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            plugin_dir = root / "plugins"
+            plugin_dir.mkdir()
+            package = plugin_dir / "compatible"
+            package.mkdir()
+            (package / "plugin.toml").write_text(
+                'name = "compatible"\nmin_neobot_version = "0.6.0"\n',
+                encoding="utf-8",
+            )
+            (package / "__init__.py").write_text(
+                "from neobot_modloader import Plugin\nplugin = Plugin('compatible')\n",
+                encoding="utf-8",
+            )
+            runtime = PluginRuntime(
+                plugin_dir=plugin_dir,
+                data_dir=root / "data",
+                adapter=object(),
+                logger_factory=FakeLoggerFactory(),
+                host_version="0.6.1",
+            )
+
+            runtime.load_all()
+
+            self.assertEqual(runtime.manager.names(), ["compatible"])
 
 
 if __name__ == "__main__":

--- a/packages/modloader/tests/test_version.py
+++ b/packages/modloader/tests/test_version.py
@@ -1,0 +1,73 @@
+"""min_neobot_version 比较规则。"""
+
+from __future__ import annotations
+
+import unittest
+
+from neobot_modloader.version import (
+    incompatible_version_error,
+    parse_version,
+    version_at_least,
+)
+
+
+class ParseVersionTest(unittest.TestCase):
+    def test_parses_numeric_components(self) -> None:
+        self.assertEqual(parse_version("1.2.3"), (1, 2, 3))
+        self.assertEqual(parse_version("v0.6"), (0, 6))
+        self.assertEqual(parse_version(" 2 "), (2,))
+        self.assertEqual(parse_version("1.2.3-beta.1"), (1, 2, 3))
+
+    def test_unparsable_returns_none(self) -> None:
+        for value in ("", None, "latest", "abc"):
+            self.assertIsNone(parse_version(value))
+
+
+class VersionAtLeastTest(unittest.TestCase):
+    def test_compares_by_padded_components(self) -> None:
+        self.assertTrue(version_at_least("0.6.0", "0.6"))
+        self.assertTrue(version_at_least("1.0", "0.9.9"))
+        self.assertFalse(version_at_least("0.5.9", "0.6.0"))
+        # 10 必须大于 9（不能按字符串比较）
+        self.assertTrue(version_at_least("0.10.0", "0.9.0"))
+
+    def test_equal_versions_satisfy(self) -> None:
+        self.assertTrue(version_at_least("0.6.0", "0.6.0"))
+
+    def test_uncomparable_returns_none(self) -> None:
+        self.assertIsNone(version_at_least("latest", "0.6.0"))
+        self.assertIsNone(version_at_least("0.6.0", "latest"))
+
+    def test_all_zero_host_treated_as_unknown(self) -> None:
+        """源码运行取不到发行版本时会回落 0.0.0，不能因此把所有插件判成过旧。"""
+        self.assertIsNone(version_at_least("0.0.0", "0.6.0"))
+
+
+class IncompatibleVersionErrorTest(unittest.TestCase):
+    def test_reports_too_old_host(self) -> None:
+        message = incompatible_version_error(
+            name="demo", host="0.5.0", minimum="0.6.0"
+        )
+
+        self.assertIsNotNone(message)
+        assert message is not None
+        self.assertIn("demo", message)
+        self.assertIn("0.6.0", message)
+        self.assertIn("0.5.0", message)
+
+    def test_satisfied_or_absent_minimum_is_ok(self) -> None:
+        self.assertIsNone(
+            incompatible_version_error(name="demo", host="0.6.0", minimum="0.6.0")
+        )
+        self.assertIsNone(
+            incompatible_version_error(name="demo", host="0.6.0", minimum=None)
+        )
+        self.assertIsNone(
+            incompatible_version_error(
+                name="demo", host="0.0.0", minimum="0.6.0"
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/storage/src/neobot_storage/__init__.py
+++ b/packages/storage/src/neobot_storage/__init__.py
@@ -1,5 +1,6 @@
 """neobot_storage 公共 API。"""
 
+from neobot_storage.backup import backup_sqlite_database
 from neobot_storage.engine import create_engine, run_migrations, sqlite_url
 from neobot_storage.models import Base, ModelUsageRecord
 from neobot_storage.uow import SqlAlchemyUnitOfWork, make_uow_factory
@@ -8,6 +9,7 @@ __all__ = [
     "create_engine",
     "run_migrations",
     "sqlite_url",
+    "backup_sqlite_database",
     "Base",
     "ModelUsageRecord",
     "SqlAlchemyUnitOfWork",

--- a/packages/storage/src/neobot_storage/backup.py
+++ b/packages/storage/src/neobot_storage/backup.py
@@ -1,0 +1,87 @@
+"""SQLite 数据库备份。
+
+用于在 alembic 迁移**之前**留一份可回滚的快照：迁移里存在不可逆操作
+（例如 0021 的去重 DELETE），而原实现升级前不做任何备份。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from neobot_contracts.ports.logging import Logger, NullLogger
+
+#: 默认保留的最近备份份数
+DEFAULT_MAX_BACKUPS = 5
+
+
+def backup_sqlite_database(
+    db_path: str | Path,
+    backup_dir: str | Path,
+    *,
+    max_backups: int = DEFAULT_MAX_BACKUPS,
+    logger: Logger | None = None,
+) -> Path | None:
+    """用 SQLite 在线备份 API 复制数据库，返回备份文件路径。
+
+    使用 ``sqlite3.Connection.backup`` 而不是直接拷文件：WAL 模式下已提交但
+    尚未 checkpoint 的数据只存在于 ``-wal`` 文件里，裸拷贝主库文件会丢数据。
+
+    库不存在（首次启动）返回 None；备份失败只记录告警并返回 None——
+    迁移本身仍会继续，由迁移自己的错误处理决定后续行为。
+    """
+    log = logger or NullLogger()
+    source = Path(db_path)
+    if not source.is_file():
+        return None
+
+    target_dir = Path(backup_dir)
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / f"{source.stem}_{_timestamp()}.db"
+        _copy_database(source, target)
+    except Exception as exc:
+        log.warning(f"数据库备份失败（迁移将继续）: {exc}")
+        return None
+
+    _prune_backups(target_dir, source.stem, max_backups, log)
+    return target
+
+
+def _timestamp() -> str:
+    return time.strftime("%Y%m%d_%H%M%S") + f"_{int(time.time() * 1000) % 1000:03d}"
+
+
+def _copy_database(source: Path, target: Path) -> None:
+    source_conn = sqlite3.connect(f"file:{source.as_posix()}?mode=ro", uri=True)
+    try:
+        target_conn = sqlite3.connect(target)
+        try:
+            source_conn.backup(target_conn)
+        finally:
+            target_conn.close()
+    finally:
+        source_conn.close()
+
+
+def _prune_backups(
+    backup_dir: Path, stem: str, max_backups: int, logger: Logger
+) -> None:
+    if max_backups <= 0:
+        return
+    try:
+        backups = sorted(
+            backup_dir.glob(f"{stem}_*.db"),
+            key=lambda item: item.stat().st_mtime,
+        )
+    except OSError as exc:
+        logger.warning(f"清理旧数据库备份失败: {exc}")
+        return
+    if len(backups) <= max_backups:
+        return
+    for stale in backups[: len(backups) - max_backups]:
+        try:
+            stale.unlink()
+        except OSError as exc:
+            logger.warning(f"删除旧数据库备份失败 ({stale.name}): {exc}")

--- a/packages/storage/src/neobot_storage/uow.py
+++ b/packages/storage/src/neobot_storage/uow.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from neobot_contracts.ports.unit_of_work import UnitOfWork
 
-from neobot_storage._retry import _is_locked_error, retry_on_lock
+from neobot_storage._retry import _is_locked_error
 from neobot_storage.repositories.memory import SqlAlchemyMemoryRepository
 from neobot_storage.repositories.message import SqlAlchemyMessageRepository
 from neobot_storage.repositories.profile import SqlAlchemyProfileRepository
@@ -41,12 +41,16 @@ class SqlAlchemyUnitOfWork:
         await self._session.close()
 
     async def commit(self) -> None:
-        if self._session._proxied._is_clean():
-            await retry_on_lock(
-                self._session.commit,
-                on_retry=self._session.rollback,
-            )
-            return
+        """提交事务；锁冲突一律显式失败。
+
+        ``retry_on_lock`` 的正确用法是让**调用方重放整个事务体**
+        （见 ``statistics/tracker.py``），而不是 rollback 之后重试 ``commit()``：
+        后者会把已经发往数据库的 Core DML 连同事务一起丢掉，在 commit 成功
+        返回的同时静默丢失写入——仓库层大量使用
+        ``session.execute(insert(...).on_conflict_do_update())``，这类写入
+        不会体现在 ORM 的 new/dirty/deleted 状态里，因此不能靠
+        ``session._proxied._is_clean()``（私有 API）判断「提交是空操作」。
+        """
         try:
             await self._session.commit()
         except Exception as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,16 @@ dev = [
     "pytest-timeout>=2.3.1",
     "ruff>=0.15.5",
 ]
+
+[tool.ruff]
+# 起步用保守规则集（ruff 经典默认 E4/E7/E9/F）：先把「未使用导入 / 未定义名字 /
+# 语法级问题」这类确定性缺陷挡在 CI 外，规则集再逐步扩大。
+target-version = "py313"
+line-length = 120
+exclude = [
+    "app/src/neobot_app/builtin_plugins/dashboard/web",
+    "app/src/neobot_app/builtin_plugins/dashboard/frontend",
+]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,13 @@ exclude = [
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F"]
+
+[tool.mypy]
+# 起步配置：存量类型错误较多，先不启用严格模式，仅用于暴露问题（CI 中暂不阻断）。
+python_version = "3.13"
+ignore_missing_imports = true
+warn_unused_ignores = false
+exclude = [
+    "app/src/neobot_app/builtin_plugins/dashboard/web/",
+    "app/src/neobot_app/builtin_plugins/dashboard/frontend/",
+]

--- a/scripts/change_prompt.py
+++ b/scripts/change_prompt.py
@@ -1,6 +1,5 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
-import json
 
 
 class EscapeTextApp:
@@ -143,7 +142,7 @@ class EscapeTextApp:
 
 def main():
     root = tk.Tk()
-    app = EscapeTextApp(root)
+    EscapeTextApp(root)
     root.mainloop()
 
 

--- a/scripts/run_archive_memory_deepseek.py
+++ b/scripts/run_archive_memory_deepseek.py
@@ -365,7 +365,6 @@ async def main() -> None:
     config = BotConfig()
     config.agent.memory.archive.allow_delete = True
 
-    archive_model = args.archive_model or args.model
     agent_registry = None
     main_agent = None
     try:

--- a/scripts/tools_editor.py
+++ b/scripts/tools_editor.py
@@ -24,7 +24,6 @@ import threading
 import time
 import uuid
 import tkinter as tk
-from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -577,7 +576,7 @@ class ToolExecutionEnv:
             conv_type = args.get("conversation_type", "group")
             # TTS: generate audio then send
             segments = [
-                {"type": "record", "data": {"file": f"http://localhost:8080/files/tts/virtual_sample.wav"}},
+                {"type": "record", "data": {"file": "http://localhost:8080/files/tts/virtual_sample.wav"}},
             ]
             if conv_type == "group":
                 resp = await ws.send_api("send_group_msg", {"group_id": target_id, "message": segments})
@@ -747,9 +746,9 @@ class DelegateStreamWindow:
         info_frame = ttk.Frame(self._window)
         info_frame.pack(side=tk.TOP, fill=tk.X, padx=8, pady=(8, 4))
 
-        ttk.Label(info_frame, text=f"Agent:", font=("", 9, "bold")).pack(side=tk.LEFT)
+        ttk.Label(info_frame, text="Agent:", font=("", 9, "bold")).pack(side=tk.LEFT)
         ttk.Label(info_frame, text=self._agent_name, foreground="#0066CC").pack(side=tk.LEFT, padx=(4, 20))
-        ttk.Label(info_frame, text=f"Task:", font=("", 9, "bold")).pack(side=tk.LEFT)
+        ttk.Label(info_frame, text="Task:", font=("", 9, "bold")).pack(side=tk.LEFT)
         task_display = self._task[:80] + "..." if len(self._task) > 80 else self._task
         ttk.Label(info_frame, text=task_display, foreground="#333").pack(side=tk.LEFT, padx=(4, 20))
 
@@ -1070,7 +1069,6 @@ class ToolsEditorApp:
             from neobot_app.config.schemas.bot import BotConfig as BotConfigSchema
             from neobot_app.config.loader.manager import Config
             from neobot_contracts.ports.logging import NullLogger as NL
-            from neobot_chat.models import get_model_registry
             from neobot_chat import AgentRegistry as AR, create_provider as cp
 
             with open(CONFIG_PATH, "r", encoding="utf-8") as f:
@@ -1121,7 +1119,7 @@ class ToolsEditorApp:
             if ps_config is not None and getattr(ps_config, "enabled", True):
                 try:
                     from neobot_app.agents.problem_solver import (
-                        build_problem_solver_agent, ProblemSolverAgentConfig,
+                        build_problem_solver_agent,
                     )
                     provider = _factory("problem_solver")
                     if provider is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3537 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+
+[manifest]
+members = [
+    "neobot",
+    "neobot-adapter",
+    "neobot-app",
+    "neobot-chat",
+    "neobot-contracts",
+    "neobot-memory",
+    "neobot-modloader",
+    "neobot-storage",
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.7.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/57/be/5afd201cc0ab139029aadb75392efe85a293403d9dd3a3226161c21ce00c/aiohttp-3.14.3-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:2e9878ae68e4a5f1c0abe4dd497dbc3d51946f5837b56759e2a02e78fa90ef86", size = 506269, upload-time = "2026-07-23T01:54:49.075Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/09/dec8189d62b45ade009f6792a2264b942a90cb88aeaf181239933cd72c3c/aiohttp-3.14.3-cp313-cp313-android_21_x86_64.whl", hash = "sha256:f3d2669fe7dec7fc359ecdb5984b29b50d85d5d00f8c1cb61de4f4a24ee42627", size = 515166, upload-time = "2026-07-23T01:54:51.894Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/24/2854869d29ed8a8b19d74f9ec6629515f7e04d02dd329d9d179201e58e47/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:cc7cb243a68167172f48c1fd43cee91ec4b1d40cefd190edd43369d1a6bc9c82", size = 486263, upload-time = "2026-07-23T01:54:54.223Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d4/dd/57187c8be2a35aea65eaee3bd2c3dcbbcf0204f5106c89637e3610380cd1/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:78253b573e6ffab5028924fc98bc281aae05445969982a10864bc360dea2016c", size = 492299, upload-time = "2026-07-23T01:54:56.236Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b9/11/06ae6ed8f0d414edf4068861e233d8fe23ee699bfd4b3ceb8663db948a62/aiohttp-3.14.3-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7041d52c3a7fa20c9e8c182b534704abb19502c8bdcbde7ab23bfda6f642394f", size = 502235, upload-time = "2026-07-23T01:54:58.377Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/a3/559639c34a345d2cf7c52dff6838119f2eaf29eb508227b5b83f573af813/aiohttp-3.14.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac74facc01463f138b0da5580329cfcc82818dea5656e83ddcd11268fc12ff80", size = 750883, upload-time = "2026-07-23T01:55:00.65Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/91/cd/41e131f13afd1e7b0172a9d9eda085ef90eb8439f41f0d279db81ed3ae60/aiohttp-3.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d6218d92e450824e9b4881f44e8c09f1853b490f9a64130801024a4793b1b3b0", size = 508473, upload-time = "2026-07-23T01:55:02.945Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bc/6b/e7f13410d391c6e55b4c007a8de024355389d7d459e3d64c42b2d33617e5/aiohttp-3.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:11fb37ef075669eee52ab1928fbf6e1741fada40409fa309ebde9607a962aebf", size = 509190, upload-time = "2026-07-23T01:55:05.173Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/97/21/6464573e53d69672cc1eada3e5c5cb2d2efa82701e8305a0f2047a576967/aiohttp-3.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55bdcc472aafe2de4a253045cc128007a64f1e0264fb675791e132ea5edaa3bd", size = 1761478, upload-time = "2026-07-23T01:55:07.383Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1a/81/d217043a4c17fbce360905e3b2bdd20139ebc9a2de836d035d179c4da006/aiohttp-3.14.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c39846c3aad97a8530c89d7a3869a8f8e9e3762c6ac0504481e5c80948f7e807", size = 1735092, upload-time = "2026-07-23T01:55:09.803Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/66/e13a02d0eeb1a9a502402a977abb4e4abff9fe4051c26f80558c57a7c975/aiohttp-3.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5895ef58c4620afe02fa16044f023dc4dafec08158f9d08874a46a7dbc0341b8", size = 1800546, upload-time = "2026-07-23T01:55:12.012Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/26/5e/57d42fca1d18cb5acc1cad945d017fabc5d6ae71d8a08ad66be8dc3ee544/aiohttp-3.14.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa9467a8113aa69d3d7c55a70ef0b7c636010a40993f3df9d9d0d73b3eb7ef24", size = 1895250, upload-time = "2026-07-23T01:55:14.357Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ca/1c/7da8d08e74d56f00070822f9638ff3f1c563f8ad87d1efa996c87bfc8644/aiohttp-3.14.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7d2deec16eeedf55f2c7cf75b521ea3856a5177e123844f8fd0f114ce252cb5", size = 1789289, upload-time = "2026-07-23T01:55:16.668Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cd/0f/cf16bcf56896981c1a0319f5d5db9337994b5165730c48a8fa07e9b34be6/aiohttp-3.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dd54d0e8717de95939766febac482ac0474d8ac3b048115f9f2b1d23a16e7db4", size = 1586706, upload-time = "2026-07-23T01:55:18.913Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fe/6f/76eac12a7f2480e1e304f842efdb07db33256b0d9165b866b6ef0806c202/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:df82f3787c940c94986b34222d59c9e38843fba85139f36e85255a82ad5355a9", size = 1724652, upload-time = "2026-07-23T01:55:21.296Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/39/b6/19c8c592baeeb94b75f966547d40c02ac7590902306ec5863d5c027cf506/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:42a67efc36300d052fb4508a53e8b6901b9284b599ae63945c377569c5fcc1e1", size = 1756239, upload-time = "2026-07-23T01:55:23.705Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dc/c9/4e9383150296f97f873b680c4de8fb2cd88608fb9f48c79edcb111611abc/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7a75aa63cbf9b21cfaf60dc2657e19df2c2867d91707d653fee171ffeedd1371", size = 1769161, upload-time = "2026-07-23T01:55:26.082Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/1e/147bdc6cc5de5f3ab011be8bf5d6e786633249f22c20bae06f85e45f5387/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e92eb8acc45eb6a9f4935071a77edf5b85cc6f8dfad5cd99e97653c26593cdde", size = 1578759, upload-time = "2026-07-23T01:55:28.846Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/31/78388a9d6040ece2e11df62ea229a822cf5e52d238374b220ae9975b2623/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b014a6ed7cf912e787149fdc529166d3ceabac23f26efeea3158c9aba2354e7e", size = 1792025, upload-time = "2026-07-23T01:55:31.457Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/03/51/a3d29fdf2c25d796746af8ad6fe56a45d6256c38b0a8a2ed752e1160b3a2/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d4f72af88ac2474bb5bca640030320e3d38a0163a1d7533500e87be458eef71", size = 1768477, upload-time = "2026-07-23T01:55:33.87Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/a6/442e18b5afeade534d877a2dc3c3e392aff8d49787890b0cf84790410267/aiohttp-3.14.3-cp313-cp313-win32.whl", hash = "sha256:5f08ec777f35ee70720233b8b9811d3bb5d728137f30ac91b7457709c3261ac0", size = 451069, upload-time = "2026-07-23T01:55:36.121Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/69/3d876ac02659f271cf7f6769f14a8e3de5b6e888ed8b5a7e998086a4cec8/aiohttp-3.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:dff9461ec275f22135650d5ba4b4931a11f3958df7dfbb8db630000d4dee0883", size = 476518, upload-time = "2026-07-23T01:55:38.303Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b2/0e/50d6e6471cd31edce8b282bdec59375a3a69124d8a989a0b1313355cae52/aiohttp-3.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:ddcac3c6b382e81f1dd0499199d4136b877beb4cb5ef770bbbfba56c4b8f55d2", size = 447676, upload-time = "2026-07-23T01:55:40.451Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c8/20/887fdcf832326571b370ffc347b3e70abe101096f3720126aac161b1d872/aiohttp-3.14.3-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:49f7325beb0f85ef4aef5f48f490269575f83e6e2acad00a1d80b807eb027062", size = 509067, upload-time = "2026-07-23T01:55:42.618Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ad/a3/92cec936f78cc4bf0fa5554ebe593b73459d94e3c62303e1902a4cccb6f7/aiohttp-3.14.3-cp314-cp314-android_24_x86_64.whl", hash = "sha256:e3be98a7c30b8c25d573dafba7171d66dfb05ee6a9070fc46535464ff97700a6", size = 514774, upload-time = "2026-07-23T01:55:44.937Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/ba/2a0c38df3fc557620b6a5acd98364af050053b6285b4dc7ee74100c63c18/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:614c61d478b83953e261d02bb2df750f17227cd33ef8002945bf5aebbde21919", size = 488134, upload-time = "2026-07-23T01:55:47.135Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/48/d6/d51b7d4bf309af3693940d8ffd2b9ed0b682434ef85959b7c9c137f60cf8/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:1caa7b0d05f3e3a36f87788c59e970a7ee1cefcfcbb924a9f138c4a6551c9cb7", size = 494201, upload-time = "2026-07-23T01:55:49.451Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3f/5a/8f624384e5f1efabb5229b94157eb966b021e97bdb188c62860c2ae243c2/aiohttp-3.14.3-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:dfa68deb2a443bdaa3ea5297b0699c1464f08aef3812b486d1348eee61b07dc0", size = 502766, upload-time = "2026-07-23T01:55:51.656Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a6/26/4ff0164370deec18fb19254ee4ab10b7a73304ac0c860b13f5f84663759b/aiohttp-3.14.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e72ee89e28d907a18f46959b4eb0bb06701cc7f8cf4366e00029e2ccfaaf5924", size = 756557, upload-time = "2026-07-23T01:55:53.964Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ad4c8b7488d745d2ca4838ebd8ae5ba9b56341d30b1da43640e4ce87f9f49646", size = 510168, upload-time = "2026-07-23T01:55:56.22Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:db332af25642007330fca8be5c4d194caf2bea7a7fc84415aff3497af5dfee6b", size = 512957, upload-time = "2026-07-23T01:55:58.437Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/47/d1/8aba53f15ccb2238405f5e9d30e2a8ca44f93878c26e7165ade00d374b1c/aiohttp-3.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25bd2708db6bdf6a6630dd37bdcdfcb47c4434d22ac69c64665b802910140b30", size = 1750149, upload-time = "2026-07-23T01:56:00.856Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/bd/40c3fee327529284375c6701cbb0fa4600cc2e8432af1378f897e2ef7d3a/aiohttp-3.14.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:cef89a58e628c4efcac3275c2d68083f82426dcdc89c1492a6f654f9f7ea6ab9", size = 1707685, upload-time = "2026-07-23T01:56:03.371Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2a/a3/ca0cc6724cca8114b05694abd916060758c79894c3aa5b012cdadc1bc28e/aiohttp-3.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c23ec8ee9d5ab2f5421f9c7fffce208435607af27fd46d4a44e031954352838f", size = 1803911, upload-time = "2026-07-23T01:56:05.817Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/95/b5/85b099c299c3ffd38ad9b3e43694c8a346934e4a30c88c4fd5a841234f77/aiohttp-3.14.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e2667f0bbe7eb6c74eae5e9691441ad186e5845ca3cff63230fc09c4e7514f5d", size = 1876929, upload-time = "2026-07-23T01:56:08.413Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18cb43369747b2ae007bd2655fb8e63a099c2ff1d207962943636dac989b3147", size = 1761112, upload-time = "2026-07-23T01:56:10.918Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/16/bc4b55e3e5cb175fd69c53c90d60d2f47797cb343da5106e23863dc4dba4/aiohttp-3.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d77640cc618c1d99fc4f8589c0f24a730adfa54eb1e57ef7bf0c8dfb78da898c", size = 1583500, upload-time = "2026-07-23T01:56:13.613Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2a/e8/13a9d957a1ee40837f46aa30f0f4c657e673ad86a2e6362a9f9be20d26d9/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:53e5179d8abb5710f8e83ba207c41c8d1261fcffd4616500e15ca2b7a33be10a", size = 1713940, upload-time = "2026-07-23T01:56:15.969Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/38/05/d33c680c1bcf1c7e130f9cbfc1fc02fe8bb0c4af2a94a53dd5fb56131e5c/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:cd817772b2fcf2b8c0905795318485f9ec16eae60b29feb7f4c77085311637f0", size = 1724413, upload-time = "2026-07-23T01:56:18.591Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/1d/af798d306f7a74b6a632dbcabcf62a4c91391b7582d2a8c6d7712e2cc54e/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4e3ac92d90e92773b2362d506068e9a948192bd553e743c5b2429e28527c8661", size = 1770748, upload-time = "2026-07-23T01:56:21.074Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a8/92/ad720d472556a995049206867765e9410969684f86ee09423ff9969044c1/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3f42e9b78301f11c8f861746175d8b9c1ccef713fcad9eab396e2f6db8ed4a22", size = 1577564, upload-time = "2026-07-23T01:56:23.475Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/60/ad/0ed7586cbef7a884e23a752fa2bb987a122e6a5dd50dab109258d0a95193/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9d9edccfe496b476db5f398d97b865e9a6752bcf8aec4eef8390ce20fb64bb41", size = 1782080, upload-time = "2026-07-23T01:56:25.994Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/97/ea/dbaed0d73e8a69aad653b045dab451c67c2454bb731a37b45a86593e9422/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c5ec8fb1bcc31a8466f74aaf26c345d5c386fa4bd08a3f0eb9c7a4a3fe8b5bf", size = 1745813, upload-time = "2026-07-23T01:56:28.604Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/1b/6893d4bc57e434fc93a6c9217c637d967a0b651d989f6e3265179375754a/aiohttp-3.14.3-cp314-cp314-win32.whl", hash = "sha256:38901a84da3ce22249f6e860bf8f90d141bcab7da090cc398f8bb58c0e44b7da", size = 455872, upload-time = "2026-07-23T01:56:31.031Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f5/8b/c7baa1ba1eda4db6989baefe5de6d99834921b84ebd7918624febcb9f290/aiohttp-3.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:8b3b60de05f3dcb6f6a00f818bb2ec781cee4de0645f59ccaf99b1d1823b6100", size = 481030, upload-time = "2026-07-23T01:56:33.365Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/8c/c29d067df825a2df88ca432db848aa2fe8199598359cc06c12b09320cac9/aiohttp-3.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:1576145bdceeb92382d899751e12743a3a5b8e460a841e3e50543859e54864dc", size = 453669, upload-time = "2026-07-23T01:56:35.731Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6a/a4/9c033beb355d39b6147980597ec9645e4729243f686ee4dc73945de72030/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8800c996b01c2772a783e3e46f3e1abd5823029adca0df54231960de9bfefa5b", size = 791403, upload-time = "2026-07-23T01:56:37.972Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/ca/87c32a0a7704583cfc49660bd817889bae5b830bf53b5dcb4e92145ac2da/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ebe8e504f058fe91223351cecd2d9d6946c9d241bb0250d898ffbdf584cc72b0", size = 526413, upload-time = "2026-07-23T01:56:40.523Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/d8/8ec0e471248c500acdce2be3f46db8fb62b5eb60efef072529cc85ee1d26/aiohttp-3.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30402d03a7c0ff52bce290b57e564e9079fd9d0cb545c8aba73f86a103162d2e", size = 532135, upload-time = "2026-07-23T01:56:42.876Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fe/45/f8919fd936e8b79fcd9bda7b6d8e62613462a713f4f17987fd7c34399142/aiohttp-3.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9fc7b5bfec6573f3ae844f457fdde5adeb713f8b8e4a81ad64fc207b49383716", size = 1922742, upload-time = "2026-07-23T01:56:45.528Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f6/ec/9ca76b28a27525b0cc53e20842e0228b022f301ce1f436b7d814b4aaf2df/aiohttp-3.14.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8a5fd34f7f7410d1730d5c2ba873cacb2eed3fede366feb268a70ba22581ed8f", size = 1787371, upload-time = "2026-07-23T01:56:48.045Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/04/6acdbf17315f7b55f1937e3387acb89a3cddeb4995689553d064af8e92ab/aiohttp-3.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:270d3dace9ca2f10f0da5d8ebe519b7a310fc6112ed916e32df5866df0888553", size = 1912623, upload-time = "2026-07-23T01:56:50.605Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/86/e6/438b0c79ca6f45eb9fd9817dd4c01a91919a38c0de5ee9e05e2b4dc0ece7/aiohttp-3.14.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3ae5b3a59436d089b5395d910121a390feed4d00578eb95a0fd1a329fe963100", size = 2005515, upload-time = "2026-07-23T01:56:53.153Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bb/6b/62cbd6577758699525f5c712d1ddef57d9875fbab0ae8d5f5a202fd598f8/aiohttp-3.14.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2498f0fe69ead802f9675beca44a7c21c62fdaa4ec5145ea1c3ad6edbee29f85", size = 1879906, upload-time = "2026-07-23T01:56:55.818Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/00/95/18bcbf830a21dc3aae24d8f6b6feaf3db1d2090242d00a7868db2ffb0b67/aiohttp-3.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a0dc483c00da8b673abbb367eb6f8d8f4bcec30eb58529ea13cb42e7fd2dfa33", size = 1675849, upload-time = "2026-07-23T01:56:58.861Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/19/47f4968659c5e23606c3790c80fc624e691c153d036148449ee84d31b287/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c7d3a97c678d34fc5b59da671ee9cd630096ddc643e7b5a30d54a2a6f3574d3f", size = 1843496, upload-time = "2026-07-23T01:57:01.591Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/64/af/38c33c4dd82fddcb4e56c4653b6f1072a8edbc6b7fa15809f14932c41e2d/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f8fb78a83c9e5f741ca3a68cfb455c1f5bb83b4e7249a3848b3cd78d0a8563b0", size = 1827746, upload-time = "2026-07-23T01:57:05.131Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/9d/0537cda4885ac8f5b7053d164dd06312f4c483a4edcb8ee5b8aaf2a989bf/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:74ab5b6a9fb13e873e5a90946588baecaf488745e1db1a4a5c433f971f035098", size = 1853810, upload-time = "2026-07-23T01:57:08.043Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/19/fe/26f9c5e6458385aa86497836b0dea6fb2f027827d63f37c7856cce9286ee/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd52f811e65f6fb634b1047159657c98f52b407f8efec907bcfc09da9a4c0a25", size = 1668895, upload-time = "2026-07-23T01:57:10.837Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/4c/618b1db9b9ba079b8875d2cdf78e7c4a3bf72903bd5850fee7dd9544600a/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:f0f177d1b195b9e06376cfd7d308d8a1b920909a609d03ac82a8c73bbb16d3b9", size = 1883833, upload-time = "2026-07-23T01:57:13.672Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/c6/bd959bd1e4771f9fd944e9e436224c48c77b018b73b519b5aad346335bcc/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:498c6c623134f8e09a3c4e60bcd607a0b4590dd7dbf08dd40851b27cbb520ccb", size = 1844251, upload-time = "2026-07-23T01:57:16.593Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/19/08d41839658bdd44a0ed2480f3891705ecb487ce28c0dde62c9040c997e0/aiohttp-3.14.3-cp314-cp314t-win32.whl", hash = "sha256:b304db572b4368edd8dda8a2274f73156fe15558fca4a917cb8a09fc47af5963", size = 474180, upload-time = "2026-07-23T01:57:19.306Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/5d/3cd6ef0a2b2851f7ab913b5b079334781bd50ff56a323e4454063377a080/aiohttp-3.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:b20032766aedf6261c7a566585a40867d092ac03a0d81592d5370ef9b054f99b", size = 500528, upload-time = "2026-07-23T01:57:21.762Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/37/cfd1ed540a4d318da025590d96b728e63713c09e9377950fc655dadeb856/aiohttp-3.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:2e1161602f45a54de2ce0905243a95f58cb42dcd378402f3697f5e0b21e9d2e7", size = 469280, upload-time = "2026-07-23T01:57:24.241Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "frozenlist" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "alembic"
+version = "1.19.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/34/10/181eecdd552217d0342492bd6f3b8a96e973083379aace3d3402830ddc03/alembic-1.19.2.tar.gz", hash = "sha256:297950a8a91f6770eb82bfbce9bea55c728b90a5386c6e81430191a319d138b0", size = 2082643, upload-time = "2026-09-04T17:10:11.212Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9c/cb/9014784dcb0585977ae23b6f43331d0a33c51ac0d692506d12b4f5ee9f3b/alembic-1.19.2-py3-none-any.whl", hash = "sha256:32d553dcd577e6fe5c3c63e91468526d35e4dcecafe865d7db4e9b328fa93cb2", size = 267399, upload-time = "2026-09-04T17:10:12.796Z" },
+]
+
+[[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.15.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/d2/f4d173e22df740bc37b1db102b386ba719b66e95b0f0d751f556b387e6d2/anyio-4.15.1.tar.gz", hash = "sha256:9f28306018cbd6d329e64a36d58256edff76dd996fe423bc957326e578b82a94", size = 276966, upload-time = "2026-09-05T10:42:39.44Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/12/b8/4bd346e22b28902df4d651910f5242c28d84e4a5c2435ca5c3f797ed7e2e/anyio-4.15.1-py3-none-any.whl", hash = "sha256:6152fdbbf9a77fdec97731721bebf7c4c44f7c29b424b0065826173efc7ed101", size = 132079, upload-time = "2026-09-05T10:42:37.923Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.11.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4e/a2/04a9383e7512c91c54b2f34b3ff86dc7d2610506f588c2bda36e952a68f7/ast_serialize-0.11.1.tar.gz", hash = "sha256:cc5db2983805f6be786488aac8c5998d5b71965488d1b18c44d435a2205a5cb4", size = 953785, upload-time = "2026-09-09T16:05:27.851Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e2/cb/3577c66278e4ea4ff6968aee04327447335ecfc58c76123f68cf7f76d75e/ast_serialize-0.11.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f7ca1557553fdab313999ad69156de154ff87152cae963698be2e765164bb6c0", size = 897021, upload-time = "2026-09-09T16:03:59.316Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/47/db/9b4eed53ab0bb63653f56ef71062fa91693c8c26b0b648c58d98365c990c/ast_serialize-0.11.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8b54e44763a851c336ca137c60a2434511f0d155e0b924ef374bfbc8d8db8927", size = 1235148, upload-time = "2026-09-09T16:04:01.201Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/97/1ebe323015c3cf530f08e88df9929bfd9f5cf8165842bd4b37a7c958565c/ast_serialize-0.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:753afabcc4abf295f515ea33185cf997a1990b88a29d3a3336a9acf62ea85950", size = 1216082, upload-time = "2026-09-09T16:04:02.87Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/72/0d3a368edc2d1e0e188c0d3f23821f4e20a6a2291b23d9df482a6b11277f/ast_serialize-0.11.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98b8aba6bb682b9e8859c628382b4881c0600b28056d63c3168c227c449f3284", size = 1282848, upload-time = "2026-09-09T16:04:04.316Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9c/fb/2a546a57d7caa708d739c1747bbdf45cc3aa9dac9407a11d9d67e8a0e255/ast_serialize-0.11.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:651a7890558896c3e08089e51ab3b3a43710eab15b72ad861c400bc9a51923ba", size = 1285337, upload-time = "2026-09-09T16:04:05.899Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bf/16/4ff4179584f8b8bec348787bf721cb7ce3d4c707c7878778065249b59b9a/ast_serialize-0.11.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ff8ddc1453bfe7934292409c7b8e9f68b0a6cff4e4c12535e4b4a66fd83aca0c", size = 1554906, upload-time = "2026-09-09T16:04:07.42Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/df/e8/e54a54676ca8965e1ae3cfe065dc26c75158e0b3a3ce35af283da106fbf9/ast_serialize-0.11.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:daec16b026c5741950a00c708acdf698c4f17babbe4829dd8232324822e9514f", size = 1301472, upload-time = "2026-09-09T16:04:08.782Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/ab/618835a2479868a0d4ac807dd04cf2f89d24afe22c4171538d9779c2772e/ast_serialize-0.11.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9961abcb93bf03652ab09c00862a2396abacd57551c769ad34490a2ae508a61d", size = 1301293, upload-time = "2026-09-09T16:04:10.17Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/cb/8acc29a1b279ccdfb30dcbdf099e1d8d34c4ee77be9be751c48061433129/ast_serialize-0.11.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:8ca9e48edf246f09fd9bdb64fbd9cd8d18cd2a69ffc24d44891466e17595094f", size = 1307807, upload-time = "2026-09-09T16:04:11.989Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/74/bada875132f452cb5c1179e3156df43cee6df6cb51f773220688be3d4bb4/ast_serialize-0.11.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6a57e0e025e9dcee48e466b3cf909178e298d238148664e796fc0f60ded5e52e", size = 1356265, upload-time = "2026-09-09T16:04:13.429Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4f/ae/720a8042fc8c1d170f4cc7ed46295ef078f8198ed3476f58210a1e675e0c/ast_serialize-0.11.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:110386eebccf200446d5f4dcc215f80866a5d3d3d054d3ced6ec1bf386cd3f02", size = 1459957, upload-time = "2026-09-09T16:04:14.878Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7d/2c/ce2ff1ffd4d70376073393c154033728c8535c17211b7710fee7b0f04474/ast_serialize-0.11.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:ef3950747f3a588f692cf4d6f2937eedd1a2d5e199f863af29e8ec7da78a4f36", size = 1562369, upload-time = "2026-09-09T16:04:16.563Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/3e/d7a5dd5f609bd0bac45617ce9425e4bd1e369b998c8678edfd70c985408c/ast_serialize-0.11.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0bc94b81878a3f999fe4cdb606bf00ef7dff6b4f66d0e089b2cf7bfc00d59beb", size = 1556466, upload-time = "2026-09-09T16:04:18.396Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/cd/a45179802a8637f2be252163ec4e4948534fa8d88798dd391c9cc54e096e/ast_serialize-0.11.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:341dfc9e6b4e47e5c37e1b7257a77d39f407cf49a371ee90225ab624c2fe8b36", size = 1687190, upload-time = "2026-09-09T16:04:19.965Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/01/eb/ef206d764ec0554368501b8b5268f5468819dc0588815acb0575465643df/ast_serialize-0.11.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:7b524cb1b08e15db0f116075c39ab51674b6d3c8103ec1a59c8ca464be83e28a", size = 1481188, upload-time = "2026-09-09T16:04:21.368Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/37/9a724c523af7c8b97a659bf4dc28a8e60f97d0cf4d19be277db4067ca734/ast_serialize-0.11.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5c2358b341aca08bd2e1005713bc480bc06eee9f345b67fcb826829aa7b8d0d3", size = 1500731, upload-time = "2026-09-09T16:04:22.905Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/48/10/890d5fcaf568088de7989e8cdb4ca525f485bd6cb25eea49d45f017500af/ast_serialize-0.11.1-cp314-cp314t-win32.whl", hash = "sha256:b9e61143a5904f46daa0cde74ba60d3b7c0e3e000752ee138e2bc68e126a5803", size = 1119009, upload-time = "2026-09-09T16:04:24.469Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/61/2bd32bd16b5e2ee07badc8c32a73c545dc5a9f087ed19c07eee1243d5a1b/ast_serialize-0.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:31df8649761d5cb6eb0de2209bd4a167c7477c0516147c70c0b2f5bddc7839bb", size = 1155665, upload-time = "2026-09-09T16:04:26.638Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/b6/84bb5e1dc418e660524b873c5bac9be2bf13d38676c96feef4cd4e7d03f3/ast_serialize-0.11.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2f8f33e416a4c7aad12ad757e895c676e953b4027b80b90718dccea83d45111a", size = 1131854, upload-time = "2026-09-09T16:04:28.099Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8c/dd/16de2c0d23a6b298c735d4e4b56d86fa70476eef98e2c66ceaa65503b62f/ast_serialize-0.11.1-cp315-abi3.abi3t-macosx_10_12_x86_64.whl", hash = "sha256:a015ede631eeb098a23de8ec0cfe11a1dd02159ab7a26bdc7c6bde2befbbc7b4", size = 1235495, upload-time = "2026-09-09T16:04:29.654Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/f7/302d2251e6298bbeabc8a1815c9147127031517b305001a02f34fd46b6b5/ast_serialize-0.11.1-cp315-abi3.abi3t-macosx_11_0_arm64.whl", hash = "sha256:57b7d52d1f5c92905cd648bda9efc83cac33097de1e5bb68de8feca9b5f7e87a", size = 1215642, upload-time = "2026-09-09T16:04:31.186Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/93/06/93b6527646613502f364cebfb23783fa6701cdbe90761ee26144f1fa20b9/ast_serialize-0.11.1-cp315-abi3.abi3t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e47b9b028efbc0486263a49f782ad0ae3e879855fe5a2897b59feefb78e1c40c", size = 1283526, upload-time = "2026-09-09T16:04:32.597Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2f/ac/ffb216262c9a582d039d846081b8c3017dc368cbed5a2520deca5cb7f8cb/ast_serialize-0.11.1-cp315-abi3.abi3t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:00adb748034c7b1938ec56925f9f6230ffcd9c56d47355fe32485df29b90b977", size = 1287526, upload-time = "2026-09-09T16:04:34.214Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a2/06/19a4c4837c4d5e73b982938d6da3c9ae10513b61527575b3e1b8396f9298/ast_serialize-0.11.1-cp315-abi3.abi3t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:82359d00ea808c260c327e43955c0190bb7baef152a01ae0b5c74d05387b9552", size = 1558354, upload-time = "2026-09-09T16:04:35.669Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e5/29/2373199907b2d97feed176115308dfb3dd0446566b047009828f266d2d66/ast_serialize-0.11.1-cp315-abi3.abi3t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f35bb9ddeed4008c7d3e272dd1999885d712e1ce623b0a65ba8a8ed1d51c35cf", size = 1302731, upload-time = "2026-09-09T16:04:37.423Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/33/55/ab6805a1457dbe565c84f8d36e2aa4207ef22408adfd01d225823cd07484/ast_serialize-0.11.1-cp315-abi3.abi3t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74093ed682ba58456f0d4450da7fb62b826fddd97824d44fc4a81ca6e0bf9e23", size = 1301594, upload-time = "2026-09-09T16:04:38.861Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/e2/4f54eab2201bb420d39bf61423abcb5d4daffd28e2270e1c5eee2bf3c0f1/ast_serialize-0.11.1-cp315-abi3.abi3t-manylinux_2_31_riscv64.whl", hash = "sha256:4dd7218870c203eff4533cfc04a39f29077d6789b20f5b746e7648fe5762a548", size = 1309355, upload-time = "2026-09-09T16:04:40.543Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/07/755dd98664e2374080b72ccb5fea63d9f11b4bec2409a05b2a4ebc97618d/ast_serialize-0.11.1-cp315-abi3.abi3t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e8d20700766171a8a17f89cf53d7bd9712c509460d28a51f7f98340577b78aa", size = 1356645, upload-time = "2026-09-09T16:04:42.299Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/34/a0/fadbde3e108064236e2679728ce6d8247aefc81bac5fd82505b59cf69172/ast_serialize-0.11.1-cp315-abi3.abi3t-musllinux_1_2_aarch64.whl", hash = "sha256:20b3371c0403099cd55d59f4bcedb6d3994d9db3fa41711c648760a89ef2a575", size = 1459696, upload-time = "2026-09-09T16:04:44.069Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/02/fd/b4f95249bd895368ea8290668e27d1f0a5c4ad888bd72a34c7beb2a500d6/ast_serialize-0.11.1-cp315-abi3.abi3t-musllinux_1_2_armv7l.whl", hash = "sha256:cc1a78b913f8665dda145999b1b4805ad2ef442ecbe3b819512cf7f95e70498a", size = 1562517, upload-time = "2026-09-09T16:04:45.461Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/98/6afac594380410710d9d863b9ef41e9c6ca89bd901bda1464ee9e99180a8/ast_serialize-0.11.1-cp315-abi3.abi3t-musllinux_1_2_i686.whl", hash = "sha256:38f7141881e783bccc362d201d7fd7437934216b669b9fef39febc2f63fd2d9b", size = 1556951, upload-time = "2026-09-09T16:04:47.12Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ae/6f/5a81b5cbf1731f4722bc90adf4b4ace7dda69ca29837844147063aeafb22/ast_serialize-0.11.1-cp315-abi3.abi3t-musllinux_1_2_ppc64le.whl", hash = "sha256:13903a3f212ab9e5d05a6c3f2337288f4f8f4c18e6ab3817417ae7a3d46dee14", size = 1691039, upload-time = "2026-09-09T16:04:48.691Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/eb/d9b903206cbd6d5143838367d385fa88ec49eaae2cc12f284327c6e0af05/ast_serialize-0.11.1-cp315-abi3.abi3t-musllinux_1_2_riscv64.whl", hash = "sha256:e5a9c53e64732118ae8235d0e57eb90e2333e90ff749a1a7dca6f8bfdfa5200e", size = 1483297, upload-time = "2026-09-09T16:04:50.136Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ed/48/ee13b4079ec67e9b333a87e5bb8eee643ab1b49f7173b3fca71158c6cdf6/ast_serialize-0.11.1-cp315-abi3.abi3t-musllinux_1_2_x86_64.whl", hash = "sha256:aecb606f67f21fd1c0ffba1826470d2ee400e41b23881ad9a1b2157306865b1a", size = 1501686, upload-time = "2026-09-09T16:04:51.734Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/15/67/2175b79e1ee6b042e4bf8ed6871e60cafea7e9cf3fc69e87d7a9d520ae77/ast_serialize-0.11.1-cp315-abi3.abi3t-win32.whl", hash = "sha256:d1ef9c478d8c8ca83499704d13e5ac32c840ed7ca7884aaaf716166aca5a2806", size = 1119522, upload-time = "2026-09-09T16:04:53.248Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f6/c3/8c96aa5f121e9bdda0346b2df3919185eb1ec9a2cce2d20e311b4575ca0b/ast_serialize-0.11.1-cp315-abi3.abi3t-win_amd64.whl", hash = "sha256:27eef0739e0110f5db1ff5dfa38b3dadfcb6f0c31975a2b412f9f2bd72139cea", size = 1157260, upload-time = "2026-09-09T16:04:54.944Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/bc/8aa663209e335eca73c9e1006197222b6b8dafa6665e513cdd975aa65496/ast_serialize-0.11.1-cp315-abi3.abi3t-win_arm64.whl", hash = "sha256:f9454960bbf185d33c669ccd5c9b76c96709a4542a95a65e27342c4d10dd8e20", size = 1132060, upload-time = "2026-09-09T16:04:56.501Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/52/185edf155ff422744acfb2869a8adff84b7dc308027852feb97287b8688b/ast_serialize-0.11.1-cp315-cp315-pyemscripten_2026_5_wasm32.whl", hash = "sha256:2db9df3bca1431da25946ee8f2c50df01212e34e6029532bc90b92d05fa8d7a0", size = 897219, upload-time = "2026-09-09T16:04:58.217Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/a7/e738887429de70350d9e25f84a95efbdd086b79579a811509dee8b02d7d5/ast_serialize-0.11.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7b9a6089f1337838492b217707e9a55d0b9b407fe9169a960fa12282abf2234c", size = 1240585, upload-time = "2026-09-09T16:04:59.616Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/f9/46b64fa883f3c8b8cf51629978f16d8a2da3d5c5c02f64add40864907703/ast_serialize-0.11.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:68929da7fb1c7375f69641baac9519d5c41ee441cd09a591ea5dfc83107ffe6f", size = 1228038, upload-time = "2026-09-09T16:05:00.948Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ad/89/fe75c8d0f104a4be11cd0e23acecf129484c9ba06c7130033752d63a78c5/ast_serialize-0.11.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8945557ed3015173dbf8d44184da9621add9162720acbc0ac4832b5a091b4e8a", size = 1292388, upload-time = "2026-09-09T16:05:02.498Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/56/3f21c881900d8254a35195e1e962355b4d570ccd9cc193b0ba08abb81952/ast_serialize-0.11.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9cbed53bb8992b72e587dd47d0ca71703f5f715420f48ed57587c06c2fcd213", size = 1294413, upload-time = "2026-09-09T16:05:04.212Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/b2/8d77be3dad1139158c59e370391f4990ea73f7f102983392272856bd3a63/ast_serialize-0.11.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65c836d1ab7af65e64a1dd73de82572566e838dd27529b1124eac0ac86f35e76", size = 1565921, upload-time = "2026-09-09T16:05:05.753Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/2e/0675b5796c897f957fbdac6af0ebeeaa9a63cee866c1c54f1e5136ef5bf6/ast_serialize-0.11.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4ab6df9898600ff45149b86c12bb5aa3359cc71843ad99ad0c924d11392469ab", size = 1312160, upload-time = "2026-09-09T16:05:07.269Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/93/c2/1749fa4efae0dc98aad3c3d29f0178e2609208c3ba34700b4551082e40d5/ast_serialize-0.11.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3eebd3dd25a81839ac7d25b5f3fb3527f6141b35eca29f63d2613fe6254307fd", size = 1312405, upload-time = "2026-09-09T16:05:08.753Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/00/14/2afc9f9d7db551f805b4d5e496946dc3dc2a703d27294ccc200b6ff07a7a/ast_serialize-0.11.1-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:311333c5f58f55fc04121be2c5adffa42a19e1038a43a2cef862fdf58c45bf4f", size = 1319458, upload-time = "2026-09-09T16:05:10.552Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c7/4a/8b2866d9d6d5d0b037d7bf2b74db6e75a66695c503248632116f24009a8d/ast_serialize-0.11.1-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:aa8d0a9f6d02e7626cdf540555bc2f5313eabe803dcca04854fc628ddf4b1058", size = 1365055, upload-time = "2026-09-09T16:05:12.069Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/47/17/73119504574f9b46610ffb718501b254c8adb727d4e43c5babc3c62d4529/ast_serialize-0.11.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e209a797fdf8680d58d2e969a9ddb25058ea682f6cff59dbabc98d8aef4e0db1", size = 1467771, upload-time = "2026-09-09T16:05:13.458Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/56/f5/776bfb7a856ba0bb9bd373b76a90230fb77b1a10c987810b621ed244d5ba/ast_serialize-0.11.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:b391becd31e9889da438d388aac0362e3dfd222affbe45d920580c351486c787", size = 1571459, upload-time = "2026-09-09T16:05:15.15Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c7/43/86a655170ee36a8fdce65a922b7e34040bb319eb4ec251161032343c1fc3/ast_serialize-0.11.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:021afb3482d27d1dace9c8999724a13083e96c7ece785e53e418bf5df3b50e0a", size = 1568959, upload-time = "2026-09-09T16:05:16.677Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ed/b1/015a3a156dc9bd46e9c4e4f24a939eb0b87179b1c53c9495ac6f088f13b4/ast_serialize-0.11.1-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:c1dc60251d93beff32d4147ecd4ccc518b0f022a900093f6f3021c2012416f0f", size = 1698173, upload-time = "2026-09-09T16:05:18.248Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0e/ea/a988b70980aca3a8a3fb731901dc911fe73a456cebbc225b767bbe5490ff/ast_serialize-0.11.1-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b77d6a2267227d68d8221cfca177f8c6d9f68019f3250401d0355d2638db9fb9", size = 1493298, upload-time = "2026-09-09T16:05:19.806Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/15/e049b2701ddab9087d7f62448f4c2c1b1463e676baa471345cf3e4a31e1b/ast_serialize-0.11.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e68ac7d7fd1a5d42a3a6d726d7cc8a7e0c9987934f11c6a5162aa2cf68e81e24", size = 1510213, upload-time = "2026-09-09T16:05:21.402Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/46/a2/23d555eb842d1397dce54fac31851e6f151e03a0ae74db389d9b39718c33/ast_serialize-0.11.1-cp39-abi3-win32.whl", hash = "sha256:ed449d786b9032a7b85fcd6c2f7f54c4cd0e1e1ad254d396805ff922096bf08d", size = 1125239, upload-time = "2026-09-09T16:05:22.796Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/4a/251f3fd1b8a5549edaedf8f3ba0b9fb5060e194d3c0ed208b593fccaeff1/ast_serialize-0.11.1-cp39-abi3-win_amd64.whl", hash = "sha256:6b43f5a9b9a8dd20ba3124914e63aa7d7427de761ac849081cda403c2112fda0", size = 1164260, upload-time = "2026-09-09T16:05:24.714Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/b5/08e2f643feb9e4d72d42a484949ad51238b18262a01c7036196c201cc330/ast_serialize-0.11.1-cp39-abi3-win_arm64.whl", hash = "sha256:a579ea6f473aab3958a64734194b22fbaec108ec45d994c28d3bd721e1e1da32", size = 1137533, upload-time = "2026-09-09T16:05:26.095Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.5.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bc/61/2cb6ad133dbbb449fa2d37ccae973232f4827e799af258d15e589a3d1e9e/charset_normalizer-3.5.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:4f298bdadb8f0b9e5672877f647d1be9373ef5320c9e2f049795e26cad28b6a9", size = 211584, upload-time = "2026-08-15T08:17:33.597Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/57/a305c968be1ca13f3dd1b32f445877e97addf55d80b65c7cb35fac82b777/charset_normalizer-3.5.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:88ca277405c2d3b71c4e1c2ee0e7966e807bcba86a69d11e19ba199d18ae4491", size = 223359, upload-time = "2026-08-15T08:17:35.022Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/0a/d3646670292ce8d8f8cc11ac067d44885e697a5591f57a9221128da5e7b3/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9362dd90aa7dab48c0054a21187791ccf05473f7dba5d92b8033ae62164675e7", size = 194464, upload-time = "2026-08-15T08:17:36.452Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/93/d51ec556e01042fed6f993ea859311bc7917b466684182fbbceb6ca24762/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:977cdbd483a9cff38179bea4fd754289a6f2195c7abd414aba85410b3e66cc5e", size = 197676, upload-time = "2026-08-15T08:17:37.819Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d", size = 340473, upload-time = "2026-08-15T08:17:39.303Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a", size = 240156, upload-time = "2026-08-15T08:17:40.66Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/53/27923ce5cc6cbccb832037b27dca98882d9c53e9b69e866bbbef4aae7fc8/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d59b75732e9b6f27388e10c14b0259cc5f2e48c78627d185e6a177b58ad3cffe", size = 228246, upload-time = "2026-08-15T08:17:42.003Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ce/48/5a97e84d63af1d55c07439cb80e56d99a8efb4295700eb4e18c0d1615d2c/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0d929fc574b4d6fd9e7c0f5c2ede8716a41911923aa7fa5fce38e0818aa4a1ac", size = 263660, upload-time = "2026-08-15T08:17:43.627Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7a/c2/071575791dcc88316c0a9a65ce38897a82e4cfe4a325f0f7fe1b1ac47bcf/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:394fea06235c8543390050ed5f529187074b029fb027213f6c46ac11ab5d950e", size = 260354, upload-time = "2026-08-15T08:17:45.094Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4d/66/70dfad64f15be09c15ccfee81330a7e515895dbe296dd23114e9a231268a/charset_normalizer-3.5.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa48b1b63d639f9483e0633e092f5851e2348c352f1f9bb6c8182f87884ef876", size = 244583, upload-time = "2026-08-15T08:17:47.963Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c0/24/ef36367d38b9ddd4bccbf72888c342e8de1f5ae506fa0b2dcf970e2732a1/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c71fb0d56c920c269cd3e2e3fe7c610e3f1fdb21a6ce60efa6430ff63676cea6", size = 242038, upload-time = "2026-08-15T08:17:49.481Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/db/ab/55e683ba0fff2e43adafc10daa3001eac90fdaa419a97227d5a7067eedde/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:485a0d363cafefcd2538a73c7c838daa2035f09b2c9f9b5e3133f80c6aeb84c2", size = 233677, upload-time = "2026-08-15T08:17:50.845Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bd/67/0f40eaf8d1b6e7cf15e82382a2965efaca787fc1c2794b7021d37aaf5036/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0ea61a470e070686aa30892fed79e297d2c8d0ab46b8bcdf027d38c51da591", size = 264491, upload-time = "2026-08-15T08:17:52.61Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5c/64/12b4c2a11ee8df4fcc518c78b0d93e3a92bd3d5253d1617ce74ff0e8c7ef/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90b7481fb62fbe172c558bc6fd1c4c98d82004a54a7551f20e11ac9bf0b8708c", size = 245196, upload-time = "2026-08-15T08:17:54.023Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/2e/651d910af6d0fba325eee1cda37ec5443462ed25360e666c144166eb6091/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:35fe081843b35aad20ffeccec3eeffbe637b15d14f3fb22cc1b59cd8ec17e93c", size = 261660, upload-time = "2026-08-15T08:17:55.491Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b4/d4/703be739b26acce318bd29eb3b25b7209e1b1f527f9eae3d1f1f01fdde2b/charset_normalizer-3.5.1-cp313-cp313-win32.whl", hash = "sha256:d63600d620ad0064c3a748b950ac5ea38a80190e5498532efefa4b7b3f1da1f3", size = 177755, upload-time = "2026-08-15T08:18:00.037Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6", size = 199295, upload-time = "2026-08-15T08:18:01.506Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5b/75/5b20dd1e6573a01a08158fe104104fa2c8abf941745596954185726cd46c/charset_normalizer-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0", size = 179856, upload-time = "2026-08-15T08:18:02.929Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/cd/2b812ce5e888f1ce69a5350281e58aab07ae64a958ecae8912f30865718e/charset_normalizer-3.5.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:774d157f112367ff4abd29019f38f023c24e00e56edc7829c20e358a5a913ad8", size = 212318, upload-time = "2026-08-15T08:18:04.403Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/4a/a6ee107430768a5334e6d63f31f148a04a1a491ef161a1ac9415a73f2fa8/charset_normalizer-3.5.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:26422d45fd13551cf564c58932f7d72b4f58b93b0fcf18c35ba6be12b46bb102", size = 224897, upload-time = "2026-08-15T08:18:05.997Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c3/d9/35ae3f64f29d0179c35c3baefe575904df2913dde519129c7f75995a2b1d/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:09a7bba9f739468c8e78c36a75c33768e53cb1959fc638f510454c14683f00d5", size = 194848, upload-time = "2026-08-15T08:18:07.397Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/74/76/f2fc7380f056cc273a53af37f50d08ad54b2c59f61078f31432edcf1c2bd/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4c9548dc78002099910abaebc0a72ac58b7d30931869e0351c09b507dff4ece3", size = 198163, upload-time = "2026-08-15T08:18:08.989Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/40/095ce62fa078483cccc1fa2b36e6bc9580b85422a20ee9f925341c50e44f/charset_normalizer-3.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c428c6c31eb5f4277d7f8eccaf767fbd548ddd5ce3c8b4f4cbbfab3d96b5904c", size = 341823, upload-time = "2026-08-15T08:18:10.458Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f1/5a/0e58b1c04a1596e0256f407274a92d5fb2ee21324409d1fab1da48a65b5b/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f06b7eae9dbe77fe1d644ca244dad508de8d302870a43f3c559b521270938a0", size = 242458, upload-time = "2026-08-15T08:18:11.989Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/95/b4618ce912e6db0b1aae89ba788e38e8a7eba0f3025cc66e8c0699f977b2/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b7430cf5728e68f6c462254009a6ef4086e1bea43cf2f57aa9c55fb4f50ff96", size = 226717, upload-time = "2026-08-15T08:18:13.401Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8a/76/c681192bbda3d55356db5dadd64381d5202b37c6b598fcda5282e88b5d3d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab743e9bc90c1f73552ec33e10e3331315acd2c397b36065b591b0181de533cc", size = 266111, upload-time = "2026-08-15T08:18:14.961Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/88/be/55127bfca72c0cff6c022488d140d7c5b04c771e3b72e9bdb4836d54979d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6f7deae3feb4edfa2efaf7c574fe88cbf055038a6abdb40188e4fff66d5699f", size = 263128, upload-time = "2026-08-15T08:18:16.515Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/91/39c3af510b0aa32bbda03374259200f28430febfd1bf5e511fe765282ce5/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15f024313246a4ed976c60f440bb8d257815513a681d212ff74fd46f7d715a90", size = 251240, upload-time = "2026-08-15T08:18:18.127Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/a5/cbe418bbc6ecdfc3e05a0116002897c4b403a5e838d697e64c78e9f0190d/charset_normalizer-3.5.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:823f82903d189af463d7df250ef1f7f696f3cee08cc8d91deb565e8d425f6506", size = 245282, upload-time = "2026-08-15T08:18:19.625Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cc/a4/689bb42e8e7cd492f3cb64907c6bc00ad247ec9a3628cd3f8eed126e8ae1/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:01e93745f7f219b703b60ba7afead36cfc4242782be5af484673fc500df12da5", size = 244597, upload-time = "2026-08-15T08:18:21.121Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c1/ce/9962938e179cf9f699d3f1e7b3114b5d7642dee6a893745229f9dd04f274/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329fc3ccb63ad22d867d84c2adea759a64079a37ba4a343433b02c7a2816871e", size = 231376, upload-time = "2026-08-15T08:18:22.57Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/54/46000450ada53bd9eac5429a2c8c54cd2d9b39c0c255f229aea9af0948a5/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:bb57753e36e4855b8ca375069482250a6246372331a3e4f3407eaebb007443f5", size = 266715, upload-time = "2026-08-15T08:18:24.235Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3d/bb/618749d70f792b44252a777bf89bfb86823b9bbc1ea13fe8ce759b07f38a/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fce8cbd4997efeb450bd298b54f755dcdff18d496f7a5ddbb4867c6d7c88fdc3", size = 245848, upload-time = "2026-08-15T08:18:25.726Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/3f/ffb64458527c7668031d5eb095d978de561958dc9f5b53f8e488a533e603/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6c9cdde8becb25a7fde49924511aa2644d6f8081cc8df8e9452724303348d8e3", size = 264521, upload-time = "2026-08-15T08:18:27.193Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4f/ab/74a55fd803916a35ac461daf002708191aac19b546b80dc8cabfedc63d98/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9ac4444d8d4fd4c4bd08bf451ed3167aa9e7ec6cdb41b648794f1d1103652e36", size = 253054, upload-time = "2026-08-15T08:18:28.568Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a0/2a/6a9034b7d3c60b17499afb482df5878bf9fa20b50cc3887d5ef017a833db/charset_normalizer-3.5.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f03ac127268b43ef4fe9e6ab6794a6794b49485a0cc0c1db79876d2f33f75bc7", size = 140580, upload-time = "2026-08-15T08:18:30.214Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/46/1d362e1a00d035d66b9869e1281eee115907f7e390a16a07824ab5737360/charset_normalizer-3.5.1-cp314-cp314-win32.whl", hash = "sha256:1f5883d77fd409a261abb5dc8ccbe335720d798b1de4abb3b1d47ccbbc76b53b", size = 180325, upload-time = "2026-08-15T08:18:31.877Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7a/7c/4938c329b6a9d446f6a59aa2092ff7118f274209b5ed0e26893d1d30a63c/charset_normalizer-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:c658c50ac0c98cd755a2dd50b7977d3bca7df401dcc47fbdfa87db53ef7d4e8b", size = 204175, upload-time = "2026-08-15T08:18:33.466Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/33/eeb384dbd8dec570661354592f4f2e1b2fcc92585624d146a000caf53841/charset_normalizer-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:4bea7f8ebe90bbd7f0e4a2de42ca6924ba23e3e76418c408ff82f1d46fabd687", size = 184123, upload-time = "2026-08-15T08:18:34.913Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/6c/c73fa9d5a85f6ab05395de61c5f6984e0a9ff40bb5ff888d46dff02526c6/charset_normalizer-3.5.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbc597639158fd7c14d55e808718848319540f51b0e6746e3eefa59723a4a348", size = 381682, upload-time = "2026-08-15T08:18:36.349Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/c7/63565f860921457feba93bae6c86fb7746deb4cffeed2f375cb845318146/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71c909f353863b2b89c83de2ebed71ea6d0df8a6ef65a128193c5e650766bef", size = 240826, upload-time = "2026-08-15T08:18:37.887Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/ae/7ae8807410dfa33f8e6f1715740adeaafa8a816cc4cb33508f54b1f7c896/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7ac76cf9afd34929d76eb7fcb63be476a4853d8a96f0dcf2d0db68a0cbdf9885", size = 227861, upload-time = "2026-08-15T08:18:39.315Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/a3/887c1642f0da26000b0e0652d91071113c0e72cea33952e225cf589f49a9/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a3a370082ce34d0612f421e15fe011c53bb1feff21a26d06ad4fb244dab5a375", size = 260758, upload-time = "2026-08-15T08:18:40.88Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3e/11/e6f5b9a3d0e55b0ef7505cd3765cdd48f22db89994c947b316f52f801fd8/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:256dd4d85d9e4dc595e2bc983c980e73f62ddeb3165c58b4c3dfe78c5c8548c1", size = 259950, upload-time = "2026-08-15T08:18:42.351Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1b/ee/e4e10a94d51cd1ee638aa7e00b65399e6b2a4e8376ab6d2eac9f95586671/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58d4aa13a59c969dbfdf9e6a9560e242cbfd9e8a8f50c2747714df1a423adf65", size = 249329, upload-time = "2026-08-15T08:18:43.914Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c4/25/d5f4198819e6059735a84e8d0bfb72dc33976da67b97adcd3fb5a5e07ec6/charset_normalizer-3.5.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0c6dfb5ca6723eeed15aa8e564a014d69fcb8812f94eef11fe3631e0508199f5", size = 243137, upload-time = "2026-08-15T08:18:45.368Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a5/e9/e925ca7569cf9fb9701fd82503fee73eea5268fdb856bdd64947092d3daa/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c010f5581d9c612804cc59fcf7b524b707fbcb72828551237ab545bb5c7034af", size = 242820, upload-time = "2026-08-15T08:18:46.842Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/34/17/672c251a888ed2aebcdd2fe830ad0104e25ff83c43f5c4f9c15e9fc6853c/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:52ec005752a56ae79547a05c0139ca2501a0c866390b6115008456b9f0e7cde1", size = 230504, upload-time = "2026-08-15T08:18:48.353Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3f/fc/f6a85abebd42ce4da2f1db0aa56cc6a0df1995e318b3875d14401b8381d1/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2bced4061f000f7187254a02ad3433ae17eaf991747ceea2f478422590a5bba9", size = 263087, upload-time = "2026-08-15T08:18:49.859Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/98/66/7c42677e739ba66746b297e2046918d793078094dc239e1e72768cffccc6/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9eea3ab2597a5e65fe65296e2d6a84570845a6b55532d90333d740d48bbc850a", size = 243269, upload-time = "2026-08-15T08:18:51.601Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/d8/a50b79237f417af10f8c2a501ce8d1ca87829a22e69117891ca4ba20a69e/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:496846868fea80e479324862fa877f02411f2fd0f83b79ccee2607aa68b2a032", size = 258766, upload-time = "2026-08-15T08:18:53.23Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2e/1d/0fc91aeaeb3c83b748f532399ce67cf84604b48297405d740000f7a9e786/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:85d5855daafc240cc045c026d7a15fd198a09b0fc8ff6f5ecbb5297b509cb11e", size = 250814, upload-time = "2026-08-15T08:18:54.768Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ae/10/3d8c777cf9024615295aa1b808324ad5b4a77855869c00824bad74ffaf8a/charset_normalizer-3.5.1-cp314-cp314t-win32.whl", hash = "sha256:58d3e12c88e0950bca850ae1f7c256055c097639c2edb9eb123af9807d8b15e4", size = 191074, upload-time = "2026-08-15T08:18:56.305Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4d/81/ae557d3c44d1a1d688696d60563413a0866a91b7ebc50f20df838be3d8c8/charset_normalizer-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:acaf604462bf330b0d07e7a07c1d6e4adac79e5fb13e9c5140590542cafacc00", size = 216476, upload-time = "2026-08-15T08:18:57.889Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/e9/61c01fb8b804692569c036b3fc50495814502dcf13a60649c6055390b02c/charset_normalizer-3.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:fdb8a068947befafba9952162645dc2fecaeb400e64584829ed5e9b2fbe21a7f", size = 194115, upload-time = "2026-08-15T08:18:59.418Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4a/4e/8544831ef59d8f27ce92c80871380fdacc8076a8a56ed62f82e54f991333/charset_normalizer-3.5.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9085f87b0e38a2b92b8923059b4e8789fe40d9279712d15dcc670048d77079af", size = 342048, upload-time = "2026-08-15T08:19:01.054Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/a6/e3b46852424246065355644f4fb6dbccc0239a42a2eee27ecfc8957f0bcd/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2679de311c7946dde5d3b6f44941844133ff5c7cb86099c0061ab1e8901c20a8", size = 242997, upload-time = "2026-08-15T08:19:02.492Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/03/3b/0cc9a26777334ab2f2e3089b948bbf4e4fe72ea70b897715ef6415043ec8/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:baf3775a2635e5a11fbd5e4e64ee69c7e86875d224a5c72aca4c141064589a90", size = 237014, upload-time = "2026-08-15T08:19:03.943Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8c/c2/027335f0aa337a2a2e121bac1ad88c4f02ba6053ea0926802784f3db11af/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac8c94b6539074e0f40899301273ac8402b9b3e01c7b7ba269ff30340aaaf20", size = 266174, upload-time = "2026-08-15T08:19:05.598Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/86/d3/e367787febe4e74769dec0f406f2c3c8d1b955fce5aee1fd0f94e8367a45/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8fe532b3c966d1fb794e0698e4589d0444017ae77fc0b31edea13c0e35bcc449", size = 263361, upload-time = "2026-08-15T08:19:07.251Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/af/3d/391b193eb9f3e84b02f9314088c386debdc0debee843535aaea2e2c6715d/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c84bec0ab5ae0c64bfe73a7d2adcb5ce73b467523fc27fd6a28ab2aa6cbe35a", size = 252143, upload-time = "2026-08-15T08:19:08.816Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2e/57/de221f1745a90d418199761967e2776bfe2c275a1194220985e8c1d37833/charset_normalizer-3.5.1-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:854066be00447fa8de2ccbbe893e2ffc4b123ef16d897af794c1e18bd4a714b0", size = 252086, upload-time = "2026-08-15T08:19:10.255Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c8/e3/d119f86a01f9331e8186175f24873b1d74a7ee9e2e4b4d68f9947dae5afd/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:21b82d8082f6f5e7f456ef0bd16323d08de1266efbfeb476e64b2a91d1471a4e", size = 245231, upload-time = "2026-08-15T08:19:11.807Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/26/de/d8e48c135ae480879539cdb179c8d3b50c7879497d75dd899b5763b69cee/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:838648accb3a7fd9803fd45c87bce8509648eb0c11bc34e216141300977244f2", size = 241546, upload-time = "2026-08-15T08:19:13.416Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/c4/217755fd1abc50d326c252922cd642002758095a81ff45010337b8b3ef65/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:195ce897c6153c0700078142cf8efe3e6454ca4cf4357499e4078dfd83396626", size = 267033, upload-time = "2026-08-15T08:19:14.981Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/d7/34d8e404e358d2adcc5a228c2134643af00104c8fb0bf525f3688d756f05/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:978eab16f55b4ab2c2a745be9a0a840bf8f09a7f227d9c76eb30214d078865a5", size = 252045, upload-time = "2026-08-15T08:19:16.618Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/fa/40414471acf0aa0692ca77305aa00e434fcd8288f0941c93c30e9a5f8f2f/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:cc0329df4caaceb950d2f580b5ac716a377f7059624a0bafaeaf8a218c6ed774", size = 264866, upload-time = "2026-08-15T08:19:18.101Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/32/90/fcc850bae791abd2e0c041847f13e270aa08692a79f3e00de6d2dce1cb50/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:687c9ca3035544b113bea2055e180af96fb63c0c476e22a9180f51925186e7b7", size = 253932, upload-time = "2026-08-15T08:19:19.734Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/af/af/53afe99068b3c10b4cbae592a52ef72a7c92c0188440e83ee3a078fd8f75/charset_normalizer-3.5.1-cp315-cp315-win32.whl", hash = "sha256:706bfd38730a5ac7a365793269a00f4e988178cec121391f4248d84ad8c972e9", size = 180320, upload-time = "2026-08-15T08:19:21.37Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/bc/f46a132041b29e4a8779ed712d3df1bf112e94ca8de58b66d7ec2c0cf8b9/charset_normalizer-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:92caef967d287a407085d61176fce4012b1dd62daed4eb6d5ceb26d3d2538712", size = 204174, upload-time = "2026-08-15T08:19:23.088Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/5d/9ed554480eda8e447b673648628fdc29574d23dbad01fe11837adedd1cae/charset_normalizer-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:5fc45d653ea8c9a20479167e11d4a0f8cb2fa3470737ab6f9c827532313187b7", size = 184126, upload-time = "2026-08-15T08:19:24.471Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3b/32/9b8929bf384061ee1fe5d9c27c6f9776d3d824039ad4e14c88ec00c7808e/charset_normalizer-3.5.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:59171c6e45bf07d0d5cab3b0bf81d945035530f6873398b3b531c31184d46663", size = 381441, upload-time = "2026-08-15T08:19:26.038Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/10/e9aa7923d3ddac652c99a1c5f7be494e737e151566a44abe018daf757f2c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9dbdd9205662134957cf0c324f639bdc5031c0ca056e2369e238db75187c0f11", size = 241742, upload-time = "2026-08-15T08:19:27.532Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/53/a2d249ebddf47b889a100c0bdcb61a2f9dbb8bc24ef325cc062e4f476877/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e4b018dc5a0eee4676e38fe84a47a427816c590b93b55d9025274ec4d6ffc2dc", size = 235298, upload-time = "2026-08-15T08:19:29.274Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7d/07/469f78af590f7d5cd48e20d8dbfa3d66deeff9ba37768c04d886b5afd45c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced3fdd71aaa83ce593746c2edb42b7a59cb4c19c8b5c407781c72e493aae55a", size = 262500, upload-time = "2026-08-15T08:19:30.955Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/66/3bb56a47f7dcba014055b1a1d33c6f08bbe9c1e74dba154cfa25f90ae885/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:19a3dd5aa73cef1c99687c4fc57db016a9c17104ae1185da88ba566a5d3bebe4", size = 258888, upload-time = "2026-08-15T08:19:32.458Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ff/c1/2adc2800903fb013210349313b710a5376856578d9e33e6b9a1d8b36714a/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc5d36d96478aa9c60654bd932525bf32964c62a7281eafdf16d85003a8d6004", size = 250243, upload-time = "2026-08-15T08:19:33.94Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/95/b5/a18d0dd1157ab655cc2cb14a545f4a4784bbad70ab3502412e36097502d9/charset_normalizer-3.5.1-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:04368edf83514385ffc3e1cfd4546e595f4f1272dd23ba437a93a9cc3741d47b", size = 249871, upload-time = "2026-08-15T08:19:35.413Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ad/c3/525f508cd1e58d0450ac55ed40ac75bc3a97482c59def5278456a5fbf03c/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:9b5db6052055d34d41230fb78d7c439c23dc536a9896f6cb039e8dd92cfc1263", size = 243580, upload-time = "2026-08-15T08:19:36.886Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7c/c1/49a91fe7e97c8140094ca5c64161ab623a70d9f636bf834eace14048acb5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:252d099029bcbea642f2a06c4ed5046bdf8b5a8150b64afa5e027e88b106e5ee", size = 239807, upload-time = "2026-08-15T08:19:38.392Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/58/56a48c296601274c4689b864a8e2dfb209b81dfcb39472753ce95eea662b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:6199d5606e2bbf2b096cf64d03f8b6790c91081d5ac866b8e7bb6422738cc60c", size = 264083, upload-time = "2026-08-15T08:19:39.856Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/4c/dc48409274a1817ff349711d26c62aa0c597df865d4d69ef79160c859193/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:77efcff2b23071c349402ac1066667a3d011f62398d81408c9b88ad991747c9e", size = 250317, upload-time = "2026-08-15T08:19:41.53Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/58/d325912115caec62d6bdd77bbab5e0b7da5d234a9f20affdffcbcb530d0b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:a5cbd90ecf0fc62e64726917ad083b73001f0563657a87ec3c0b504e277dc90d", size = 258173, upload-time = "2026-08-15T08:19:43.07Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/34/f7/b13b1ccae2c8ec63980d13be1890eb73f8aeabbfce02a24aabc0908788f5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:4d26f14f041e83dd8edfd61f4cd4fa7285d31798b5bf1f28e70c367ba6c41d61", size = 251960, upload-time = "2026-08-15T08:19:44.587Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1e/25/ed3f9919c5aef8cc818be1f972f565f7610d7b2076b8ebb98839516ffc3c/charset_normalizer-3.5.1-cp315-cp315t-win32.whl", hash = "sha256:ac13b004224fb341e1e25a1ed5e19d32f57cdb2a403e01f003b46f051a550f6f", size = 191186, upload-time = "2026-08-15T08:19:46.293Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/69/d5/43c2b3e9d8267092b913eb8b0603f0f71993c395632886bd37a7223f96cf/charset_normalizer-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:35aea775dc2bd5f54cd84a1cd2696cc3207c479cb9cf0bd346f0d343e4300ddb", size = 215947, upload-time = "2026-08-15T08:19:47.853Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a8/76/9aad3e9c8865e5e0efa9a7f6f81c37a67635a985145ecd44528a81e088ee/charset_normalizer-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:fb78f6e7fcd8ad785d28cd577168bc1aaee827b25bb8755638f694794ea98f0a", size = 193909, upload-time = "2026-08-15T08:19:49.383Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "courlan"
+version = "1.4.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "tld" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bb/16/2a771612ee0b3acaa95ac21cc7e8a3319e815d6360f8ffc5987d1ce28499/courlan-1.4.0.tar.gz", hash = "sha256:fbbac7b7fcde2195ea08e707609503c81cf39c891e8d26cdb1fed4585782d63d", size = 208997, upload-time = "2026-06-01T17:30:17.306Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/38/ce65091ff20a16e06d17418c4353af5f56d3190821b1a06983c79ae79274/courlan-1.4.0-py3-none-any.whl", hash = "sha256:ad1dbdefd912ca7238d4607dc855df5df097f56bac175dd662c84eed3802f49e", size = 34193, upload-time = "2026-06-01T17:30:14.984Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5b/f0/424cb557d99aa86ac55da5e2add02e2882e44047b6264f93ade1b975a993/cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f", size = 3973525, upload-time = "2026-08-25T19:44:30.7Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4d/72/3a2711d967977ab5fc80b782837c7e8d1ac7445e764c20c381a265c57ef3/cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a", size = 4708817, upload-time = "2026-08-25T19:44:32.773Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b4/f2/bb1f56e10815b789df0b409a69fa4992ff3d3fef9c72747f4a6b26fed38e/cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367", size = 4697300, upload-time = "2026-08-25T19:44:35.144Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/08/bd/ed5396be499ffcf8807a585bfe38b71a1fbdd1c342b4f9b6d0ef5162a946/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5", size = 4716039, upload-time = "2026-08-25T19:44:37.192Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f6/6e/1cf405c5c8e8df7545378048e954792f00b7f2367af8863ce8b8f3e10607/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9", size = 5332388, upload-time = "2026-08-25T19:44:39.16Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/47/92/b4317e8c32c4f47b062f5398bd79106b220a124546f42be83bf32b761e2a/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0", size = 4730293, upload-time = "2026-08-25T19:44:41.298Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/39/0d/a1e7633e2c744d0f2983320a27e924ef2264c79c56e1a58d5fb0a1cfd413/cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc", size = 4346031, upload-time = "2026-08-25T19:44:43.245Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/88/dd/b215616f9bab3fc18510c78a4e5c9f362d77838503c363dc747c7d4f5c6f/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17", size = 4715344, upload-time = "2026-08-25T19:44:45.291Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/1b/ec3ebd31741d0e963612c4fe43caa39341b9b1e031e469820e42e4c83918/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6", size = 5287201, upload-time = "2026-08-25T19:44:47.297Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1a/01/0127d11a762b31a9ee0221894f540318761783f3fdc4bc5d057698caebd5/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3", size = 4730023, upload-time = "2026-08-25T19:44:49.435Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/b9/e7425ebfb599241a0c1d7000f1b466c3062da66c19d9525031315dff7213/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6", size = 4847362, upload-time = "2026-08-25T19:44:51.94Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/fd/60d0ddf4defa12e482c9d5e0f554384d6e8ab25341fd15f060028fd92e6a/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149", size = 4999247, upload-time = "2026-08-25T19:44:53.876Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4d/56/bc4f2b209e766c93372cfcd59b781a0b2b59700f62a969580415b699c2b2/cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf", size = 3825806, upload-time = "2026-08-25T19:44:56.209Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+]
+
+[[package]]
+name = "cssselect"
+version = "1.3.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/0a/c3ea9573b1dc2e151abfe88c7fe0c26d1892fe6ed02d0cdb30f0d57029d5/cssselect-1.3.0.tar.gz", hash = "sha256:57f8a99424cfab289a1b6a816a43075a4b00948c86b4dcf3ef4ee7e15f7ab0c7", size = 42870, upload-time = "2025-03-10T09:30:29.638Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/58/257350f7db99b4ae12b614a36256d9cc870d71d9e451e79c2dc3b23d7c3c/cssselect-1.3.0-py3-none-any.whl", hash = "sha256:56d1bf3e198080cc1667e137bc51de9cadfca259f03c2d4e09037b3e01e30f0d", size = 18786, upload-time = "2025-03-10T09:30:28.048Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.4.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c7/5d/bd21ba1519b6b1e222b29878301d2e1fb928e890dc7d085fa4222ac5671b/dateparser-1.4.3.tar.gz", hash = "sha256:bab8c43a746266e68142f4926e69438ce551441aa88e54e78bb6410bf3ee7000", size = 362152, upload-time = "2026-09-03T10:07:54.545Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/5f/63f927b5ffd1cc2c030fc2bd362bf920890e8806cf42f701198de5b3f9c7/dateparser-1.4.3-py3-none-any.whl", hash = "sha256:cbce86c64e0cea5c54c84c015d34c903d46c51bfad50632bf2f05a6141d10c05", size = 322384, upload-time = "2026-09-03T10:07:52.913Z" },
+]
+
+[[package]]
+name = "ddgs"
+version = "9.16.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/30/dd2ff7d817573e30836fb99bdc04e167ce03ac5b878072b3e9e892aa810b/ddgs-9.16.0.tar.gz", hash = "sha256:161ca8e78ea08d40cd3f83fb12279b49322ffb342d981368bfa39bed9847d874", size = 38018, upload-time = "2026-08-26T21:52:33.604Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f9/0c/b43a87e81e45caf2c30fea9a5914dfd17b83a9f3c2c59ae22b6257bcf083/ddgs-9.16.0-py3-none-any.whl", hash = "sha256:175d9198c958a263f51a06a54368ba0b41294942c0cd29f4aa71be03dbcd5f4a", size = 47580, upload-time = "2026-08-26T21:52:32.001Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61" },
+]
+
+[[package]]
+name = "docstring-to-markdown"
+version = "0.17"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/d8/8abe80d62c5dce1075578031bcfde07e735bcf0afe2886dd48b470162ab4/docstring_to_markdown-0.17.tar.gz", hash = "sha256:df72a112294c7492487c9da2451cae0faeee06e86008245c188c5761c9590ca3", size = 32260, upload-time = "2025-05-02T15:09:07.932Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/56/7b/af3d0da15bed3a8665419bb3a630585756920f4ad67abfdfef26240ebcc0/docstring_to_markdown-0.17-py3-none-any.whl", hash = "sha256:fd7d5094aa83943bf5f9e1a13701866b7c452eac19765380dead666e36d3711c", size = 23479, upload-time = "2025-05-02T15:09:06.676Z" },
+]
+
+[[package]]
+name = "drissionget"
+version = "1.2.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "drissionrecord" },
+    { name = "requests" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/2c/c9d6aeffeecd7f5620af419d8a33aec7d2ab29da7503a442dae2d7177a15/drissionget-1.2.1.tar.gz", hash = "sha256:a05519bea59cc7a588f1a5a9ee6844282e59963eac212baa406da1c20bca9908", size = 18014, upload-time = "2026-06-04T01:44:33.94Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b7/93/7e4f2026811349c70fb9b7a2cc4c1dc31a6592fa41554d0e4406b80bf83c/drissionget-1.2.1-py3-none-any.whl", hash = "sha256:cd0ae08c26e6a7f5bd105ca787d79854569c8ebfeb67f978b86aee7d2b983a29", size = 22254, upload-time = "2026-06-04T01:44:32.923Z" },
+]
+
+[[package]]
+name = "drissionpage"
+version = "4.1.1.4"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "cssselect" },
+    { name = "drissionget" },
+    { name = "drissionrecord" },
+    { name = "lxml" },
+    { name = "psutil" },
+    { name = "requests" },
+    { name = "tldextract" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/12/bf/872f23aff6181a2456dc94f955e43c5dff1bcaa2e4c64ed886df0bbbeee6/drissionpage-4.1.1.4.tar.gz", hash = "sha256:4c624485cbc576e1477edb77cd92a3184704f7d6d0fd01928c944a5e66ba4719", size = 207960, upload-time = "2026-05-27T01:49:10.846Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1a/98/6411ae36a9c103e4cf78e2674643c6c0f6aeb394ea84544c2bcff7f3f27f/drissionpage-4.1.1.4-py3-none-any.whl", hash = "sha256:d1d066e732031c16b00bdc88a2f450e8400da46362597a23c8c6144e4cbb768d", size = 258240, upload-time = "2026-05-27T01:49:08.774Z" },
+]
+
+[[package]]
+name = "drissionrecord"
+version = "2.0.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "openpyxl" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/38/21/94b080a620635599bc74b34291a1de8ef594626e8cb537505cec6999c6df/drissionrecord-2.0.2.tar.gz", hash = "sha256:37e337e60e451876f0f7cb635eda2bee1f527cbde87450d03ec29c8df7568ded", size = 44169, upload-time = "2026-09-04T08:39:30.707Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/c5/3b62be0f3d913d1aa690d47f010b295720254ad767f793409f8df5b44ff7/drissionrecord-2.0.2-py3-none-any.whl", hash = "sha256:d4d88b484326eb6958a92b8b47b41348ff9b5bb19c7eafa972542901c8313cf3", size = 58959, upload-time = "2026-09-04T08:39:29.225Z" },
+]
+
+[[package]]
+name = "duckduckgo-search"
+version = "8.1.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/ef/07791a05751e6cc9de1dd49fb12730259ee109b18e6d097e25e6c32d5617/duckduckgo_search-8.1.1.tar.gz", hash = "sha256:9da91c9eb26a17e016ea1da26235d40404b46b0565ea86d75a9f78cc9441f935", size = 22868, upload-time = "2025-07-06T15:30:59.73Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/db/72/c027b3b488b1010cf71670032fcf7e681d44b81829d484bb04e31a949a8d/duckduckgo_search-8.1.1-py3-none-any.whl", hash = "sha256:f48adbb06626ee05918f7e0cef3a45639e9939805c4fc179e68c48a12f1b5062", size = 18932, upload-time = "2025-07-06T15:30:58.339Z" },
+]
+
+[[package]]
+name = "ephem"
+version = "4.2.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/f0/a38e882d3c73bb8bcc37a0a27c9a7b8fceb7906312006fb03c01d0a098b3/ephem-4.2.1.tar.gz", hash = "sha256:920cb30369c79fde1088c2060d555ea5f8a50fdc80a9265832fd5bf195cf147f", size = 1261529, upload-time = "2026-02-28T09:48:25.935Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bb/8a/2af7194252902b8f9bd6f282051864d86311b90e846a9f9a6c33798d60a9/ephem-4.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:19ad36d7a5bf63cd424576ff392d7bd9bf579d903b14ecd98173d577a51051e1", size = 1431651, upload-time = "2026-02-28T09:46:49.335Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ef/3f/d28fb26afacb07c81268a5f7b6a1c2b4a14d0304899c20502205dfccdeaf/ephem-4.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:458637fd487cdc897a86912089086161f042c3525a268245490565255bcf46a0", size = 1433094, upload-time = "2026-02-28T09:46:50.736Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/43/b9/008cbb78827b145b7afaa152af6991ba7fc5baa99cf16cf64ec9f0fef9ce/ephem-4.2.1-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:b99bdfa5372d83f43c052c845c05260e9355824dc0a88bbb0b9b4bdd438305fc", size = 1768840, upload-time = "2026-02-28T09:46:52.974Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b4/b2/2e6674089d4eb0e4cc4bde6e30d841ff9bcd2d513deebb4ae41b83eaef84/ephem-4.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ae26bc5abc4073edf6898e5969f3e7b77c47d3c88521177cb3df14fe8963259", size = 1788881, upload-time = "2026-02-28T09:46:54.655Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b9/b5/c04ddeea27c093146d064c994bd795ce5244533b839ef7ccfe35850fb289/ephem-4.2.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:078894d72e38cfaee8d00959d6720506af61c0fba5ef42f9e2ea1528296a4320", size = 1834059, upload-time = "2026-02-28T09:46:56.083Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/53/1c/c7149f3be5e9852316907621e6d6e2f8833b2044c12f041157495eb74358/ephem-4.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b37ef161ca287f025c7c299b612fbb7e83530840c938d06a61fcd7889a66db5", size = 1784679, upload-time = "2026-02-28T09:46:57.908Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/54/3f8575295de6c07b151d73dfa4d7ed0dd3efe6a02b7b633fbd74381e13d2/ephem-4.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e9934d309fb3c6d79373259b2a9fc71874a512b90d61523e334720805b6fa5c", size = 1787191, upload-time = "2026-02-28T09:46:59.71Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0d/72/b961fa4b1efb39ac0021e1e31fb3c0a6c5fad45d7fde4908748252e2ac17/ephem-4.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5530ca3c85a22d31838844427b96abcbe96da6048b6e83a675a5bcc23e5af43c", size = 1798895, upload-time = "2026-02-28T09:47:01.067Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/74/ce/93ad503431136611187a60c986441510cd69908add782003526e0d7bb24b/ephem-4.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:61e38e2affe676fc9f9a8fbd4f575f05ca7db4f87a6e5fc589a09c14fe68850e", size = 1817637, upload-time = "2026-02-28T09:47:02.712Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/59/ff/fbcd7a7795741e5770c73b39dd1318215b357f6e8d503233ca3b3fb10437/ephem-4.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:46427d35a2fbf4a95fcf6de9d36dc0a29e49b96a63654856285f0262c4082fc7", size = 1784648, upload-time = "2026-02-28T09:47:04.151Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8f/c9/340dd18a288ecdf079ae15711a84d8fb82bad63dc7f1e985b88aeaeea81c/ephem-4.2.1-cp313-cp313-win32.whl", hash = "sha256:a075014299467d29598019fb11972a8f3f476d28962987231b24a234ea8764f2", size = 1399821, upload-time = "2026-02-28T09:47:06.162Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/57/70/323fd7145e7a9abb4878c1abb5822b9578db3fa4d8d952806941d7c7910d/ephem-4.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:f22a797ab3658f5f1ae56dd32627e9ef4766aa3e9dbddc817cbb2741893a8a28", size = 1414942, upload-time = "2026-02-28T09:47:07.781Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/42/0a94728aaf67b9bb7ee2f0f300380ebaea3362f188c1d9956c0d88ada6ec/ephem-4.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6aa46747d0866afcaf64c25855546ecbeccb58456a93b368c963a8e18e414794", size = 1431765, upload-time = "2026-02-28T09:47:09.229Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/45/e3528adb5e496b4f2c6853313b4bb65f3ea665b41cd4553847ece39040f1/ephem-4.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8339dcc7187c99b169d3b0f650b9e1f1047f6d7687bda025acbdeb049ae3e9a2", size = 1433099, upload-time = "2026-02-28T09:47:11.941Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/aa/e8b86b27357eafbbdc15ab315014c15651c9009d504d73b9e1fab7ac7062/ephem-4.2.1-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:560a417a4252f4c77a8ebc325a081c684f24c2287f82579ee4eb62d382dcfa89", size = 1769064, upload-time = "2026-02-28T09:47:13.632Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/38/28/971ada8acdf52afafb1866cc474dba1cc3deb631f7092e7dc10faba88198/ephem-4.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ce6b0b076b18e9b7a7a9ff5f37573455849079ec232eae0419c172304e7d2aa", size = 1788690, upload-time = "2026-02-28T09:47:15.182Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c1/b3/75194b704da47e649a449d7797ce78f18b3147dfee761fa7dea83eb23fd9/ephem-4.2.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ec91aa7735a10bfd8a4f79afb39567500483a1b5812a3ba675fb10abb5aa95d1", size = 1833795, upload-time = "2026-02-28T09:47:16.993Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/c8/578499dc1383ddec58a79be525e54d47a23210c8147a65610ee7cf477406/ephem-4.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3610fd501549fe8e29417ecd9fecdbe19e1bc416bd76ee24e40ae81ce3049760", size = 1784463, upload-time = "2026-02-28T09:47:18.323Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8c/21/c76b805d70df3e45cf4795ec19bdb91b0fe42d473b56ea8c80f7706af1f6/ephem-4.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:27b8d6893cc47765ab55b2eb4f4bad97b8ffa844ff6b67b0dcad44e48d0b6e77", size = 1786832, upload-time = "2026-02-28T09:47:19.687Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/66/1e/79e7eb46c1bda35187a4cacc767f3d6707247a4afc759981c3c69ed6af6b/ephem-4.2.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e29c7aabcc32af070d99fd7a2268e7c854d7b68df3414133b5581eb9996939ce", size = 1799002, upload-time = "2026-02-28T09:47:21.594Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/ef/6ab516d889986a7c16731f9b7a89a9a689ca9a3196dc544d187f2f82f9da/ephem-4.2.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b831567c5db7b101e9e647cfac38da458f48b4c66bee949cff11a875f260d153", size = 1817236, upload-time = "2026-02-28T09:47:22.97Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4c/12/9c4d2014ddad6a9c4e3a7cc43ed9f9585d60a04475dc47b8822b78fbb3dd/ephem-4.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7359e573798357318738f628660946e4cee89f39e84940264e428504d541921b", size = 1784500, upload-time = "2026-02-28T09:47:24.319Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/47/b5/59b5554ba2f8a850a65e3beb52cf290b4616e2e94827261b3a3b826e1ac4/ephem-4.2.1-cp314-cp314-win32.whl", hash = "sha256:c0bc8c928b7ef10167b7a2f2f20c7ee079c3b988b9a3a943bda123949acef79f", size = 1406790, upload-time = "2026-02-28T09:47:25.96Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/a1/a40f57eae2589933943369d0aa4de024fbba18f5689c06c5f012b59627de/ephem-4.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:936d7a8745fbb18869e238d541f027cd7fc086e3fdfb826cb76fcfb4bed3e35a", size = 1423041, upload-time = "2026-02-28T09:47:27.286Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/84/bb/55932750261f35d84c944941dff761112eb9582b608b314fd8c4b87e89a9/ephem-4.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1e5806b5a633fb25480486d5419604e82a6932f9f9e6855f1e07da852b8de570", size = 1432847, upload-time = "2026-02-28T09:47:28.603Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/8e/c6bbb724f1a51ec79dc9c167dfde27246095abecdf45057fc6de50822e94/ephem-4.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5ad67a86ffeeda5173d88b04b9477b5ca3e78331acc168a084d18779452c0f7a", size = 1433840, upload-time = "2026-02-28T09:47:30.009Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0c/2e/84b07818630298656dbae0c95c0e99b89ff98d6a87daf9819a5c5aee191b/ephem-4.2.1-cp314-cp314t-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:2b8792e60114a07253160e81b63f28b3c021f4a5dfbee91a6db526965bdc039f", size = 1782457, upload-time = "2026-02-28T09:47:31.827Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/be/fc/357df051cdc848b482c823f18dc94632d40717c64fc0068d79b91cf12f75/ephem-4.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7812f16600ecec6d7b21194a38948ea3a0c406332481375e735924a3f82f5e29", size = 1804033, upload-time = "2026-02-28T09:47:33.19Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/cc/4348e26e0ba41a5e5e6e4ecc1fca81ceaccc656c9ad3d4251c301bf34d78/ephem-4.2.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e020cb6976ff3badb303bc55026366fa3886280f15f6d4d46c52fa36356fe16b", size = 1847470, upload-time = "2026-02-28T09:47:34.926Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/9c/77f0007679d0de12372db61d863bee604441b4827b27dbcbed07f48a815c/ephem-4.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:788e61fa779c54e6dd745f57adaeeff14eda2b8dd737ef578af6ac8415d31a48", size = 1796560, upload-time = "2026-02-28T09:47:36.363Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/6f/30751b504be2c55b9a2a77f678003f0e065554d1f2f75f3ec85162f2ccd0/ephem-4.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e8c6598443375f119c9f7c586f3198c6ac60a38bac3fbc08781c55c8e102cbba", size = 1800619, upload-time = "2026-02-28T09:47:37.755Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fa/79/49981b3ad843f2180a17ea6f89874ff5ec4d26b6d6fad754be4cbaf97d13/ephem-4.2.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d62cea09046153052cc15c85938fadf7648a7c8b1133d729b76f20d4cabcfefc", size = 1811800, upload-time = "2026-02-28T09:47:39.506Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/16/c9/235acf25dfa74e041a4d95b3fbe6835ddd152d6479ebb762da31818bee09/ephem-4.2.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:bfdcc68b2a5ac84305d792ca8ffac23bed0b5be21edbf45b33dd00423f7a6fdb", size = 1829542, upload-time = "2026-02-28T09:47:41.284Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0e/70/429ee91d941b4969571fca658f3350eb5e217f04e4aa9bc295b77613ec3b/ephem-4.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15bc51d5c926b65ec15742042de79f6181a979809a6f9da1bd8d6abfb23415b7", size = 1795831, upload-time = "2026-02-28T09:47:42.703Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9b/92/cc35c78c00894e64d312960507ee84c9fa76919ffca28a7f92ffa59bda20/ephem-4.2.1-cp314-cp314t-win32.whl", hash = "sha256:ce86665355d88e4e7ccc3b9e9c74905a2c6ad51c27433e5c98371a7ea38ad502", size = 1407887, upload-time = "2026-02-28T09:47:44.374Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/c8/b0f1788a6a87a0a18e799b73486329f33f0ae4c152d62bca46476e76fc35/ephem-4.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c4e6e15dc6ccc22504e27aea58a06f8308fd7eb007947d16dfcea6a3aec28b4d", size = 1424698, upload-time = "2026-02-28T09:47:46.38Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.6"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/38/46/126b1831dca12060d4a8296bf9c4fe5c93c4f22197fa239cb0cc82042bba/filelock-3.32.6.tar.gz", hash = "sha256:a3f55a18af3652a94d8f47d6055df434f254ca1d02ef2524850c6d249ca2512c", size = 225172, upload-time = "2026-09-08T22:57:11.528Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cc/06/4f138f618dbea66803291274f228f01daf29f306fe8b96bc30dab765df75/filelock-3.32.6-py3-none-any.whl", hash = "sha256:3f16ecd0117feae0dfc147e8c62eb5daeccd8bd800378c3ddf416de9b4feb6b1", size = 100189, upload-time = "2026-09-08T22:57:10.182Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.64.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d4/41/0f072a712dc74496e03710e462a18a4cfd8a258ad055a4e22d28b43a7abd/fonttools-4.64.0.tar.gz", hash = "sha256:ecb2e59a7bc692fee64dda6010deb66222335693b30046f15cccf81233aa715f", size = 3664266, upload-time = "2026-08-31T15:44:33.685Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/44/7b/49b0054a79b9ed918c018e70e09b56eb5678ee8b44e59e126c79de4d8d73/fonttools-4.64.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9443eefff58aad558608f352092e1be6d278980e8c3b4e8621fcbfda97818500", size = 3092750, upload-time = "2026-08-31T15:43:02.705Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/83/e2/08e73bd2f6e6248f071d3e9debe4c2b4cecda3a7dc057c56b44e255421c3/fonttools-4.64.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:09657817b75575822bcd6098ef0ebf0386f34430839ee53109e70fd40a7f6539", size = 2583001, upload-time = "2026-08-31T15:43:04.923Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2f/58/6dc0ff0963fc1e12f53bac59175617ec5927342ee7a4ffb871b44d56d81b/fonttools-4.64.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d7995b906666037d7114c20a5566a372902747452af7d5bd4cd6bca8f1a2550", size = 5392765, upload-time = "2026-08-31T15:43:07.096Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7a/dd/4d3911049680da7b3aecf97cb5094e3a05554f5d94829358fc7664640456/fonttools-4.64.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2c42237b7e8c6813643e57d3efed3be094d4c06339dc2166b626e2cc5c12ee93", size = 5373969, upload-time = "2026-08-31T15:43:09.617Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/48/0a/a2cf94121fd3ca9166bdb4863f71d6db32a5606b223c81e2ba99832a0612/fonttools-4.64.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:498f02ea92c9ca18c0f9c581ea93184a9d56c25b0af14189b0767adaf34235d8", size = 5333854, upload-time = "2026-08-31T15:43:11.985Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/44/e2/632f4a8b94e6d7eea41e6d82f0ed337f64f5fb96f9910e2ac6b1689910e2/fonttools-4.64.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8252f20108e557532f91d7d6dd9af87c16ed6fa930f65516aa480fa2cfed3363", size = 5492828, upload-time = "2026-08-31T15:43:14.288Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ff/25/7fee1978fdedc1a2d978b76dddbea88785416f5774e7222327b867712d71/fonttools-4.64.0-cp313-cp313-win32.whl", hash = "sha256:45e3ecc3888f1637094fd75cd8fc727f3a4b06d1ddf89181126c071e244fd2a5", size = 2429011, upload-time = "2026-08-31T15:43:16.463Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dd/ed/bb1c217c9e1fbfa59f42b266af57df937a703882a73e59a309773752228f/fonttools-4.64.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4812f71c39d77ec5041348dafa400532adf7bf8f1fffa9aa6495fce5876d7b8", size = 2480199, upload-time = "2026-08-31T15:43:18.774Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a0/0a/59b9074b8ab165cc28d3e08bcf7a8eff8e1dc5932a5a41c87b15952fa3af/fonttools-4.64.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6f1ce9ef9a1b13098efdc2e43a2ed96d9851bbde7b31c652a87552c4efe9b422", size = 3096790, upload-time = "2026-08-31T15:43:21.125Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/17/39/af1077a36feefe79f36d67d75aee637a96673c0a74eeb2c6f24266f5a20b/fonttools-4.64.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:83cc48d1411d2ff388dab99973dca81172cc9ceae9c9799da9548d494cfb38cb", size = 2584288, upload-time = "2026-08-31T15:43:23.148Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/00/c4/1ea58af0eb78264d28e5871bba0810bf0943cd93d641fdeae92553ad3410/fonttools-4.64.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e412767d1c9765cf1b82f7b00f1686c6ca5809ebb77af363b3f9f2325a465c01", size = 5378061, upload-time = "2026-08-31T15:43:25.193Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/93/99/5c7e36d770407b66f7fc8378d2bb47f1530d083d8b9247ff011ec9b4dd70/fonttools-4.64.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b4a7af455ffed980925bc0ebf5b8d6239e6c3e797d9d755b6db192fb3080d614", size = 5319458, upload-time = "2026-08-31T15:43:27.696Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a8/09/89e8d600e92723309d4ddd3944c4ca565197a5df0236ae4115ccbe797375/fonttools-4.64.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:398b14f89ca950b288bd290875f07e4e10685644fa4ac668546fb107b1ada4d4", size = 5316656, upload-time = "2026-08-31T15:43:29.842Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0e/b3/56719ab37e1592ceac89724574146622bedec036a207be80f3c7b1c14cbe/fonttools-4.64.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dc96150f99e05a317cb1f042b92c4cf8bc93cdb1f9f85717322e202ecdf2e505", size = 5448380, upload-time = "2026-08-31T15:43:32.311Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3b/b0/15951b7e3006073f3260da4f8983732d18903905cfe26daa5138a0bbf682/fonttools-4.64.0-cp314-cp314-win32.whl", hash = "sha256:1c3661324f3f0fa4539a32288a3e0711a5f3ccf020036e760bb558ae9811a16f", size = 2432778, upload-time = "2026-08-31T15:43:34.421Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/f3/0c97402b29411f4f6d31b32f2af5b4bcd5babe5a93c64558a8fd3654f140/fonttools-4.64.0-cp314-cp314-win_amd64.whl", hash = "sha256:043f6c572bf236f2a76e762c25f841daea11e8fc03e78088d7be66e0c5b4e4c0", size = 2485394, upload-time = "2026-08-31T15:43:36.506Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/00/da/82192c7bee5314f04129a068dddae11082a63295d4e3b5ce08657de96608/fonttools-4.64.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4691a122b8c1d0d82d6e7510ce59d5c42146518240274b53e912e255573924f7", size = 3170118, upload-time = "2026-08-31T15:43:38.579Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/42/2d/0b4f608d754f625fecc7d94b3b26af6f65f6ab4527b386bb0c6141cdd9ea/fonttools-4.64.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:3200180abc69639483cf54a17cca2e13c31ede5f665979ea0a9c829d093f372f", size = 2617333, upload-time = "2026-08-31T15:43:40.934Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/df/9f7448c38dea05458acfee81c443b14ef97d6d66c636af053d41cf8a32dd/fonttools-4.64.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53eee22af5b5a305c1ee2652955ed46b148e881456fcec1e7f0eb27f642f6bb4", size = 5542345, upload-time = "2026-08-31T15:43:43.114Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/e8/cbf4a81e8be322bc4bee4ba31cd33a7b6336ef8030fa13b53b3e9c09fbf9/fonttools-4.64.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08f172961e11f4eb4f80f2f20049e09b0ea8e044fa6d456fed8346eb8588f360", size = 5349981, upload-time = "2026-08-31T15:43:45.363Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d8/dc/106fd9e93e962dbb60482d30c0913af3d108f5762429dfe93265a850bdc5/fonttools-4.64.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6eae4376adb104c2acfa76fd9ea0cb12b572ca1d70eceac709871f638ff76e93", size = 5409249, upload-time = "2026-08-31T15:43:47.817Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b0/2d/c7be990abf74c9c5c5367ae3dc65953ffce49fe00f62abd129cf725a2397/fonttools-4.64.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2730946ca8f12c356bd98eb9b2b095c8e761ed05bed5afb0d5b380cebe4f6370", size = 5443781, upload-time = "2026-08-31T15:43:49.909Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9b/cc/bffec3dccb9e3f4f6097a2baedaef5a8dec2cb816522ee163e4bb7f54b44/fonttools-4.64.0-cp314-cp314t-win32.whl", hash = "sha256:d30c966bea2deffa19c738c81776f7182da5ccabd97e666bae4f3d6ba87341d9", size = 2466542, upload-time = "2026-08-31T15:43:52.088Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/49/e31f97dfc94e0648999f04bfccb37a97062d978f87df60654f496942c89f/fonttools-4.64.0-cp314-cp314t-win_amd64.whl", hash = "sha256:917fd520bb60809d83c14d43cfe48d5ad2516abaf2c073d65a431800dade2d29", size = 2516703, upload-time = "2026-08-31T15:43:53.954Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fe/ec/e39b9e56db7dcc859983caa24cf2a36209dd71f6cc8ddbbf00d7342d7988/fonttools-4.64.0-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8dd18fdff0ac9759b8d67a714730abee07b2312e3656c20ba5affb0107094762", size = 3091150, upload-time = "2026-08-31T15:43:56.309Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a8/e1/3e6a409d6f99efb66c2f6d0a71986432ff9cc9aca0df9ff4a8bed1d850f6/fonttools-4.64.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:5af87d1a6d247d7467ee082ae977a5443b2c45f8cd4d59375b6daa38d523c2de", size = 2582833, upload-time = "2026-08-31T15:43:58.348Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/91/7e/e8aec0e6eaf93267450535c1be9c9ae63e1d9c49659c2ffdb52c19982114/fonttools-4.64.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:769fb64412ca237547ca73f111a64252d9e32c9d938bed51ed537bc9146a8f54", size = 5375327, upload-time = "2026-08-31T15:44:00.417Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/d1/fa9ce5c1c3c0ef858a2cbe5632e9b6b137deca010b28d5d9a677e4aa89a7/fonttools-4.64.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e662f874ab2c7da9861584db44a13573e0936df087215f63013138f6e5eba083", size = 5338647, upload-time = "2026-08-31T15:44:02.62Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0d/13/e4d4fa3c166f7f5a8f9b6403ad9dcb3887cd05f8b9d2638bd2b43d2889ef/fonttools-4.64.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2524a26f8fdb9051b0d778d052f5d238285ca9f91a7dc004514c7d6cf38d35f4", size = 5313557, upload-time = "2026-08-31T15:44:05.037Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/91/c8/5a352d69608ea7606f677080ede971090fc7340b9f143c0b4fa00cfbf63e/fonttools-4.64.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:1e4e84b47839d35be24dbf476845a34f2ccf99707b66df125c1c414d3e86d25d", size = 5462363, upload-time = "2026-08-31T15:44:07.13Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4b/f1/b15b845f66b559a24a9c40859391bbd3048af3ac0fd04e45b57dca11c4c7/fonttools-4.64.0-cp315-cp315-win32.whl", hash = "sha256:be084d19a3ac0c8b2aba696680642d703118d3b1f18cf83f5b7dbaf0ffc62ab6", size = 2431682, upload-time = "2026-08-31T15:44:09.293Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c6/b2/909beff0d2e2e1adac896e36cff7f9d76fd154bcd57e303d8f09aee8f72b/fonttools-4.64.0-cp315-cp315-win_amd64.whl", hash = "sha256:de8acaa5f4160f537a3cf41b031171d51004b9f4aebfa6c194f18dffa9533d03", size = 2484393, upload-time = "2026-08-31T15:44:11.117Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/40/47/06a51becf651cc071daa88e18ecb9f45ace9e3a570d8191ed8b3cae353fa/fonttools-4.64.0-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5b90ad6637237b636d15c9ae8b7c4a7a1c194f33def378677e468c13fd4542f8", size = 3162235, upload-time = "2026-08-31T15:44:13.182Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dd/96/8b3faf58fd7ec3bb11943126658ad15b3f385068b23248deffccf2327ac1/fonttools-4.64.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:fa75c7970bc6bca340cc6e20f20f069201bfcb50094c31a536fd99724d1d01ca", size = 2613507, upload-time = "2026-08-31T15:44:15.123Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bb/3a/223d1437e72d79f1549be7bafb3cc08f397e1d9c354a241a8ec8573b7d33/fonttools-4.64.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:236e59bc7e2a63557a4d7b013f9cb9e28d9aebc45bc09f85e545e6bf091db626", size = 5518005, upload-time = "2026-08-31T15:44:17.359Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/9f/6f1a4b40ae533b9e907b7e627e397be632d0d9fd6f6be7756cf458870279/fonttools-4.64.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a515f664cad988f2295056833a59f62220bc3e46afdaffe389a29060f6712355", size = 5341654, upload-time = "2026-08-31T15:44:19.869Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/f6/9ca30ba98730a22b527bcc1e02034f0b13b3be2ede764bb0fe8b8e0408d6/fonttools-4.64.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:5bfdaada437e7730c17d366bd7bb8c4a16639963ddbfc1b2f302a68a17a290e7", size = 5385994, upload-time = "2026-08-31T15:44:21.979Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/27/baf1b61bff983bfec72cbb7b32162c4b68d76dc824aaaa48a1c26fa10b6b/fonttools-4.64.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:c60be0aed97a32c6ba8cee21f0d0477136e495451bd97910f589ac892db120d4", size = 5432407, upload-time = "2026-08-31T15:44:24.469Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/21/ff/2eab37d43f2e2ccc0993959d8f2605d9a68470082c592684ac98611ee70a/fonttools-4.64.0-cp315-cp315t-win32.whl", hash = "sha256:f8669ce37851b597d3435b91fefa51139e58d506ca449ca0e5bb68c63b8b6d2b", size = 2463614, upload-time = "2026-08-31T15:44:27.198Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dc/8d/8bdff3ea656592197c8ef5062774221885468ffa01d8b0dc782dae23a83a/fonttools-4.64.0-cp315-cp315t-win_amd64.whl", hash = "sha256:89356c0793b474af7e49ec90d39fb2363e2341516a90460e38231df5ebe8acd5", size = 2512422, upload-time = "2026-08-31T15:44:29.478Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/82/f8/7188153c4b265c899cd035de6a062677d51f67118a4ba640902bd9683e90/fonttools-4.64.0-py3-none-any.whl", hash = "sha256:4a05783ff54ce4c7a28f18e5772efdf63c219374bd9ffc55452182e1cef8be60", size = 1195327, upload-time = "2026-08-31T15:44:31.741Z" },
+]
+
+[[package]]
+name = "fpdf2"
+version = "2.8.8"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "fonttools" },
+    { name = "pillow" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1e/bc/8fd4321aed40cadadddc8f311c65b6082346b252bca048f7b476d8f35d72/fpdf2-2.8.8.tar.gz", hash = "sha256:9e94e155e85e8053329a9a1fce8b566fd7a7c5bb79e98a1a3952d379b947c5b9", size = 374689, upload-time = "2026-08-09T23:32:45.334Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f5/be/af012eda9507494f28b99b077423806c43a11573eb6225dd46f19ae2d263/fpdf2-2.8.8-py3-none-any.whl", hash = "sha256:3557a478fc577a929c94aace9666aed4dcc432b5ab6764232e6a59f1ccd75f17", size = 337000, upload-time = "2026-08-09T23:32:43.728Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/40/0832c31a37d60f60ed79e9dfb5a92e1e2af4f40a16a29abcc7992af9edff/frozenlist-1.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8d92f1a84bb12d9e56f818b3a746f3efba93c1b63c8387a73dde655e1e42282a", size = 85717, upload-time = "2025-10-06T05:36:27.341Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/ba/b0b3de23f40bc55a7057bd38434e25c34fa48e17f20ee273bbde5e0650f3/frozenlist-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96153e77a591c8adc2ee805756c61f59fef4cf4073a9275ee86fe8cba41241f7", size = 49651, upload-time = "2025-10-06T05:36:28.855Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0c/ab/6e5080ee374f875296c4243c381bbdef97a9ac39c6e3ce1d5f7d42cb78d6/frozenlist-1.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f21f00a91358803399890ab167098c131ec2ddd5f8f5fd5fe9c9f2c6fcd91e40", size = 49417, upload-time = "2025-10-06T05:36:29.877Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/4e/e4691508f9477ce67da2015d8c00acd751e6287739123113a9fca6f1604e/frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027", size = 234391, upload-time = "2025-10-06T05:36:31.301Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/40/76/c202df58e3acdf12969a7895fd6f3bc016c642e6726aa63bd3025e0fc71c/frozenlist-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaa352d7047a31d87dafcacbabe89df0aa506abb5b1b85a2fb91bc3faa02d822", size = 233048, upload-time = "2025-10-06T05:36:32.531Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f9/c0/8746afb90f17b73ca5979c7a3958116e105ff796e718575175319b5bb4ce/frozenlist-1.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:03ae967b4e297f58f8c774c7eabcce57fe3c2434817d4385c50661845a058121", size = 226549, upload-time = "2025-10-06T05:36:33.706Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/eb/4c7eefc718ff72f9b6c4893291abaae5fbc0c82226a32dcd8ef4f7a5dbef/frozenlist-1.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6292f1de555ffcc675941d65fffffb0a5bcd992905015f85d0592201793e0e5", size = 239833, upload-time = "2025-10-06T05:36:34.947Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c2/4e/e5c02187cf704224f8b21bee886f3d713ca379535f16893233b9d672ea71/frozenlist-1.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29548f9b5b5e3460ce7378144c3010363d8035cea44bc0bf02d57f5a685e084e", size = 245363, upload-time = "2025-10-06T05:36:36.534Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/96/cb85ec608464472e82ad37a17f844889c36100eed57bea094518bf270692/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ec3cc8c5d4084591b4237c0a272cc4f50a5b03396a47d9caaf76f5d7b38a4f11", size = 229314, upload-time = "2025-10-06T05:36:38.582Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5d/6f/4ae69c550e4cee66b57887daeebe006fe985917c01d0fff9caab9883f6d0/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:517279f58009d0b1f2e7c1b130b377a349405da3f7621ed6bfae50b10adf20c1", size = 243365, upload-time = "2025-10-06T05:36:40.152Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7a/58/afd56de246cf11780a40a2c28dc7cbabbf06337cc8ddb1c780a2d97e88d8/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:db1e72ede2d0d7ccb213f218df6a078a9c09a7de257c2fe8fcef16d5925230b1", size = 237763, upload-time = "2025-10-06T05:36:41.355Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/36/cdfaf6ed42e2644740d4a10452d8e97fa1c062e2a8006e4b09f1b5fd7d63/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b4dec9482a65c54a5044486847b8a66bf10c9cb4926d42927ec4e8fd5db7fed8", size = 240110, upload-time = "2025-10-06T05:36:42.716Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/03/a8/9ea226fbefad669f11b52e864c55f0bd57d3c8d7eb07e9f2e9a0b39502e1/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:21900c48ae04d13d416f0e1e0c4d81f7931f73a9dfa0b7a8746fb2fe7dd970ed", size = 233717, upload-time = "2025-10-06T05:36:44.251Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1e/0b/1b5531611e83ba7d13ccc9988967ea1b51186af64c42b7a7af465dcc9568/frozenlist-1.8.0-cp313-cp313-win32.whl", hash = "sha256:8b7b94a067d1c504ee0b16def57ad5738701e4ba10cec90529f13fa03c833496", size = 39628, upload-time = "2025-10-06T05:36:45.423Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d8/cf/174c91dbc9cc49bc7b7aab74d8b734e974d1faa8f191c74af9b7e80848e6/frozenlist-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:878be833caa6a3821caf85eb39c5ba92d28e85df26d57afb06b35b2efd937231", size = 43882, upload-time = "2025-10-06T05:36:46.796Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c1/17/502cd212cbfa96eb1388614fe39a3fc9ab87dbbe042b66f97acb57474834/frozenlist-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:44389d135b3ff43ba8cc89ff7f51f5a0bb6b63d829c8300f79a2fe4fe61bcc62", size = 39676, upload-time = "2025-10-06T05:36:47.8Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d2/5c/3bbfaa920dfab09e76946a5d2833a7cbdf7b9b4a91c714666ac4855b88b4/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e25ac20a2ef37e91c1b39938b591457666a0fa835c7783c3a8f33ea42870db94", size = 89235, upload-time = "2025-10-06T05:36:48.78Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d2/d6/f03961ef72166cec1687e84e8925838442b615bd0b8854b54923ce5b7b8a/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:07cdca25a91a4386d2e76ad992916a85038a9b97561bf7a3fd12d5d9ce31870c", size = 50742, upload-time = "2025-10-06T05:36:49.837Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1e/bb/a6d12b7ba4c3337667d0e421f7181c82dda448ce4e7ad7ecd249a16fa806/frozenlist-1.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e0c11f2cc6717e0a741f84a527c52616140741cd812a50422f83dc31749fb52", size = 51725, upload-time = "2025-10-06T05:36:50.851Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bc/71/d1fed0ffe2c2ccd70b43714c6cab0f4188f09f8a67a7914a6b46ee30f274/frozenlist-1.8.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3210649ee28062ea6099cfda39e147fa1bc039583c8ee4481cb7811e2448c51", size = 284533, upload-time = "2025-10-06T05:36:51.898Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/1f/fb1685a7b009d89f9bf78a42d94461bc06581f6e718c39344754a5d9bada/frozenlist-1.8.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581ef5194c48035a7de2aefc72ac6539823bb71508189e5de01d60c9dcd5fa65", size = 292506, upload-time = "2025-10-06T05:36:53.101Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e6/3b/b991fe1612703f7e0d05c0cf734c1b77aaf7c7d321df4572e8d36e7048c8/frozenlist-1.8.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3ef2d026f16a2b1866e1d86fc4e1291e1ed8a387b2c333809419a2f8b3a77b82", size = 274161, upload-time = "2025-10-06T05:36:54.309Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ca/ec/c5c618767bcdf66e88945ec0157d7f6c4a1322f1473392319b7a2501ded7/frozenlist-1.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5500ef82073f599ac84d888e3a8c1f77ac831183244bfd7f11eaa0289fb30714", size = 294676, upload-time = "2025-10-06T05:36:55.566Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7c/ce/3934758637d8f8a88d11f0585d6495ef54b2044ed6ec84492a91fa3b27aa/frozenlist-1.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50066c3997d0091c411a66e710f4e11752251e6d2d73d70d8d5d4c76442a199d", size = 300638, upload-time = "2025-10-06T05:36:56.758Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fc/4f/a7e4d0d467298f42de4b41cbc7ddaf19d3cfeabaf9ff97c20c6c7ee409f9/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5c1c8e78426e59b3f8005e9b19f6ff46e5845895adbde20ece9218319eca6506", size = 283067, upload-time = "2025-10-06T05:36:57.965Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dc/48/c7b163063d55a83772b268e6d1affb960771b0e203b632cfe09522d67ea5/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:eefdba20de0d938cec6a89bd4d70f346a03108a19b9df4248d3cf0d88f1b0f51", size = 292101, upload-time = "2025-10-06T05:36:59.237Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9f/d0/2366d3c4ecdc2fd391e0afa6e11500bfba0ea772764d631bbf82f0136c9d/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:cf253e0e1c3ceb4aaff6df637ce033ff6535fb8c70a764a8f46aafd3d6ab798e", size = 289901, upload-time = "2025-10-06T05:37:00.811Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/94/daff920e82c1b70e3618a2ac39fbc01ae3e2ff6124e80739ce5d71c9b920/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0", size = 289395, upload-time = "2025-10-06T05:37:02.115Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e3/20/bba307ab4235a09fdcd3cc5508dbabd17c4634a1af4b96e0f69bfe551ebd/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6da155091429aeba16851ecb10a9104a108bcd32f6c1642867eadaee401c1c41", size = 283659, upload-time = "2025-10-06T05:37:03.711Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/00/04ca1c3a7a124b6de4f8a9a17cc2fcad138b4608e7a3fc5877804b8715d7/frozenlist-1.8.0-cp313-cp313t-win32.whl", hash = "sha256:0f96534f8bfebc1a394209427d0f8a63d343c9779cda6fc25e8e121b5fd8555b", size = 43492, upload-time = "2025-10-06T05:37:04.915Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/59/5e/c69f733a86a94ab10f68e496dc6b7e8bc078ebb415281d5698313e3af3a1/frozenlist-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5d63a068f978fc69421fb0e6eb91a9603187527c86b7cd3f534a5b77a592b888", size = 48034, upload-time = "2025-10-06T05:37:06.343Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/16/6c/be9d79775d8abe79b05fa6d23da99ad6e7763a1d080fbae7290b286093fd/frozenlist-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf0a7e10b077bf5fb9380ad3ae8ce20ef919a6ad93b4552896419ac7e1d8e042", size = 41749, upload-time = "2025-10-06T05:37:07.431Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/3d/8cef5f724ec0d4add2af8961d504535ec60c3cca9e464f6d03bdba29d85b/greenlet-3.5.5-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:b79fd2a5bc099b5e744f34c4c9a58954a5f4cb7529fb4b6e8446057d61b6edaa", size = 294730, upload-time = "2026-08-10T13:27:51.206Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/88/4b/8e7aa3f514273aecff30a16ab1bac09ff54cfc7e6860fdd8058c37ff2499/greenlet-3.5.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:634cf15a233a949136879dd388e25d3296e16f3f1e217d2456797b8579ebc6ed", size = 614536, upload-time = "2026-08-10T14:14:36.589Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/48/4e95e9dd5a8a397dc6a6345dd7f1935113d0fca4f85e89d3976da9cd988d/greenlet-3.5.5-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:499adea519f748407fc6806d20eedabac2884fd73b9f38d81236e190ba20dfef", size = 626924, upload-time = "2026-08-10T14:27:27.048Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0e/84/eaa476d6bf3816828d0d70e80dcc36bf30a058233bd889e707e693f6e860/greenlet-3.5.5-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7278591501941bb2456af102bb9cd59aab48c6cfd6e2dd68fa1290bb0c49a42", size = 632726, upload-time = "2026-08-10T14:30:09.874Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/89/5d/398a1c71fa7a277deeb376c999979de6786f08fc2d5747a0b9d6e11738dd/greenlet-3.5.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2eabb980975cba5b93a95f6f69287d05fc05ac955bfd6a320a7c083eeb52c0b0", size = 623906, upload-time = "2026-08-10T13:40:50.501Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/f2/0cc2849ede68579291e9c59b3ab6ec1958f98681cca5b14d8fc75bf674a4/greenlet-3.5.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:4dfc7c4470354e7b09184d1a3a985761053a2fd694ddb5b5c80242afc2c8c90b", size = 434966, upload-time = "2026-08-10T14:30:03.729Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/04/1b/745450fc5ea9e0cb17d840d248f284db3363de736d362c7d2d883e3eadba/greenlet-3.5.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03115c2e0a371999bf8ae616aa8d653f96641d4705c457aebaa187276e9f7537", size = 1581430, upload-time = "2026-08-10T14:15:06.853Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d4/29/d51b296e3191bb15d3d81ec375af1909e4466c0f395d744ed475801798a9/greenlet-3.5.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4441153ffba21b90d3ca89fe3d31f5c093ae6c0bf0cfdfc98f54cde22f95b62e", size = 1645684, upload-time = "2026-08-10T13:40:32.133Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/12/63/369f1a1625e64e9e31df3963c6044056e3fdfa3fa3fdba3c54ffefa6e987/greenlet-3.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:95c5b1f4b3a193f8a0c2de4bfdcb48d119f7f1063941f1de1f2168051b3e52dd", size = 324075, upload-time = "2026-08-10T13:26:58.974Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/78/649cb5c09d4d81f6dd1444e75474a7206784743283a21d24171562ac4899/greenlet-3.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:1af90aa4bc129883b340cdd6957a3bc74f60528a4993bbd1f53aaebe1d9981cc", size = 308260, upload-time = "2026-08-10T13:27:50.795Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/52/f005d579acde46c3d1cc3cab1c9f3d5708c8a3006a4120e8cf5da801afe9/greenlet-3.5.5-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d98ef6f92e67c6dbf299dbfd8facc1b0d2d9cedf91e325e73b3d0373fe4309d8", size = 677863, upload-time = "2026-08-10T14:30:11.663Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c4/8a/a75f8a2bdcef3c358a3147cdc9db3aa83755f0a038f766ab0bedb66f512c/greenlet-3.5.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:159df1942d88e8f784cbb38d6f18bdb365cd11319cfbb3e89623de2b97892d53", size = 480554, upload-time = "2026-08-10T14:30:05.171Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a7/6b/594fa2de7fae7629168a404a4305d7d7e31a5742c50a801b1839543cb93d/greenlet-3.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e2afcfc4d4305dd715809b03da5cbe437c8984f61d8917751eb5fe4aefa3e07", size = 311146, upload-time = "2026-08-10T13:27:25.046Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/ac/0d7887aa4bbfc9eba075cc428244dfc96f623478454d5ec81180d0d6bd5a/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5e9ec2e7c98e895fcea0c5cc57b2606cf86ece6d0a56578f3eb225e2af4f0387", size = 681587, upload-time = "2026-08-10T14:30:13.519Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4f/18/8d58ba1c429b0383e3219a3d0e0bba241d0444d8ed05b73349953c7d7c7b/greenlet-3.5.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:102817506f6090b5176c746a82603341a549b40e5c3d5b72a4c672228a918c41", size = 510175, upload-time = "2026-08-10T14:30:07.047Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/65/53/4e13642efc4d7ad6554ecb2242a5be42666b2e1a067323e88dfc0124a04b/greenlet-3.5.5-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37faa97daccb6d9f4c2141ce3118d023c3c5506864a7d8bdf726f665018c1f76", size = 681436, upload-time = "2026-08-10T14:30:14.839Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cd/32/188447c9a468d6977d2989397226b0c6b65ab6f4cf943f931643328512fc/greenlet-3.5.5-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:b18007dc2473a7942fd157366b55f01da6fed7ce85318591005b419e0a439474", size = 487404, upload-time = "2026-08-10T14:30:08.903Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ce/f4/e450a68a152f819491d8c7df6a8254e761d87e6a78759268961f8c5bd4dd/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2888a3a38bc5ee5bb6c438372197152e815837e4fab7ed7a1f86ef18ffd58ad1", size = 686022, upload-time = "2026-08-10T14:30:15.96Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/23/17e63d6bf3b9c9b9dbea981b7f643a71f79603bdfb4f1c3a9cf353e22aed/greenlet-3.5.5-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:1e8d9391fe77f15649589a907cef972dbbd6352ef7ff7dc0492f658c0c26495f", size = 516951, upload-time = "2026-08-10T14:30:10.907Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/41/62/3c062f593bd92ef4e77a0ef39541e3d82a0a1d3947c8a777a02a13a27828/hf_xet-1.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:70cbb9c896901600128cb9b6f06e132954fbede1db30f31f7c6c63f84cb7c31d", size = 4074584, upload-time = "2026-08-03T22:32:47.364Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bb/1e/c0ad437dd267a8e435bef594acf781bbc3874ff0b6435b4962d03ecf7cc4/hf_xet-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23379c2f9ec8696d952b16414a2bae72cad86a52df869b050698ba60f538c675", size = 3867381, upload-time = "2026-08-03T22:32:49.049Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/ee/7c0d7b6ab336167531b1c30af2af003f054af4c749becbd7209ae33a77c3/hf_xet-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2f7278c05c22fd60cb436cda1269649b3e81db65ecdc8496e5e164aa4143e7b", size = 4453982, upload-time = "2026-08-03T22:32:50.568Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/63/06/ad8eab1c9525246650cbaa821caa3cdbaca734ab1a5b8c91bea09cbd8d69/hf_xet-1.6.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:948f15d3a9545cfe5932f6bd8b440f6ae630aee108f14b7bd6c561f7c2dcc522", size = 4249445, upload-time = "2026-08-03T22:32:52.391Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d8/26/1eee8aedb0dafc1ab9717dc9ac602cde33361b232dc06803f1f6ed18b58c/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5153e6bb103ad49d6ea9f1b2e230db5a2ea32551ad09a706d2f61d7c7c80d80e", size = 4451099, upload-time = "2026-08-03T22:32:54.114Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/57/0b88af1f194ab6c9c650547d9cc06bfeaab836ae4dcdb331676bfb8be95a/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:35cec30d75c6f9eb9c16a77cef68e85a103b72e24d4b473714ec9ff06428bab9", size = 4664712, upload-time = "2026-08-03T22:32:55.547Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/53/a0/26b717a9d1840e8abf48dcec64b5ed8fbe472671d38ad28d30e147132b33/hf_xet-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5789835d7c6bc9436962853192082374297fb72d7eff7e7762ec25ceb7e25338", size = 4025906, upload-time = "2026-08-03T22:32:57.391Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/f6/4a9966633c6fef83af997e2cff68ec1963676d412bdfd096df2a93b8e185/hf_xet-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:75765820ce4700db3750c94acc8fe27c5fae4c9ec000a0dbac3ca082acf97765", size = 3849221, upload-time = "2026-08-03T22:32:59.123Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
+]
+
+[[package]]
+name = "htmldate"
+version = "1.10.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "dateparser" },
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ad/1f/e7cf83e23d7b68105de8b874a8b36ba23b450d6f71388583e4ca3ce475ca/htmldate-1.10.0.tar.gz", hash = "sha256:a38df10772ab5d7dbb11896e3f6a852a8491fb1b0965465bc174e23fc2baae58", size = 44455, upload-time = "2026-06-01T17:43:53.437Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/17/d3356233c826c641f940983d9479eab27faec59d49f4070bc58e80fcc021/htmldate-1.10.0-py3-none-any.whl", hash = "sha256:9211dae35ab94147c8ed9e5fc2c9287a5cf31d2394cb7857e7f5dd814eb2aad6", size = 31561, upload-time = "2026-06-01T17:43:51.797Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.30.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/35/97/2eb4abaa5b969ed385066a0496a3823b3ff467fc1082e2202955f1867d60/huggingface_hub-1.30.0.tar.gz", hash = "sha256:e6a6120bc8c8e2723d03648434ee247088cceb55ba7067e7d34d692cad5fdb57", size = 964291, upload-time = "2026-09-03T10:05:14.053Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c3/0e/3e45bbe0dd48f4e56b1d46649d342de853cd1c7e815323472ab62687f153/huggingface_hub-1.30.0-py3-none-any.whl", hash = "sha256:96ae0a8e99a234374a6fe43e989ebd21c04640b91ab2927e7e5773ba1131ca59", size = 796795, upload-time = "2026-09-03T10:05:12.21Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6f/7e/1e7e8dc30634b93ebb3d58a3dea569ad146e656218d3960ab04f62047b29/importlib_metadata-9.0.1.tar.gz", hash = "sha256:ab830580bc0ef3db61ce8fae716389e5462b67e033018bab6d8f80ef17172f99", size = 59124, upload-time = "2026-08-28T15:30:34.646Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/55/ecca97ae19075f1fac62def77731e7f535e6c1fb8f92ff08160c5e6dade8/importlib_metadata-9.0.1-py3-none-any.whl", hash = "sha256:bba5600596a7e21f3eef53281cf28d6a5195634d2f2b78ff9501a3272c6eaab0", size = 27920, upload-time = "2026-08-28T15:30:33.433Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "justext"
+version = "3.0.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "lxml", extra = ["html-clean"] },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/f3/45890c1b314f0d04e19c1c83d534e611513150939a7cf039664d9ab1e649/justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05", size = 828521, upload-time = "2025-02-25T20:21:49.934Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f2/ac/52f4e86d1924a7fc05af3aeb34488570eccc39b4af90530dd6acecdf16b5/justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7", size = 837940, upload-time = "2025-02-25T20:21:44.179Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.15.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/36/9b/356320fbae2ac8467e21c5e73e1389c80468e4998c62cc7d3536cc51b614/librt-0.15.0.tar.gz", hash = "sha256:4e66cbe84437497d951b799d3e1551291b6fb3d643820a7014b3655d57a59162", size = 214338, upload-time = "2026-08-07T10:49:42.663Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e7/42/467b53a601b406ccd7b97c1fd54b59cb34f9185ad5ce7e9d5c3c4e8961c8/librt-0.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:db13ca398005abcbe538deda87b686d9bd08b7001cf40c4c06b444960ae10a26", size = 151029, upload-time = "2026-08-07T10:47:19.312Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3e/e6/36c2299b7a94b84fdd01220d8a777a71be5be0925bb0dbdf71c0a06a34d9/librt-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa1f1995789dca3698bc550aaceb09a51bd5df0a057ff84ff15296cd1975b801", size = 155194, upload-time = "2026-08-07T10:47:20.398Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/b6/ed5071f9325845e670bd36012757419767fbf56af77ed483077b9e4db541/librt-0.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55456ea87d8df21808446d03817be2f65e20391c1c615d9187440dff28cd08dc", size = 502568, upload-time = "2026-08-07T10:47:21.652Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/81/6450c67c3615d87704bcbc21323fafc69c799b06a044c447529f725d4b01/librt-0.15.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5a86a5a08c2235316bdb359d5dbb6ce0abfca7fac06363103e2c5af571d92f95", size = 496153, upload-time = "2026-08-07T10:47:22.925Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e1/d6/5f52b722bc75076954b3bfd49be15ea362df4d580c6fb315d0f617100d30/librt-0.15.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e56b6a368529bed262da40ce13f8fef590db0479819cca84f16a1f01ac356d0b", size = 513336, upload-time = "2026-08-07T10:47:24.213Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8d/e2/c08fd1d36ce63ea5a12b85c5d37f4550b5f86a692167e41e5a74222607ae/librt-0.15.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:234d8d394721fa0d786af15ebf1f3fb7f3ed82fd1cd0cde45c2f247b5d4281d2", size = 531661, upload-time = "2026-08-07T10:47:25.507Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3f/d8/d9482fcbeb177b9eb87bb3899eeb3b42be690313c652f9e146b1d0681fb2/librt-0.15.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d8363d7accb0286ac3a0e633f396e93800dafb8150494505daf9515bbda591f3", size = 524487, upload-time = "2026-08-07T10:47:26.79Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/cc/075171517b41f861753034fbb151b42cfc83bcc853849f24f5e66fd60ccf/librt-0.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0f0ee3644d951f31055ad07d77d92520e84505dd7a432cc4cd501dd70ee06785", size = 543201, upload-time = "2026-08-07T10:47:27.999Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b0/03/42c2330f37eeb475b6affeedd06518f60035f323af3a839335e3fc9fef2d/librt-0.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2cfd1a81a648806e6a7717be4cc4d1bb392fa229752bf8444ba365e381e984d6", size = 546467, upload-time = "2026-08-07T10:47:29.396Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/57/1e/1ad4c5638f7e64d8560328bd25c54b409a661bdb6ff254b38ff90744288d/librt-0.15.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a6cd22c9da0d866558e46a041f1cc0c2bbb26b61b137b2347fa834c332e1d101", size = 555139, upload-time = "2026-08-07T10:47:30.815Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/41/39fa7d15db1204cd1cbe6514680fbdc243adf754a0885061308f43afc013/librt-0.15.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:6d5225ef8801e4ea5e482fa9b5dfb891dd9ef6f6d870f1f25d449ca2c70ac218", size = 536050, upload-time = "2026-08-07T10:47:32.222Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1e/88/c6dcf0dd8e26dc0c9a499a2abab8646c86dcaf9ecea9524cb46d3686331a/librt-0.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d28a05796b99f749bf8794f17ba9ba1612d0076b802e9cfc62c554634e9ce3b", size = 573700, upload-time = "2026-08-07T10:47:33.527Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1b/9b/ab54c71a7918a7c34fa5327fb61390a77446a07a146fbfb1165250a61035/librt-0.15.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:2067ff438048cead9d223ca5675bae2a25e520a7c3e6c1498bf9c6892d22caab", size = 82194, upload-time = "2026-08-07T10:47:34.835Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8d/b2/4f9a243bb892395f3becb80789ade13771701091f9f07ab8230247953ba8/librt-0.15.0-cp313-cp313-win32.whl", hash = "sha256:1cd3b721f24c206398b9e26da3c3a9c011e6e89d06f318ba8ebefc30f1003890", size = 106231, upload-time = "2026-08-07T10:47:36.251Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bf/af/64aff4885a40b93132382f2c314647d722574605416504379184ef3045ea/librt-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:f395a4a9a03ac062dbe9a9f82e0c720502e590a38feee6a757bc82e9c63afbd8", size = 126996, upload-time = "2026-08-07T10:47:37.453Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/83/335bccf6c7cb9028cb0b54aead27d9ece3f01f83bc6baa2abace5da655c1/librt-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:0a15cb554761247d84a3ec0cbdf4078d70725384f0e4662c0fa3b26266eb60ad", size = 112188, upload-time = "2026-08-07T10:47:38.729Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a8/93/949053fb462eecc4a9a5ee770a81f4b40be7b79538b245545d4aebc6b58b/librt-0.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f5de7feedc56337a088eb15cd9fafa9938367362221d8cc62c642b7f94821993", size = 149833, upload-time = "2026-08-07T10:47:39.86Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/ca/8281aa6cd560a3420e4497729f6b704b53be3eeaaef82d5aeadddaf7441f/librt-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c0eb900c0e91f4aebe680845242e614f1864edfd44106380d0752ac29522bf8", size = 154088, upload-time = "2026-08-07T10:47:41.065Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dd/02/1a1662dceaba6a086360891448d5ce9a7d3555976cae59a31a39d744b9c7/librt-0.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e8c9a650a188e38bac005048cbe6342e81407782944d01934540ab75e417df21", size = 494215, upload-time = "2026-08-07T10:47:42.388Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/69/84/99211619dc656370a3740c33d2b0b6d5a3fb1e73689314f6ed477a397dc4/librt-0.15.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:92bfed8deec93df30286b9fe9e3b1dd17329cc076a192b4ee5ec223841d54953", size = 491173, upload-time = "2026-08-07T10:47:43.683Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d4/aa/5448d0b05f4579b635d3899176817ebf561af0e57bacd425b5b1887264c1/librt-0.15.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec4b19788f835711a2072f9dbe6b03b3bf32ed1f0fb30cf399bdd59d9f0c33fa", size = 505512, upload-time = "2026-08-07T10:47:45.314Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/95/82/01940e40b83c43a546c4a3c896cf34ca272a9690899d55914e4827b3dcce/librt-0.15.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4c7bacb70930f3d0a56f4ecf1be474a1f0d941b01dd73b756f3c256d42cb879", size = 523073, upload-time = "2026-08-07T10:47:46.66Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/88/fa/759c0030f3ee371439eb26de34fc745807caf0abb878af7af4b8b7c3dd3d/librt-0.15.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e79f05e4a08b4d880342673312bbc895b56df7765605796f15902eb5367d3ae", size = 515080, upload-time = "2026-08-07T10:47:48.319Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0b/27/894e072228fcb159703c655da69f8cd10dbed489c36e3df7dd032a2483be/librt-0.15.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a417149c0cba4d50b61e992e5a15e69eaf96746609b461cc4ed168aeef6b79dd", size = 534164, upload-time = "2026-08-07T10:47:49.875Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/98/a3/0078e91c1f36f8815db17827de15650b9a3fe56c55fbf998c854b34e40d3/librt-0.15.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:da7a94d6a3411f579d72aa3e3bc5fbca7ed4549f3dbd7e5de3aa567333374285", size = 540616, upload-time = "2026-08-07T10:47:51.408Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/86/33/81a29b796dd52a45e9ef7974c7732926e8f10f15b8d2be505665979f896d/librt-0.15.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:856f743ae607f2c1380eccb566c0038a9fb3eabf0fc2be2704d76d9f73557239", size = 545890, upload-time = "2026-08-07T10:47:52.818Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/05/82/8be1baa1350e5d30cfd70ae79d0a6f4dc5862ef47f7bb2808aabc9bb86e5/librt-0.15.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:779a6e7c894737e5983e7790a9c78c4000c30e23c9aada08081bdbea53b0fa60", size = 523287, upload-time = "2026-08-07T10:47:54.165Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c6/4f/d1be6a01a35c20ef734e0e44113f87d4af756a9354a89dcfbe3b4f8af5e1/librt-0.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:96bb17dbe8bab3c0954fbebfc69ed395599de75b6bbc35e3270a878e15d4dd65", size = 565868, upload-time = "2026-08-07T10:47:55.566Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/88/649cfa33f5825927b160610f670bdab012a64d627eddb94fa795ea4292fd/librt-0.15.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:7220697efaa6e5348fc3d18ee7f8563d4bfecd9872b37ffb915bfc1d08840622", size = 81619, upload-time = "2026-08-07T10:47:56.886Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/31/8e88a8d5e48fc8d1a817787fb6811dfff6499acd6c8683dd83934aa6ede0/librt-0.15.0-cp314-cp314-win32.whl", hash = "sha256:f54598964d357b1c5ab77cf5d92f21e598fe0e23cdbe9618480807f81b4eba15", size = 100138, upload-time = "2026-08-07T10:47:58.093Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/92/20fd6c4b6a1b1a564b076d55cd3d427d8428217d7638dc25a654cc4791d4/librt-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:3ff5893a2c23d886aa9ce786de5ac6ddc74aeeaf90743682b74d920e117d2e28", size = 121258, upload-time = "2026-08-07T10:47:59.564Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fc/28/6af430b44d9ebb897b865a3c363b6dcace51357be2347cc0f8f869656a86/librt-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:3722a099730704c9a3d70c879fc0f51daec25fe5f1555672d97bc595abeafb95", size = 106467, upload-time = "2026-08-07T10:48:01.097Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/aa/b42bb798942ced219f6d63b27e07f91237887a8d0bd0921666db79a13790/librt-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:38c0c7d4b6fc06c3324b3f9162c8391bfc4fd9dde53afe1033ce7edb48d5a714", size = 159523, upload-time = "2026-08-07T10:48:02.442Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/75/03/1b53cd4ef904e73b1d828a5f90143bf94a2967d7cfff0b9ccf93e12aa9b4/librt-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8b2fdd7ead3c995c37940a790690660d0ca006c302db26cc51933f6766866fc3", size = 161638, upload-time = "2026-08-07T10:48:03.725Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/c4/9f9c9fba097d49e9e694c2b4dc331df31884645ecbc58a93b4b5fc69d2c5/librt-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2fde98cf1fc4bac144ce23c2c4c017b924ba714509ea9334977b0b27050c837d", size = 701795, upload-time = "2026-08-07T10:48:05.135Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4c/05/0966840bda0380c8ae167b9043c6230202941cc90ea29c48e096964c765e/librt-0.15.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:e3b461183c5fa7681b48560f91515f53a953122fb30c71e07abc67d7ddf58c38", size = 682147, upload-time = "2026-08-07T10:48:06.555Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/af/1c47ca573c30ea47d195aec26133af522fea1104afaace028d7b32247ea8/librt-0.15.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4bbcc257e3babea20a91715c361b24554ec4e8f51aa578568afc230799fe1a19", size = 696397, upload-time = "2026-08-07T10:48:08.03Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2e/0f/1aed6223d4f9f9d1171a8596ff100ea4c3f7699fea7a4ba657c3e60daa6c/librt-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b845b8d48088fad0cadc84be4b8fda63203be7e9237b71015b3925443c1f35ab", size = 722542, upload-time = "2026-08-07T10:48:09.569Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c6/22/9e3a929aea456c97d69e6ef3884efea56d4807f97399471cc946baebd8af/librt-0.15.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b30e600e8f337b9bd7f39b86d9fdfedc73cc46e3d0f745931a23a234220bb7e2", size = 729709, upload-time = "2026-08-07T10:48:11.129Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/1b/c327ef6018e3a9ca0b8e7c5eddeeb331ba8f9b76c24e126d37d0f6d62faf/librt-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:64b0c8c35aa4c4ed79896359f3e0b285cbe4e610042106500da4811c322cc108", size = 752891, upload-time = "2026-08-07T10:48:12.558Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d7/d1/d5f1ea02c56930087009e39db9b70660a663e76c730b27b925d786718457/librt-0.15.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0da0d94cb802f32a0524653e7201f2cef72d5f700a5407678f5290483d4fcd08", size = 745301, upload-time = "2026-08-07T10:48:14.55Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d9/3c/5f7c585d15ebb2250c73e7c0ee4e9e47be72c65d520c07ddbcdc62037674/librt-0.15.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:4a6369168d371207339b1e50d4532b06a7121586141f82599505a3f315751d47", size = 747921, upload-time = "2026-08-07T10:48:16.453Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/52/1443a446486eba966bcbca1696b472e4f210320ec42f490a47f48fbf0fdc/librt-0.15.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c434e072557ade9cbc642d052c89d031efe47d5c9614523619d0d74a02378e81", size = 727561, upload-time = "2026-08-07T10:48:18.089Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/79/91/2270a9380f11725cf83ce1925a5e32dd1dde2be9bba597f25c10a38644e7/librt-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7eec6a42018bc1d45763b1c162d3d2bf7c3b9a1b0ed30d3e91dcba390efefcc", size = 774417, upload-time = "2026-08-07T10:48:19.611Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/3b/f4b1548d4f5b99186737fe27aec238e9823e8d5d23bf4df007c030689dc5/librt-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:6912fa5e635d74529ac7cdb1bdf6ca3af4453da8d1edbe0110ee1cb4ad407ebf", size = 104381, upload-time = "2026-08-07T10:48:21.048Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/b6/134afad262def1de04c0843c376d02135f1168af43f22e09a52bd8394727/librt-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8e11699ed745931c395acd3621b07062e0f840efa6935aad87a64ed0995f0915", size = 127034, upload-time = "2026-08-07T10:48:22.561Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/5f/1b6846b20572bd699c9e9ec321a5f781845bee477df2aa2a43b28bc40119/librt-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5d2a91724463bfed4f573cd7a9fdc856d2e230d0c0e5a61416a93481dccd8605", size = 110827, upload-time = "2026-08-07T10:48:23.804Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c6/44/4de9f4ddadb009a55c7758eb5736d62534a7daaf27bd71bc50e64b606b06/librt-0.15.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:8443e38dcfcfdbcf5add5118c623efd788d65ac2e25756d6251a54a06a4d0aca", size = 149843, upload-time = "2026-08-07T10:48:25.148Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/eb/5d9ab71e30119c44094e0275f38b47dd327aea0f843a080396677029d508/librt-0.15.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:6d15a29033c57490cfe2069097c6fc4049e4e65ffbb749be7dc453b7c4c68965", size = 154510, upload-time = "2026-08-07T10:48:26.485Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/9c/8505d1b8f5e8c19587bd03f7429993b3e9ce5c06819d856bfb11d919374c/librt-0.15.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d2c05c729b589e734c09578bf5964be48a911765484840d017bbc84f49d4c4ad", size = 497543, upload-time = "2026-08-07T10:48:28.045Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1d/9a/3a8390775cb095765aded027ac9c63e7c8ea74e731498607544c6505de0e/librt-0.15.0-cp315-cp315-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:fa60887537e1d0cd2d9982269d33a709bf54b195cd2b9364fc0a758022af5bd9", size = 480452, upload-time = "2026-08-07T10:48:29.531Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e7/40/258a4a7117ee915d66de5cd9b8ade65a440993161107ce3a686f1859955c/librt-0.15.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d8bc24219b24c0af375718942ab75e3544b2763085f40f965be4326734ae8328", size = 507768, upload-time = "2026-08-07T10:48:31.007Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6b/c6/2f4dd296c97a0b85b98894519b279408ec9dd602d4f692b1ea0e25dee670/librt-0.15.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86a21a7bd3fe3a419512ef424cc1c020f6771d0b29cfddff36d1635a855e63f0", size = 525122, upload-time = "2026-08-07T10:48:32.7Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/dd/29eab42be13b2bf0ea8cb227135a45d44693e30a7e8b92871981ff56b82b/librt-0.15.0-cp315-cp315-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dbab647e88d90b3167b91efe7091e248653688ed4337e4f90907a722c7361bb9", size = 520371, upload-time = "2026-08-07T10:48:34.294Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/91/ed/4bad71adeca8fe208b775c2a35417fa5a2584c8f4791daaf89a89450fea1/librt-0.15.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:d8edcf6f550e918dca779c069b9e156385c60b406f99fc7641f32c52f7193659", size = 537258, upload-time = "2026-08-07T10:48:35.88Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4c/63/59dba6143fdcc7240c54458b629f3250000a61b8945890fc9efd451b19c5/librt-0.15.0-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:8b62076030baa2d8b1501a46bf0e19c27a489aa90671c55665bff7887f7660b0", size = 527432, upload-time = "2026-08-07T10:48:37.466Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/21/21a24c6a2327d8362580efebe77286bf47b0f4062ec5ea41766e609d3c7d/librt-0.15.0-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:d00d20d1818e82a07a0ee0aa89a98b17ed7916b92441090b683719cb20a59b6d", size = 548108, upload-time = "2026-08-07T10:48:39.384Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5a/6d/fc68c89a7971418b41f9a873623ff935cb864097544c6a2f8ce491c8ef5d/librt-0.15.0-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:4e6ee93fc3cf848dcbf0cce2eca73d8e7dcd0cc2b6df3a529d57750b30a4c55c", size = 529681, upload-time = "2026-08-07T10:48:41.392Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/65/7e/c2d98766124400d722063a630b0fde38a9fc768705d37eecca15c47dc192/librt-0.15.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:32896a0af72508ea979e0acb4e4c04cbeeae04938167950d535c83c45597167d", size = 567736, upload-time = "2026-08-07T10:48:43.124Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/6c/f8c34a95e3a515c6e1c192b89511e7253c89a7760c6b500d57ffdb8d2dc8/librt-0.15.0-cp315-cp315-pyemscripten_2026_5_wasm32.whl", hash = "sha256:ec3ba415afaf951f6951b1dd16d3c8e4f540065fc382d7e70b823a79567ca374", size = 81673, upload-time = "2026-08-07T10:48:44.645Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/9e/e23fa8e78679ec45728188650b39e8ff476c83b691c96f749217df3b1b7c/librt-0.15.0-cp315-cp315-win32.whl", hash = "sha256:d2813ba2503764f0450680c533d13df7cff9b49df1411062eded5f67db4195b9", size = 100081, upload-time = "2026-08-07T10:48:46.171Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e1/dc/3eb4c5e297343f0620a55532cd7c8d764d3001fa2159212dadf480464827/librt-0.15.0-cp315-cp315-win_amd64.whl", hash = "sha256:b87d67e33afaf265262f2a66db578284b88ee2e6fcd224579cb5c15518677ad8", size = 121228, upload-time = "2026-08-07T10:48:47.631Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/97/70/43abce19f04e49762f8ec834c8fafee13cc40fd6b94a72a24e534febfcd0/librt-0.15.0-cp315-cp315-win_arm64.whl", hash = "sha256:713bd7df21170b982e729e46870f31d6b437bd1a9b4648cffb529bd3c2ec5c4b", size = 106487, upload-time = "2026-08-07T10:48:49.095Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/15/83f2deddb9368b8951ec8c9477269b5b9b8bd9bbf15e57402d0f38817dca/librt-0.15.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:3de789c82752730f94782a5ee518baf9c05edf85733aeaf73bb6e518755cdf54", size = 159448, upload-time = "2026-08-07T10:48:50.649Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/bf/043097353f9b3c73b583d07f6b8e552795463f4bfc8caf85e42eee50c26a/librt-0.15.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:e0b5deec9a8664eb722c797241970fd4aa1894d25fda36a1ddac0f7407606bd6", size = 161686, upload-time = "2026-08-07T10:48:52.174Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f4/2a/8ae77f9719d42ce71cd708560a3557b38ac3c17a0383e57f87084de45bbe/librt-0.15.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5563302a8359bc2295bb7084d1a8ed1519df96afb30eb2aa4e0bff7b54228988", size = 710668, upload-time = "2026-08-07T10:48:53.782Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/34/c0436ea134deb9a0d6da80a396a2739a81cb31e0418f7227239e23140898/librt-0.15.0-cp315-cp315t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:22d6263b9d39d7bbb286fa791945646e3218f1be2d693e36fb630f1d0e59cd13", size = 679396, upload-time = "2026-08-07T10:48:55.645Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4a/9f/001e0d99aa9250d5cd5715a9081291a20656083459f9019cda15255329e1/librt-0.15.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:39ffd14646190c454f0d86e0d256b33f00a87a26ab410e619773b841d0e41416", size = 704313, upload-time = "2026-08-07T10:48:57.46Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/53/b34fa9d0ff00f136f4d58ebb4c411ff634baed1eb412bb602a2bc8dcafcb/librt-0.15.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c47318cd3a61401452de11282242937e3e057c4fd3dbaf601e269d0928a06c0a", size = 729847, upload-time = "2026-08-07T10:48:59.231Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/86/ac/fa4d7a424665040e95baf480a6d523446057684b6758624c85338e8a23b2/librt-0.15.0-cp315-cp315t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a56a1d4f859a82ca5b99fc4b82c9b027b15e3c455c5cd99e7d0719f27bb20b6c", size = 742736, upload-time = "2026-08-07T10:49:01.151Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8a/f1/e17a9bb5de6fb8c3186ed1a7d68d21618b027ac2d3633e03d3b6109c67ae/librt-0.15.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:077471b3182db4e17c36ae91555f36a4d2c00080b267f749bcad34a478a9a302", size = 763454, upload-time = "2026-08-07T10:49:03.039Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1d/ec/ecd02cd30935b931b9cdbfed6ab5a099c51b280b4e7baa274da80978ed27/librt-0.15.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:411ca4d1b905b860ceba7570dd6717a71dedaddcc4b0f77ece710aa41ee11f8d", size = 743296, upload-time = "2026-08-07T10:49:04.941Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e6/b5/b3c2b8353ce820a4854f78d19321344242f89fa71c975b71132ba9bf242a/librt-0.15.0-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:1256589e0b0adb31751d685a68bce29d73407ddf4ef05d4188f49d5dcf9566d9", size = 756217, upload-time = "2026-08-07T10:49:06.825Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3c/52/6cc22542ba59146b05cca2a656f9ff8bb67e38e63d12c3b0cc183d837bf1/librt-0.15.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:f42b74a53e5f26a0ba0007411a7455b66c67ce4022a39cc1f56fc4efd65bcbab", size = 741934, upload-time = "2026-08-07T10:49:08.839Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/40/32/a04b72b1aa86e3be23b2ecff8c1aad2dcc955bd3956d6d26e7e34267e57a/librt-0.15.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:291bf73caf78b9e88d6fae9bfd693207ff7d832e2fdbe2cf8e746bc13f5f892b", size = 783763, upload-time = "2026-08-07T10:49:10.661Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6c/f0/89eb11dffbe9279ff37144dec786927314502ae0b114f1449dc78c458aab/librt-0.15.0-cp315-cp315t-win32.whl", hash = "sha256:c16d15ee371643ab48dc8248a3e680ebbeca573a13af2c3dd0c985b142d77162", size = 104313, upload-time = "2026-08-07T10:49:12.305Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6d/4a/1f1978c200f563beda63c36adff2d65bbecb81e365e8e69e572f5f70fbc6/librt-0.15.0-cp315-cp315t-win_amd64.whl", hash = "sha256:dbd605739f228912dc49027cb764456b9757750bdc2b6b7773164db7096c6fd1", size = 126889, upload-time = "2026-08-07T10:49:13.881Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/38/a6/800800bfed7b1fb10fc3f3d557785c3854e80d3f7a9800d784b176a1fc2d/librt-0.15.0-cp315-cp315t-win_arm64.whl", hash = "sha256:84d244b00604d17df3fc7736c327892d6bba66181254aa4087be807b6c342bdc", size = 110700, upload-time = "2026-08-07T10:49:15.499Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "lunarcalendar"
+version = "0.0.9"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "ephem" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/01/eb/5900632e13fa5ae7fd10127d59b3809f4586484b69c9603e624b570ccbfb/LunarCalendar-0.0.9.tar.gz", hash = "sha256:681142f22fc353c3abca4b25699e3d1aa7083ad1c268dce36ba297eca04bed5a", size = 18019, upload-time = "2018-06-13T12:01:22.982Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ab/e0/a52ffc02395474858552ca6437226e23ad67e25fd85cb387f02e479cfe01/LunarCalendar-0.0.9-py2.py3-none-any.whl", hash = "sha256:5ef25883d73898b37edb54da9e0f04215aaa68b897fd12e9d4b79756ff91c8cb", size = 18280, upload-time = "2018-06-13T12:01:21.466Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/23/ad/28ecd7cb894d172f3c9c80a075eeeb2017ac62e3632cee05a5f9493547eb/lxml-6.1.3.tar.gz", hash = "sha256:45222d94ddd511536f3b2f7d9deae3b2339b4ce0f075f1ca25703b07cad9dd21", size = 4211198, upload-time = "2026-09-02T14:48:02.287Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/05/3ef45db776baea068044c799bbba68f3ca00a440c0e930a17c572f3d9639/lxml-6.1.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3a48093cdb058a93af842ede9703520e810b05dcd0fc6d7190a06376c3bfb6bd", size = 8590357, upload-time = "2026-09-02T14:48:17.413Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8c/a5/eee2fc77eee5ea68e4a4334b1def1781a3beaeefd3d98e81b4a38dc447b7/lxml-6.1.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:887c021d9a977cff89cb273047c1352997b772a8908a25c21836861f69b92be1", size = 4632616, upload-time = "2026-09-02T14:48:20.745Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/35/42/df27b56848acd29d8a720acc28977911aab36f2a09df4208d5502e887415/lxml-6.1.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:611a51e61c92f62345a50b0035df6fc0d678f9299f33728826d831598862f59d", size = 4936186, upload-time = "2026-09-02T14:48:22.94Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ab/8d/8a7b91df0b54d09d25f5f44885d6b3e0a6d6643a8c070191580318d20c42/lxml-6.1.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b477912f42c5c33405a10c759d22f80cf5af043ae02d95b9d8e5e5bc555739ed", size = 5093324, upload-time = "2026-09-02T14:48:25.132Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c6/7e/8f340ddcd43790332fb0de8a26628d571a492da3300cd191821698407c96/lxml-6.1.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cffe18571ccc51d742cd08cbb3f8b756de9311d18c7ea98f5d92f37b8fb60c2", size = 4998850, upload-time = "2026-09-02T14:48:27.394Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/c1/9c5bb572f1f09ec9e4322bd4a4e9f4ad48347fc56ef94cf4df58a5279dc8/lxml-6.1.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75cc6569e86be5785b6188ef1642670c6adbc984e81ec35e224842ecd9eefcc8", size = 5626813, upload-time = "2026-09-02T14:48:29.61Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/7d/8bf1fd8bae8247743968bb76d027a1ac5bd2c4b44495fba6a71b30d10706/lxml-6.1.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d85dfab42dd672f87a7f76e9de7172962aee69fa12044f0d6e1a23cbd53fb80e", size = 5232385, upload-time = "2026-09-02T14:48:31.969Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7b/2e/6cef69ed81cb7df0d03b0dd09d08e6e2cf5061a743ff6f42f0b741548e9b/lxml-6.1.3-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:42632b4024ab24a6b488f559ac851312509888b6b80ae2aa11cf29a646a0d245", size = 5347088, upload-time = "2026-09-02T14:48:34.13Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5f/e1/8e5fd8ddc8c7d685badb0f2db149e3c9da84eefc2827c01c658df2c4e3cb/lxml-6.1.3-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:febd35ef45f603c2d74b74655efdbf45e14f55fc0aef4ac82b663ca829b283e0", size = 4707227, upload-time = "2026-09-02T14:48:36.62Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7a/7e/00041382a11be40a88bf405ebff11c8efabd3de79f2691e1638b1c47a8a0/lxml-6.1.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a43b3bdf11e477dc7770609d3477316f974354dfc8425d596f64f471cc8daf6e", size = 5240208, upload-time = "2026-09-02T14:48:38.893Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/fe/316538b5cff0936fa63d45d421c655730fcbb5a28dcac728c175083002bc/lxml-6.1.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d582042c69857c364e8153de6e18e0da9b7b515a6a8113caf69a6ec8e0520f2", size = 5050271, upload-time = "2026-09-02T14:48:41.213Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/91/455bcccb3ac725373007344d351151810cd19762d1673b64b811f4359a42/lxml-6.1.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8e49a646acfab83c68974f4aa1d0a2acca9e88d7d627ae0fc13201b14b76d310", size = 4780433, upload-time = "2026-09-02T14:48:43.779Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/f6/580440e2f52cf00bba5c5e1080bfa88cdfcde73be71a11d95170ddbb663f/lxml-6.1.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0dee106e9aa97fb00541b1ed7827070564d0549c3d3fba8920e6b20fd980f748", size = 5645928, upload-time = "2026-09-02T14:48:46.187Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f6/dc/d123c1f244306543d545f62443f794959e4f1ea709fe100f8740d514e74a/lxml-6.1.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:dd5e90f34cffcfed97f36cf066325773d2b6021c60c29942e53a18b028501b1d", size = 5231184, upload-time = "2026-09-02T14:48:48.691Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c3/3c/fe55b2bd5c6113c906511cd88f6a470195c5fbff1124f19970ab706c3477/lxml-6.1.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d9b3e7d71bf6acff341233417abbdface29c647e3113892d9aaedc02eb4aa2bc", size = 5255814, upload-time = "2026-09-02T14:48:50.948Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e7/a7/485df55acf55dc35e4ca89d2f48f03889e5a3241826b18b85102b32ce9d8/lxml-6.1.3-cp313-cp313-win32.whl", hash = "sha256:160fcf381f76c3aeac28a756bec44f48942a8f7245a87aa28e3a523b4d90cd87", size = 3602214, upload-time = "2026-09-02T14:48:53.236Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c0/28/e46a7702bd95e9043291f7c3539b6184cba66f96cea9936f20939b284eeb/lxml-6.1.3-cp313-cp313-win_amd64.whl", hash = "sha256:e477aca0bc0d19f3b4ae9e4f2a1cfd687c31bf772d78734910658186b40b2477", size = 4004091, upload-time = "2026-09-02T14:48:55.699Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8a/1d/154c78e20479a43916e63f19cb720d83f44f024b03228be44c92d9a97b24/lxml-6.1.3-cp313-cp313-win_arm64.whl", hash = "sha256:b1cc980905221a5d8b3c476330730b3adb40ff80add71ffbdb6215ba055656f1", size = 3665468, upload-time = "2026-09-02T14:48:57.703Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0c/15/fc75a70b0af6021d0ea16811f1fc71cc42cd06ce90fe10f007a69b2eed84/lxml-6.1.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2bec13085dc8ef48a3fe62f7dfcacfeda2c785cdf19cc8eeda2bb9ed081da165", size = 8609725, upload-time = "2026-09-02T14:49:00.156Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/84/ef/398fcf9018f881ec9aeaafae1ddd6586dfb13314a35d35e899de373dcae0/lxml-6.1.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4f4db7c7e954d289d71878938348b3d91b904a3e8210a11939359fb758a58e7d", size = 4639629, upload-time = "2026-09-02T14:49:02.81Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a7/2d/49b6a6ad7ce8f64b07b9fe852ff0c6d3fcbb26db61bee4f63d4120180a1c/lxml-6.1.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2cae5d5c90a62d9139c512a0cb1aad1d182b022b5740daea2617eb5bf7fc658e", size = 4965074, upload-time = "2026-09-02T14:49:05.133Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/66/bc/6230cf80e4331c33383b0b6b73dc31a393dd76edd4cb73d761de5123034d/lxml-6.1.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c6c0c13128a32eb04a51357e56a094e13aa8e6d3d1884de2e9ae923f6915e1a8", size = 5099355, upload-time = "2026-09-02T14:49:07.343Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/cf/d1143d9b7717e07a82f158a1fc9ce6e581fdad1226734950af869e3ffde4/lxml-6.1.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2221e88679d1351e9a40aaee54bc65679b9795bbd0160bc3d5e36b163344eb75", size = 5036795, upload-time = "2026-09-02T14:49:09.65Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/31/6f/194bb00ffb89712c30f5a7e1b8e685590e140fad6c8261fec172c09a3dc0/lxml-6.1.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cfb398886a7eb4c719161c3efcff2a1248febc53a4d8e5072d2d8a87fed84ac9", size = 5658740, upload-time = "2026-09-02T14:49:11.9Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/44/27e3cee3dcdb3b7bc09727b642bdbfcd098490ea77df04611db9060d7722/lxml-6.1.3-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7eb78ba28b187e1e9203a55c60fcf70df2d22cb205fe6d51b9383d6097419f0", size = 5245991, upload-time = "2026-09-02T14:49:14.154Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ca/e9/8312560579fc980bbd2233a8a673cc46f7d613d3633f2bf08a21e8f4ad13/lxml-6.1.3-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:ea6b1e9105b4b24a34c722432d9fb578f9ed83af21fa1abda639011e0f22bbb6", size = 5354136, upload-time = "2026-09-02T14:49:16.459Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/74/d8/eda60f4f73a9c780b5d6e1175484f66e6c81a2c93346e2906a1fec9c7a02/lxml-6.1.3-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:e8b17e23df3e827a69d25af70990ca2420e92668aaffaeeb3cd2351d7916a023", size = 4704379, upload-time = "2026-09-02T14:49:19.032Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ba/c8/c9cc60057be78ac34bd2b842e45e6e88edbfe5e532e82c3b82381b7aab49/lxml-6.1.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b7c37339d7e75cab9a123a04248e243cefefb302ad6db566ea0c77cbcde421e", size = 5258676, upload-time = "2026-09-02T14:49:21.306Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/41/7b/66894008fee8d1785b8db129747ae963fd427b68f456918df7f2f24a8b98/lxml-6.1.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:83e3a51e7933db700a0da0db31849db3a24022d9970da9bb73001e1d0326fd92", size = 5090069, upload-time = "2026-09-02T14:49:23.562Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/31/c1b60404859f4c3cd1f41f29c65a24e25cea78fde822d9574a21f66810be/lxml-6.1.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:9bde9ae026a55b9a192078dfa6e27dd0ca4a050171ab6272e92f97b757dfdf48", size = 4741958, upload-time = "2026-09-02T14:49:26.037Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/23/b8/6285f0cf546f14da2554cabdeaf7c2c2ff3190c74807f0de2e8810a786f9/lxml-6.1.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1a635e837b50a1819bebfedaac5916498ea024120969da8790500148fb0a894d", size = 5683245, upload-time = "2026-09-02T14:49:28.438Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/f6/2168cab44336dcb15fed0f0b78577225b83297cdf0dee349c95420c3dcb0/lxml-6.1.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d0c5c362bc94f1929dc7e96e715bbe7bd17037f802e6d8f0d1545df9133c0559", size = 5246087, upload-time = "2026-09-02T14:49:30.955Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f5/89/32f5de69a0a31f30e6164981851f87b37ecb2c4ee838e504b88d49d4818e/lxml-6.1.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c59e4265608da6a041f54646ecc0c9ecdbb19aaf14c4c684bb6c2114998cc415", size = 5269352, upload-time = "2026-09-02T14:49:33.502Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a2/a1/741d952ed3a7ef7a50055c6415aec3f067015e97f72f4389ce77b09657ba/lxml-6.1.3-cp314-cp314-win32.whl", hash = "sha256:2e62c569ec7531b679b184cbfe335c501c1d13c4b363560013019962eb630e6d", size = 3662783, upload-time = "2026-09-02T14:50:23.751Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0f/bc/5811cc73cac05e324e05ba9b0924e1a163a317a167ede8a9c748b11db30a/lxml-6.1.3-cp314-cp314-win_amd64.whl", hash = "sha256:66299564c046bc7e0cc5de5106601eae907e9fa5904cd68a323380a8502f7861", size = 4073951, upload-time = "2026-09-02T14:50:26.348Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/92/18/3768c8b01ac3a9bed1914715e6011711b00e2a11628ffa6f7fa37f8e0269/lxml-6.1.3-cp314-cp314-win_arm64.whl", hash = "sha256:ebd054ad1737a68fb7c5c073d405cef2b88bb824e294de3b4a4e995b47f0e376", size = 3749279, upload-time = "2026-09-02T14:50:28.749Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/38/84684784738d9451db2b330de2483f496690c3a5c642071df24135739b37/lxml-6.1.3-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5a143e6207579de8baeded4eaac9134413200359f1969d636f0bfb98ee8c3c8f", size = 8860296, upload-time = "2026-09-02T14:49:36.346Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/24/b7/fc4c50bb1b38e864010ea396046cabe85129bf9e65b11edcfbc37d356241/lxml-6.1.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a1cec0f99b9b914d39176347a93b7610dc09324491aee1cbc57cd291a41a1d55", size = 4755190, upload-time = "2026-09-02T14:49:39.872Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/e2/ee9aa6ed2b666b2db1f6f7fd48964ff9da39ebe827ef5eac0ab881f639d9/lxml-6.1.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f6b9d2aad499c769ee8287609ab0e6de99d8bcea99c6e6c2e64945259fd52fb2", size = 4979517, upload-time = "2026-09-02T14:49:42.153Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/e3/e7763d1661b283ddd4fa36f91b9a497db6b8d2aff55028b16c7f642e0755/lxml-6.1.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a23fefdb345b2d4d0ff2860571b5ff9a89a28b6a120f720e8fb0324d346626", size = 5115270, upload-time = "2026-09-02T14:49:44.493Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/cd/22205d5b4d177e3f4156f780412426ee7c7f8107809f119f0dcc40fa51e3/lxml-6.1.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:545ccc14fb05485f48b4439ec35beb16d5b5280eb6c81c658bd4707a2a119414", size = 5032449, upload-time = "2026-09-02T14:49:46.841Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/43/06a4626c3bb79ef8c501b674afab8100d64e798665bb2a97d1c960636a49/lxml-6.1.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:93476b6514b373fc6ca67d26c442784f7807c86f00635bfe79f935c3eab2af17", size = 5603325, upload-time = "2026-09-02T14:49:49.664Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/9c/733682a0c2de9f5779ba207bbb3f3f6be8c6bda863fc01739b186b38783a/lxml-6.1.3-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8db38ff3fb7aee7d6a82ae4da2eef1178656fe1216841fbd24870062a9d60473", size = 5229023, upload-time = "2026-09-02T14:49:52.447Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c6/8a/e69cdaca3fd33a647942925664f01b20908d41a6968c182305be9c38fb11/lxml-6.1.3-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:25f4118c438f96bb466e83108506d03d5c31b1bd2387e83e5b070bda6ded9c37", size = 5317811, upload-time = "2026-09-02T14:49:55.25Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2e/b2/0c397588174403c2ab68fc464abf97e03e7324f9c6cb6a99023104707195/lxml-6.1.3-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:1beb0f9909b26cee938df9ba56b15252a84429b1fc30ce6fca161390b9789a70", size = 4646516, upload-time = "2026-09-02T14:49:57.761Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/56/7e/cfea25afafbe49db8b225764f7f74bb37c2a7f5e717d917d3d4a5e098ed4/lxml-6.1.3-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3a27ac6c780c8b8a1cd231b58407634cafc1c4cc28cd6c7141362df0f36351e7", size = 5240626, upload-time = "2026-09-02T14:50:00.279Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/75/7a587771bb52ebb0e2c57b6dbe9fd96a70fbb54d72ddd97d54c5f8ec18d5/lxml-6.1.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a1932d7ce78a561367512c594fe66eac2b2ec9b9264cfd9b5f950622f4a116e2", size = 5086619, upload-time = "2026-09-02T14:50:03.245Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1e/01/94c0ebe6d831861542d251e038052e52bf6d33f1d18f1cfffdc82851065a/lxml-6.1.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:7d0f5976aa2701996f759b30172925829867547bb073af0ae67d1307a0f0262c", size = 4758828, upload-time = "2026-09-02T14:50:05.873Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/f1/938d67bd0e5b1fdfa52be28aefdffbad57e1f6b8e921c2aab88542c75f40/lxml-6.1.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:c5e7ce578aa8a80910a72a8ca0bbea3baae10100827249001999726a788456d8", size = 5627083, upload-time = "2026-09-02T14:50:08.555Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d8/65/4e51522f6c214650db0abb7b16ccd11b1238b8a05a8d59aa4ebed59c9f67/lxml-6.1.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:d97c5227621af74b111882a290b10f371780a38eef9d9e730408fba2259b52fb", size = 5235170, upload-time = "2026-09-02T14:50:11.255Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/92/c2/e73d19365665f6b16ef84df21199befc3b06e4c539046ad2d9595f6fb9ea/lxml-6.1.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:da707f14ea3c35ee463d50acd596d6488e4b2b4ae7cf77a5bf93f55c023d63e8", size = 5252273, upload-time = "2026-09-02T14:50:13.782Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/48/a9/7f386c84c9fe2854e1ca6e231c285e1c8f392971ac353c6865e6ec49faff/lxml-6.1.3-cp314-cp314t-win32.whl", hash = "sha256:9efe56a68179f3adc4de41861c9358931db03837c48dd5e1c78077b84dd07f3a", size = 3902712, upload-time = "2026-09-02T14:50:16.171Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/82/a6/8a3eb793f7900ef01c7f99e6f5fcbcfbdff35251cfaef66b32a4c16352d6/lxml-6.1.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c9389b3784b56c58d933b5e0aecdf28f901b073ff385358d8a7d40907f6e14b2", size = 4400979, upload-time = "2026-09-02T14:50:18.621Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cc/c4/3807bea283b4fe9e9d9f5dde46a73df91178472b335d2778e10b2a37aa22/lxml-6.1.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32a409be3190b088f960ac92bfedfbef2f86c49ff940765e1548177592d20026", size = 3823401, upload-time = "2026-09-02T14:50:21.119Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e1/8e/4614fcd65496054cfb7172662f3576a59200278739506433b8c241ea422a/lxml-6.1.3-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6ea2f13dce778ca072ccee598bca46a092ce192e8fd907b6c1f0e52c800529a0", size = 8609378, upload-time = "2026-09-02T14:50:31.772Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f2/51/2cdce3c65fa99a6195dd8fbd512d33407c1000ad99f63e0a285b63d7a8eb/lxml-6.1.3-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:c581b1d68b3845fb86c6b2983e755b29bf001461c59fa411d2c26a911b6559a9", size = 4640022, upload-time = "2026-09-02T14:50:34.41Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/09/0b30084e9eb1c546a4be3d9c56df70058d116b1a320400a59b0f7da87bf0/lxml-6.1.3-cp315-cp315-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e01125896585139453cab8cb235893644d8815d7509520da95ae3ee8d1c1f79", size = 5037928, upload-time = "2026-09-02T14:50:37.007Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/0e/5c37275a3e361f6138dc06db748ea565c1fe8a5f4ee5e2ddd80047c81a89/lxml-6.1.3-cp315-cp315-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:290f66b97ede0e552e1cb44a0fd8a74f9753ee635b50830a0b122fb72788d015", size = 5661932, upload-time = "2026-09-02T14:50:39.777Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/70/c5/b71ffb289b15e2642e2a3cf6d468c44da39ea119061a99e5b05e3d10f217/lxml-6.1.3-cp315-cp315-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:73fc05988ed20809450474ba760a87c8ad4e455fc09783c02195e56ec634b41a", size = 5249209, upload-time = "2026-09-02T14:50:42.141Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/ea/9910da149a23932f9301652e57661cd9e42b0df18f12be21159b7255f92b/lxml-6.1.3-cp315-cp315-manylinux_2_31_armv7l.whl", hash = "sha256:dc3a44689eea43eab836e5c98a8ab015dc2419987d1ea6eafc7c590cdff86bed", size = 4704543, upload-time = "2026-09-02T14:50:44.634Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/76/07/9290329cd188c62e22021f79df04ee0cc33d9a93b0d38bd65ccd452ad9d0/lxml-6.1.3-cp315-cp315-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:209c3ccbfe35a04ac6d24f0611f9d1cbf8025d49991b14acd935236234d6c156", size = 5261298, upload-time = "2026-09-02T14:50:47.301Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/0c/aba78bd3401cd99b73a0aed8e2b9b43e14be94fab3603d4bbc8a62365f2a/lxml-6.1.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2f5b2a2b9811b853b39bfa41367c6d78747b8e3e80e07fc5a24aae295c1a4d7d", size = 5090453, upload-time = "2026-09-02T14:50:49.952Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8d/dc/fa4426c3355aa0216cbeb3911495b5f65a26e0df85859a89928fe28f0396/lxml-6.1.3-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:6a406d0b3cb207b0fa460ed4dc93e866f44f105da0169361cb18ff998a44c7f0", size = 4744709, upload-time = "2026-09-02T14:50:52.394Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/be/2b/224fe7918658ab7c532ac2412f3c1eb28f71e6364fb07566262d0cc6a7b6/lxml-6.1.3-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:53258656846f5c48996b882fb4b135885e088a3ad3d96b4bc0530f95124d1f69", size = 5685802, upload-time = "2026-09-02T14:50:55.043Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/21/44/7d480819b9adcae5f84dd8ac529132c6b7a578544398225cd20321adcd91/lxml-6.1.3-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:aa633613ff907ea91b9b0489a1f0da1b8725d8c6ccec6b77e8a1c9c235044bb0", size = 5249019, upload-time = "2026-09-02T14:50:57.985Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/83/385a267ea1b6b283f2249dd827ef360a295e9db14e13ef4665a120c60d64/lxml-6.1.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:90f709b9accab6b2e4d14f5c8718203877a0486bcb3afd74d8b539ecd1e961d4", size = 5271886, upload-time = "2026-09-02T14:51:01.667Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d8/0d/f967b0eb172ae876855a402d6d9b11fa86e3e0c89ca9bbfeadf7ffbfa719/lxml-6.1.3-cp315-cp315-win32.whl", hash = "sha256:b4fc6b03b9d9d90557274f571ab30e7fbbfc527955536935d96f98b6817a86e4", size = 3662894, upload-time = "2026-09-02T14:51:45.173Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f4/48/d8a8c4160a29e663109ad520bac2deb37fcd014756d024561e8bc3e611ec/lxml-6.1.3-cp315-cp315-win_amd64.whl", hash = "sha256:33cadd956b667997e4de1635fce9541f2e8ede2038fcde8cf55aa14d571d1bad", size = 4074626, upload-time = "2026-09-02T14:51:47.77Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/25/20/3e1395d34d19f9254625d0b567b81cf70d37d3417be074f4d63b94a2be3c/lxml-6.1.3-cp315-cp315-win_arm64.whl", hash = "sha256:8a330c0ee5fa318c7b5cbbaad882baeca3f570357e7eb25ab34bf31008150758", size = 3749495, upload-time = "2026-09-02T14:51:50.663Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8f/c6/7465ffd9c43883526a382df6fa4846c9d8d419214f7effbf65270e795471/lxml-6.1.3-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0bf5a3e397df2ec4258eb5eea4c1ac6cf013ca1abd04a176903bff20a70021fe", size = 8857677, upload-time = "2026-09-02T14:51:05.109Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ed/eb/1f3a917e299df43c8162c3e6f64fc2cea3bcf277910f35bff5b8e5d39901/lxml-6.1.3-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:13d22c0d57355366b393936acf6b98a5e0edeadddd3fccbc6a846c50a76b8741", size = 4754522, upload-time = "2026-09-02T14:51:08.137Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d7/f9/f81b4bdb6efb7a596be29603d8758154d00a5f545db9f3cef9d9041c8f64/lxml-6.1.3-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad7617727a96d189bd6f979d0fadf765198c7934e85f4edaba9bf3ad919a300", size = 5033744, upload-time = "2026-09-02T14:51:10.633Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c8/0f/26d9bfaacb319c86e0eca8a1a0bf1130d36a7afbd318883e23caea63763d/lxml-6.1.3-cp315-cp315t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cae82b5ca24b0c2beedb269f6e2a96f466acd926879ab00ae19f1a65cbf9ffb0", size = 5615269, upload-time = "2026-09-02T14:51:13.357Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5d/90/73675f3f4141350ed65d6fec533b107d4e802c5caa340cf111771edd86e0/lxml-6.1.3-cp315-cp315t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:69cafd61aea04ebb3502c93c2aaa568b12931ca0802231e0b5de76bf8b6e74bd", size = 5236280, upload-time = "2026-09-02T14:51:16.051Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/be/ed260767e7977de463a0f91f3f4fffcab85c0a2a024a21ffe1fa442c2c79/lxml-6.1.3-cp315-cp315t-manylinux_2_31_armv7l.whl", hash = "sha256:dc205732d593118cf701d986f40e9de7801bb2e371cb189ddbda9b7348f4d97e", size = 4650718, upload-time = "2026-09-02T14:51:19.102Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/fd/e9839d03b1e767f2725cf7d7d81b80d5f3f9fdc10ad8827e2479311b046e/lxml-6.1.3-cp315-cp315t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88e719b9437f148f7e1465df845c758dd1598618cbea3a2fd1e61a715542f2b2", size = 5243376, upload-time = "2026-09-02T14:51:21.606Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/34/a5/4606e347e2788c301f677004aa83e28d24da9fe663a24380122af57be6fc/lxml-6.1.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:40983eabefd13da003e68170928c7acc011f0d095eefce5871a3c71c9385fb9a", size = 5092340, upload-time = "2026-09-02T14:51:24.21Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ea/99/3314a8661cdf30f493c55a87db283961dfaae08451976a2ca418958e1804/lxml-6.1.3-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:fad67b12ffe0f71e02b4932b04883cbc76a9072bbd30731409d3523cf058b011", size = 4758768, upload-time = "2026-09-02T14:51:26.813Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/58/3bdc577f78ea8b7d72d39a84506f7001d5b28728f43e5b84891e3b7d9a4a/lxml-6.1.3-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:6cd11e7550d89e551a87dcec30f04b1fca32e86b68708aa01a4daa455d8605e5", size = 5649546, upload-time = "2026-09-02T14:51:29.453Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6a/e4/652633de1a2395949ebb7a8fc7d089aba12a2b45f0fefbc9d29e3e3ab3cf/lxml-6.1.3-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:ca0ec532ad2f5ba1e5ec120ac157769c57f01855b3d8bf37213f5d88abd9ba0a", size = 5234874, upload-time = "2026-09-02T14:51:32.262Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/65/a6/c4581d171de30449304b4859bbd3607e9b40da13c0f88b68e6097c8d785e/lxml-6.1.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e99e09ab7741f1281e2677f4c0058c7f5267d182530b09c87e4f6aa26adf3887", size = 5260043, upload-time = "2026-09-02T14:51:34.841Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/d7/ed6ee6186a89e69ca4ea9658b2a278f46a5efe8b5d4db56c7197f18653fe/lxml-6.1.3-cp315-cp315t-win32.whl", hash = "sha256:ace1d2c83b2bd24db5940600541140e87a325e119cb32d5fa9ad720d7e76648e", size = 3901093, upload-time = "2026-09-02T14:51:37.234Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/9d/11d10257a4a048d04195d638bb61f0246ce2448eb05f682bcbab25a257a8/lxml-6.1.3-cp315-cp315t-win_amd64.whl", hash = "sha256:b49638355ea3bebba70da783ccbc630fd72afa16bc46c54474bfa1f9a915bbc6", size = 4395446, upload-time = "2026-09-02T14:51:39.884Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f8/b7/44edd7de434181c582892e68d1ffe6775ca403ce14aea07cb5a218a936cf/lxml-6.1.3-cp315-cp315t-win_arm64.whl", hash = "sha256:5a721a98c649855963811b59b55755b30566e7f7fc40bdc9803d66dee9f811cf", size = 3822836, upload-time = "2026-09-02T14:51:42.471Z" },
+]
+
+[package.optional-dependencies]
+html-clean = [
+    { name = "lxml-html-clean" },
+]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.5"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0a/63/195dfdde380a84df309e3bccf4384b034b745dba43426886f7ae623b4fba/lxml_html_clean-0.4.5.tar.gz", hash = "sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560", size = 24142, upload-time = "2026-05-20T12:17:53.574Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6a/bd/6e2b76a6c5dee10397db9c929f0c5066766ec1036046f0335b7ca7ca08b8/lxml_html_clean-0.4.5-py3-none-any.whl", hash = "sha256:c76fcadd1e5bfb9b8bafc2200d51e4e78eb0dad67f56881c21dfb6484c7e7746", size = 14573, upload-time = "2026-05-20T12:17:52.215Z" },
+]
+
+[[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.4.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2a/12/b5fa2353e2754cd67fb9f83793fa48ff42c213a5da7e719869d2301f6ab8/mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27", size = 410165, upload-time = "2026-08-05T06:10:56.611Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617", size = 80010, upload-time = "2026-08-05T06:10:58.248Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/92/ab/d1297139c0e2ceb151ae564c8c4f57ac0155d8f1f8b4cbd5d6523c82ea36/markdownify-1.2.3.tar.gz", hash = "sha256:1a176f05522c8a2cb1dd3ab9d307dcdadbed5c26ae717855bfc42b3b6d38d937", size = 18852, upload-time = "2026-06-30T20:27:39.06Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/04/10/fa543d484e8b1199243fe20eedd02cc5af050edebce98a7293a5773df592/markdownify-1.2.3-py3-none-any.whl", hash = "sha256:a189a0bedfd14009030fde5f85bb6f77c56897cb839b5c25315dd7d4e3e290ba", size = 15732, upload-time = "2026-06-30T20:27:38.094Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.8.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/14/95/989c1b5ca17b72128661530cd6e351a0a83cda9a4d6c036e9ed976c18931/multidict-6.8.0.tar.gz", hash = "sha256:5cd4637ce76312ba1e05eb9c5193fec231f64fee0944e135fa1e951242355b37", size = 122412, upload-time = "2026-09-09T13:57:57.967Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/84/1f/d7112c2dd7db02677097be72fb65542f51a5aa73cb472b87ec211ba9e0dd/multidict-6.8.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:ec0a4d066356054d569a66e0a94691a2058b680be5e710298f61db11a3c4609f", size = 54197, upload-time = "2026-09-09T13:54:20.814Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ae/24/876015abbcb4a179d946579eb77b778eb5a948fc8381bc7928ba895bc051/multidict-6.8.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:714597cb5d5e15a8a449d2ae23c45b486a9e8fa33c462c7a33d7f35b65d92943", size = 47787, upload-time = "2026-09-09T13:54:22.51Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/c1/ceb7d25f8a567599db2eb19b08cac58d67ff553cff42dcadbea9aba56a20/multidict-6.8.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:e0db3a4d1e264e225037a6023888972c25206a96e016021a5bea41c9a939f2a9", size = 48815, upload-time = "2026-09-09T13:54:23.986Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/e3/e1c6e9c3818c34b782f23ce5fdba3eaa34ec6750dc53078dfac80fa59be7/multidict-6.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:27747162712e85c84598d364425dbf1714ff335bdb6ba3171c4e5081196e8916", size = 83484, upload-time = "2026-09-09T13:54:25.674Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4a/a0/c23f78a4badee9a5b3e760495c661c62a92c340a1dfd00f829cd16e256bb/multidict-6.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:847d6082ae694dc95e548acb201bc100e1cfa96513bc71fdcb86f709dad6c435", size = 50763, upload-time = "2026-09-09T13:54:27.135Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c4/fe/db552d402a3f6b650f5d3ae11b82b93833836aebb51bcda22d8691121129/multidict-6.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:88a6df88567680504ae28bfa7a1f2f64243d91e79a40b2c92ef42efc531e23da", size = 49029, upload-time = "2026-09-09T13:54:28.483Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/01/b4/546853fba19dcef77cdf91fc173faf0b02284a49106cf250511166b4ec5c/multidict-6.8.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:560b211fc3bd4a1e1c6de44f6d38113bf5b410dfc89a4c0d2a3c0edbf1a0dfb8", size = 278863, upload-time = "2026-09-09T13:54:30.145Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/3f/4b52dac7db547936eb762123ac1d99df23f92fdb358bae600e322f611247/multidict-6.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202436df907c15adbb94360296c425ea53cf8968a5d2cff9b5b9790ae1972b33", size = 283915, upload-time = "2026-09-09T13:54:31.937Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/6e/c0dfbf170e49a91bcb9ce850d51cb98357f3033c5227529200ca7625853e/multidict-6.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c46a08bf070d6849fed483e9d9833f9d06aecb8382ed985be0b38508b3ae958e", size = 260704, upload-time = "2026-09-09T13:54:33.529Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/91/02/56973a060ab8dfc2e80bb6797682f6577aff7123cdb1de1a568670ae3499/multidict-6.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2cd560498ae8e1bcc955643c1d78eb8e338226d07a983c656ea8c4443d3eec0f", size = 290243, upload-time = "2026-09-09T13:54:35.408Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/67/69112989f131bdea4a87b74e82cb0a2daf37880cd92b0e6f0420020adceb/multidict-6.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:758233648ac47b07c575224c4eadd73c8929c3b4c31e2afcfea935fde1cda735", size = 291131, upload-time = "2026-09-09T13:54:37.205Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c2/75/9435f68b0cfc442d4917de85c26f2b2e1292630883414a25576083fa2469/multidict-6.8.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:122adc7c46ac1e31ecfc7f81b2530533dccafdba70f5d741649f87e336c63384", size = 287551, upload-time = "2026-09-09T13:54:38.835Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/13/08/2ee4838081d6587849611aa7ec722c4cb2469e912fd0eaee980e7bac064c/multidict-6.8.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8125e60f3c70e323ac07dd8b3635f7b3bbc5c3a9ac04ae5988f668ff7ae28a18", size = 254591, upload-time = "2026-09-09T13:54:40.806Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/f1/05673b51191f77f4198b8e4b35f16ea71c0300c72ca8aa027a66a61b6edc/multidict-6.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:83ff054b04915be5c15680da6c6012474a2cc2bf534129a0e8c6a99f17ba7238", size = 278204, upload-time = "2026-09-09T13:54:42.672Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/4f/b6cf74322b3fbd3e011a1e903730191922291a7779f6d404114c2189b806/multidict-6.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:930c6058047410e3edff445f5a6e4457f2e089042dede00e2d18ce06f3ceae2e", size = 275600, upload-time = "2026-09-09T13:54:44.348Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1b/ab/958bbb04377159ff03c7314cd9d8a48dd6fc4f78c840589c22ab155ee9c7/multidict-6.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:13e26f59f0eecfc5f67c663ad550ffdaf62c0f657547cde387f6c86af1c9449e", size = 279793, upload-time = "2026-09-09T13:54:46.086Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a0/3a/706605ab0dfc4179748ee7949829e63c6f14ae28667aceeefaf2c701807f/multidict-6.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fd789a294d8e098528be29b2669b83005ce569339f8cef167fc0274c3115c34c", size = 284751, upload-time = "2026-09-09T13:54:47.793Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/a5/567e36c013ad023546de633079c6b22101dd43226b193cba00e6399703be/multidict-6.8.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:3126f2a96704505aa4e92a72d6e8a5d7f29d40a987ced8bf69e29d71dfc71fbc", size = 250812, upload-time = "2026-09-09T13:54:49.509Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0d/5f/6b0b64aa0cd346b07831dabaa6ccda0e73014c5df044b68baa763f0f0552/multidict-6.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:23c9ee89967b6a9b4048acb3b93b660ed714ce9c8bf3bbe652959bc120dc02dc", size = 281606, upload-time = "2026-09-09T13:54:51.288Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/31/8c/b846b6796f26d496efb07fedef2b69f6de533da32a56f12d236722a96157/multidict-6.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a62e302fc8cd6aa8972207e7e951d1fdee7c1dda18568305041d19f0e2c00f5", size = 281733, upload-time = "2026-09-09T13:54:53.05Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/f3/bf14a39d4af5697fd9404baaf70a0aeeb82d258b95de5cb16b1a7f98ae6f/multidict-6.8.0-cp313-cp313-win32.whl", hash = "sha256:093167d22a8c95af30f597b8a5686f20a14512989942d4be804d119899caca20", size = 47738, upload-time = "2026-09-09T13:54:54.676Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/19/0a/598511a5741a3cb374971b3b02eda8a09896118ba528a54795f7e7e8bfb4/multidict-6.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:f25b61a708bd276e8cbb6afcbbf1b8e793a3be70ba0a842d0b8692020f83b706", size = 51609, upload-time = "2026-09-09T13:54:56.38Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/b7/6f5c1bd4ffe42d4a6db0f2f65491d4088e9c25c990358fb31a614621d664/multidict-6.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb36381e1f9f9d06eba2f10bdd438e5d20c07d5b55e1a3eee30b9f44cbf52316", size = 48280, upload-time = "2026-09-09T13:54:58.03Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ab/85/153341590e233a967c1d6791a83402d01693dec0f4c1f695606ef16c7ed2/multidict-6.8.0-cp314-cp314-android_24_x86_64.whl", hash = "sha256:f8b09b25e0f4dc2ea9e2adbb1cc3ba11a94d6fa3dd978ae659c8743052e1afbc", size = 53758, upload-time = "2026-09-09T13:54:59.563Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/ff/44f72d516ece0398683ef52061797d83a74b16b8c1e4587408e97959d783/multidict-6.8.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1f57c414be82490bc0e0305fdb834186229b2d9b6a35fa0afd1eb1a772d125ab", size = 47495, upload-time = "2026-09-09T13:55:01.382Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/50/5f/6e118f761b024dd35d26c2fe7ba41572bb0e8ac5f8cfccbbcbc2ff76da4e/multidict-6.8.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:00be37bde741bf60871082cd347a093218c44886e99231b7516671c70f2c280d", size = 48540, upload-time = "2026-09-09T13:55:02.989Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e8/4b/3eed744491b32f0e318e7db89dc06858732362f706e8d045fa9ab51a343a/multidict-6.8.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e37b744849fb631bb52e3dadde35ffeee365a6c41cf71257b5b7acc9cd83fd38", size = 83130, upload-time = "2026-09-09T13:55:04.554Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6d/de/95c2c0ddcccb9a41ffbaa5df8ea059a8ff81916b7617a8847ecd89ed8061/multidict-6.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c2b2a96cf1dd99fe7867be4c013314225f4d5786e6685906e29932d42aca6f11", size = 50574, upload-time = "2026-09-09T13:55:06.387Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f5/b7/f4f4989594f99bc121ad9277090c4e49819b08ab1a96e132b628a9e10b7d/multidict-6.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bea7df027015856ba5d0a88e3b4777ff8cb5c66b58fc108050fe79d4dd9d4d2d", size = 48786, upload-time = "2026-09-09T13:55:08.131Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b2/86/f1d86a0222f31fb3df8eef3d6c9abf7e8d65d49edd8d0d7e7afaf23d23cc/multidict-6.8.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d3da668e903c934ed0b587ecacfed6901f6ae6384a6e975887592b61845e78bc", size = 276670, upload-time = "2026-09-09T13:55:09.803Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/03/50/6945c50f86a978b2bcace9ca344165ff80883be47d984489bbba8fa0ab20/multidict-6.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64eaeda36ee8d88f9e8616a587a8c66a663283cf6e0dcf013c1ddd8c758e4aef", size = 279339, upload-time = "2026-09-09T13:55:11.685Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/2c/e649889ba23fd1f4442a85427b99d9e6261226b2ac31914aa7f5b241d947/multidict-6.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ac746cb365bac1c462da9e3e6ab8904a8efe2217a56b0b2e3d9480f41d2b2602", size = 252549, upload-time = "2026-09-09T13:55:13.527Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e5/f8/1023b66e011b1395fb160dabb0f0608ef67e569f0bdb2c1d5ac9b2f2adc6/multidict-6.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:18f0e06360c3e451a3ab800355773c8d125a758238d780c800b0ee5e90ee903c", size = 286203, upload-time = "2026-09-09T13:55:15.19Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/6c/48aea545cbda6d0444848ec23d988c13b86538a00a1b7d3868cc2382ff94/multidict-6.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:69708fecaa88bcb2341397b49fc95057a835b02a3670c551b37f95dd79e64e3a", size = 285039, upload-time = "2026-09-09T13:55:16.928Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/2a/066123b17291671bf67d2a5c65ee81a48de53913bd1b1578791519eacdb0/multidict-6.8.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9606f583e7acaf61e7b3f56074e14037b9af7cb194590edfc0114b3ae5931ff7", size = 281075, upload-time = "2026-09-09T13:55:19.155Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/47/20/4f0b2c485da2e8a659cc677717a3745872918c9c85064491a1ef75d7a3bf/multidict-6.8.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1f66fe6a021173d0d47968491791966b9f3e6d61115f2491744aa0c07a6e67af", size = 250431, upload-time = "2026-09-09T13:55:21.07Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ff/c7/b9a288901577aa0b82c33c64d52246c88076d260ad7b6c16b021ca0f8e99/multidict-6.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:be007d1aee2cbd530347dcafedb400891a3b5f1bd7135f95cf5d5b330b5219ee", size = 273891, upload-time = "2026-09-09T13:55:22.887Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/51/0ba50cab2cfd067988de2abb73f23076ac727fe18d03f1368a59def64727/multidict-6.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:8457aff3c12a89a8e1c4674de5c777857fbc429f40fe117a3d29538547cbc364", size = 265262, upload-time = "2026-09-09T13:55:24.77Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0f/d6/e5be1117dbca6eb9ce231142b7e20599418bb3500147db51bf844ce8afcb/multidict-6.8.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:95c27b4f3f04320fc44e338573f40c5c956b504a7fcf081a157fd0b02579311c", size = 278033, upload-time = "2026-09-09T13:55:26.67Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d2/28/cad0afaec3caa56ea2c1ceed43c164d62ad3e83e950daf0d0c87bcf9dca7/multidict-6.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:d244cf6b52b5ba1c34c3832f4652a668ebb36d95949b96eed9a1c54d916a90dd", size = 281717, upload-time = "2026-09-09T13:55:28.569Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/d2/025702df0b69b856db70a4d66f77622f51c3d99771ec9a07f3ca80f7e098/multidict-6.8.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5bbbb696c8024475b1877d14ce20d5f1cc05b8f6d786cea0fe3aa7fedc02e891", size = 247124, upload-time = "2026-09-09T13:55:30.497Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b4/96/9dddca563f06a921956389c0bc9b894355b98b0bdf62299e2560c50afb6d/multidict-6.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:cbd86f9787c5e2f5fd27d8b21458222f107347c6731c4e93dde68f554b466a2d", size = 275954, upload-time = "2026-09-09T13:55:32.57Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/91/8b2f1f2a774a955665f268340a2b59db7020c5f12baac02ae9ef1b1660cf/multidict-6.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2f8a4b0b4d639d525928c7f30de527bfdf9ead6e44a5e8cb9c50aced5e4590cb", size = 275508, upload-time = "2026-09-09T13:55:34.368Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b6/1a/e2cabdfc0880a61a99d2b8bc361035036fb5a2c6af31ea3fa054ba1065c5/multidict-6.8.0-cp314-cp314-win32.whl", hash = "sha256:8890c89d662560e51c55ac1304d6f919b23942abe9ae1127cb1de9aa6132fa52", size = 46938, upload-time = "2026-09-09T13:55:36.057Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b9/7c/11234bcba62c22a58f2ba168499cfe3531f49de3edd5090d04a8c6cdc936/multidict-6.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:45cc39ba50fb0754a4359b90f8229ae08598fe2266abe3521b4e5a9ba916534a", size = 50291, upload-time = "2026-09-09T13:55:37.698Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ab/61/793668439df924752a8137d6db0de97ed1add494779b01e4764dfc60571b/multidict-6.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d0264f8d5cb0a803f650a6a8572dfa0cd1e099a2234c588dc8fb220b415b865f", size = 47622, upload-time = "2026-09-09T13:55:39.335Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9c/b8/3c091b929e6b5b2f6e0eba2232178e76d4503c8b96b92dfc281ff1d823be/multidict-6.8.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1969971900b0871530f9b62280dcc2d75688e74d2a69262bc01faf2b96c78f04", size = 88789, upload-time = "2026-09-09T13:55:41.086Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/d7/3df83fab22dd64615db71e3b3cc1346b581d1459719637ce52144f9f6558/multidict-6.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8180b635290a75af8478f1b3e9810135381ae24833293fe77b85c1c21ff842ab", size = 53399, upload-time = "2026-09-09T13:55:42.685Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/78/41bd04c04b0aed16540c4856c9e012afc1c254298da154398308df05e26a/multidict-6.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4261863fc8b5ab1b815ede94e592e94c6af5b04616014929057e61859e7382a9", size = 51597, upload-time = "2026-09-09T13:55:44.569Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2f/6b/7bc4cdddf624e1e7e0231734b1331729ea46df10d7c8fd3fce79756e7d0e/multidict-6.8.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0b143d53590e89f43153d81d505a8448d4d57354354385aef8a51d67ffefa27e", size = 264391, upload-time = "2026-09-09T13:55:46.548Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dc/b6/d2a946e5938771e92c39354563e535ef6bc6dfe399dd4307c6df8dfea183/multidict-6.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da1c112c5784ccd9d32cd90be6739fee32644e874eff6ae8f0497cba3e352e58", size = 264680, upload-time = "2026-09-09T13:55:49.915Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/33/6b/3f9e981c42e7eb9329918523f0f9362ceb0ac3ee0ee1165c28f674249d75/multidict-6.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f7eefd0233a7c33ca980a5cfef26f1e9b5e2137839e752a99963696729f12d91", size = 235420, upload-time = "2026-09-09T13:55:51.92Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bc/e1/a3a33a039fb6d381800ae5d1d587b697b8c27fcdfe48819420f08703acba/multidict-6.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:348bb85e2038b40c007383616d73f734869063772372519549ebd7da1723d1a4", size = 270309, upload-time = "2026-09-09T13:55:54.023Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/95/5d/8b06724a957f2e480f159b9550988a67810fbe9555a09c5f6a2a4b829607/multidict-6.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:095f62ea4e7a3be2f6c567ab695ce10e950f2adb905c1bec82281593e0b2d2ad", size = 275169, upload-time = "2026-09-09T13:55:55.948Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ab/32/8f3dfe2ffa5d0df2a95f71e63c2f11fe3b5e1771f26ef73bb1af84de83f8/multidict-6.8.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be569fff1d85cd29391c431c5641c8772acb75bbdc61e60a8e82fceb9023d385", size = 264900, upload-time = "2026-09-09T13:55:57.803Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6b/73/d5829fc00a055d6ab445e0876346ee9cdee670766cd4190dc0a496188c0f/multidict-6.8.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3533a03e4e789baf6a286e7b0b1b6da3f3d7c3eab569686ee29ee1d8b52e2cb4", size = 242486, upload-time = "2026-09-09T13:56:00.002Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b7/58/e8d7874038e31e0533182d1c3c5331a856b9c849a71bb26a21850e8c91e1/multidict-6.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1bdb9b8fba5a9aef673ec90db3f55b1ce743f2fbdea4d37dc04d14ccdfc153ff", size = 259916, upload-time = "2026-09-09T13:56:01.802Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4d/f8/1b56a7401acda20efc016440f4fad3bef66c4aee54ca080ec143881ebb0d/multidict-6.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f8d7b66c9e09c0bb0add2b5895e646b62a0849e71155066f215523de6b95cbe6", size = 251209, upload-time = "2026-09-09T13:56:03.767Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bd/5b/68d67a9e302b0645a747ba910c30eb41f2834fcdc1d85f53eae2dfceee0a/multidict-6.8.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:563d6500ca80dac7bba6f48a78e0ffd87e21a7d4d24642c6503a2ddccd70c110", size = 264505, upload-time = "2026-09-09T13:56:05.795Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/13/4dc304ba2c5f5307b474ab2ce1ed1f6b02b0b4e233c182e3981ed436c2e3/multidict-6.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:346ac52e56bcda320c0dcdfdd081947ed7cada33afea4e2284bef7b0733bff9b", size = 264916, upload-time = "2026-09-09T13:56:09.079Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dc/0f/7b1f729d18369915009185201be5d0b8df0e525340fe6a600d2f8441d6cf/multidict-6.8.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4ee953a5ebaeed38dc21cc032ed17a9d9782802e00042200497ab4b01b0bf7c0", size = 236839, upload-time = "2026-09-09T13:56:11.273Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/d1/eba1b88b18b7019d9136303fe77909257c40fabde5aaf138a4d900b6ce3c/multidict-6.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:2f79cc3e8039a8cf5c77e0811b0807953fd52d0863b9b76970b20d696dc64a78", size = 265307, upload-time = "2026-09-09T13:56:13.379Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/a6/6c1e4106faa27118ac612f4d664eaf909de252634785286262a627108e58/multidict-6.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:43a4b56555bbcf8af161e7c7682bd93eec10f068c95844511864c018c8e5e13b", size = 259041, upload-time = "2026-09-09T13:56:15.666Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c0/bc/ecfb8b6faa8e158a71b03bdf7f947f30e0bc5d899cc357573a76ab7bb1e5/multidict-6.8.0-cp314-cp314t-win32.whl", hash = "sha256:48ea524a25a1cd5972cf293bc95713918cba0bcd6fa9b992d906c857c546abe2", size = 50628, upload-time = "2026-09-09T13:56:17.837Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/7f/e27fb699b70ad24dbd02ddee604658acb36f907c03c045baffe4ea774501/multidict-6.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d0be2b832435001bc623ca7f1499ca1a853d4f082fb61221a80ce71132f50b26", size = 55592, upload-time = "2026-09-09T13:56:19.652Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/7a/76de70b2f6733696803f1ee56abe44a3757a52777383032c7373d3fea0f4/multidict-6.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:62b8e291a4f7edbf7cde7a43d831d893ba443a1b627498b53581943b0e348feb", size = 50300, upload-time = "2026-09-09T13:56:21.516Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ce/32/4de7320ae032dc768090d11f708d2d386df3db04cb6b8b0db0230cfc66c3/multidict-6.8.0-cp315-cp315-android_24_x86_64.whl", hash = "sha256:e192018b732f7b168e6604cbdf40fa8e05c996693b9eb445a0d8a73f4b77c5d3", size = 53761, upload-time = "2026-09-09T13:56:23.192Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5c/45/ecb641309dc2cdc6040f18e22c68eb5e94398f9404c4365d810f4292e053/multidict-6.8.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b25426f9f6ed402835617c8f23609a47045f91ecff365eb6734817e039a8ed25", size = 47505, upload-time = "2026-09-09T13:56:24.902Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/68/87d6161b9fef11943e0b894203da3fff561933ca3c9b2952b6e7100e9c9f/multidict-6.8.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:fa6c2880709c84457de104385b704fc28860f27e442ad13966fc4af8e714fe9c", size = 48549, upload-time = "2026-09-09T13:56:26.574Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/97/f7/d852d2276407640cdbd29fe11cac6e93f70f59542cba174ef9d146738946/multidict-6.8.0-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:eabb03dc3e4ed6333ecd1cc9826ec80e7a98b5506deeb832d7260c8e44166d23", size = 83157, upload-time = "2026-09-09T13:56:28.227Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/14/e3/16fe7ffa6090591d83cf6bc2486e77ce891705fb6d0191823140928311b5/multidict-6.8.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:59e539c4eb4d3a53b0e630a6ba2b2f2824732b5e73f90e30a280f12fde157b15", size = 50578, upload-time = "2026-09-09T13:56:30Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/0c/e38e41c1087a599f86ff58a01f358abf7c4db3c26a3e90eebb3e02193ef1/multidict-6.8.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:835d5a90b11d1f5f8200ff3cc8316bded76eebebc92436398947a27657e645e7", size = 48815, upload-time = "2026-09-09T13:56:32.056Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/f0/eb691f42af8e7775992f57904ec75dc356fc7cdc896e5f30879decdd26f2/multidict-6.8.0-cp315-cp315-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d2d236b8a44ae91536a12ebcb996bdb31cf27425f36b4d05c87f2ba2716050ba", size = 274804, upload-time = "2026-09-09T13:56:36.741Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/87/05/28472ccfeb43c00a043c0385ca4294da21a5957859fb7860e2ebdb3e3011/multidict-6.8.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bb9a60b7faa5d37c426fa91cf4d6738182a1f2755b9fab7c9c64cd466c4ce51e", size = 279693, upload-time = "2026-09-09T13:56:38.531Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/a1/2b4fe73e5fecff807b47650a155c391a103136428cb21d6ba8e39c5912b5/multidict-6.8.0-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0ef606c15cac6c90279acf34120784b6f36662cbf382defd3955cd8f1115336b", size = 254969, upload-time = "2026-09-09T13:56:40.407Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/44/e0/c97d1822783dfe52e02fd150fa3f02eb22410211a9e2615f71541803ed4b/multidict-6.8.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:68186a2d4051c8ffd17be33553bea2ec9bbc8ef860fe2980a221d96126296f31", size = 286392, upload-time = "2026-09-09T13:56:42.234Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2f/d9/772f1339e1d051236bcc137b0eac2b4aaaa0bbb56aaf924e9aaba901d9c1/multidict-6.8.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2cc66abb85e2108c9ff8a1c0d20fa260bf690bbb33caef4ff3ecb2c2cbdfff5d", size = 285348, upload-time = "2026-09-09T13:56:44.255Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/ae/cd045747e4680362e02955a82c468e95b5e4d319e3a79574b3fb677de568/multidict-6.8.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:69b3e519a132bb943b0daae15fc8c2168706b17f826481d32a32a5e784b129e3", size = 282721, upload-time = "2026-09-09T13:56:46.088Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/35/14/0802d9a3aae4ef21eaa39adbd729a380fa095932105e1424e417b53e783f/multidict-6.8.0-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e41226ecf607f062fe34a2f4cf64ad3a89e3a0180dc800b463b6b14c06dd10dc", size = 253168, upload-time = "2026-09-09T13:56:48.07Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/64/3f92298bab8fbe1332e708863fb55b66e755be6f416b3459720d48b33af9/multidict-6.8.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:610c7637bc36b90f39e6c66f710f93d57018f83d53e1e187caaa218c6892b95f", size = 274209, upload-time = "2026-09-09T13:56:50.023Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/08/c2/2001ac0eac1a8b7390a5902d7115f66d4f256268057a502200b6ab12dad7/multidict-6.8.0-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:65c85c79f5a2c04fbbc18f006c014674dc5fdf270cb978d8862c82c6f694e60c", size = 268044, upload-time = "2026-09-09T13:56:52.033Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0d/90/78a9e26c85f89abd562a67f7fcbaef9007fd5c37bb9efac19f1cf604e7c2/multidict-6.8.0-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:628ff11e6720f90acd0c305dfa3339f04a783a20de8cda6ac333ba46447261e8", size = 274806, upload-time = "2026-09-09T13:56:53.975Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3d/71/713bd445421b21531234c1f3630b768192cb9d80c8b1c5b05c5b505ff4c0/multidict-6.8.0-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:0935971bffd0b479fc90c4811ca787703e93fcb6afea939a375dfc80285ab368", size = 281890, upload-time = "2026-09-09T13:56:55.848Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/a5/1387c538663e2dc8c27bbc7cd6955cb66de0f55c780cf7cd0fc06a1a16ca/multidict-6.8.0-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:9442b14eec262a1f74369bbd07e75bc5155105164649a4b9fbc1ebc7b8fb0b14", size = 249749, upload-time = "2026-09-09T13:56:58.01Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/91/15/104296c9d70896b9759ce0812aa4899fab76d8b16bb32dcc5a78ab547c89/multidict-6.8.0-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:397599503b718f0137f26d3f6532d6955069cd2e5917c47ef581495bc2529ff8", size = 276138, upload-time = "2026-09-09T13:57:03.591Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/0a/f2a0c2658e9d7ff5964ec2820a02054558636fafd663230ddc8310b8ed39/multidict-6.8.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9e37024b41d7a7e7e9cce14b248d54707c21c2a2ea30a47b71bdcefcafec00f2", size = 277077, upload-time = "2026-09-09T13:57:06.024Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/98/50/bc46566caffba5c1c4a510519156371edf7c4ecd35c9ef917d0c1803487d/multidict-6.8.0-cp315-cp315-win32.whl", hash = "sha256:071da134651b04a8507dfb331ac0988f376337c2aea59486bf20989fb5b5a64e", size = 46930, upload-time = "2026-09-09T13:57:08.009Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6f/1a/cafb31049ecc1a6ce52bcc69fa436cca239adc057b1718a0c49044848663/multidict-6.8.0-cp315-cp315-win_amd64.whl", hash = "sha256:3bafff8598f0528017ddc74194e5451d5c22d046c98935f8f86247b0f286e4f8", size = 50294, upload-time = "2026-09-09T13:57:09.986Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6b/51/00e037da14cd1d894b123e0bbe62de5c561679a6ab23ab1c009f2965dcda/multidict-6.8.0-cp315-cp315-win_arm64.whl", hash = "sha256:e886ef8c9879105fe4fc99417447b3a5f35d1131412ce839470bd2089fe2043f", size = 47626, upload-time = "2026-09-09T13:57:11.738Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/f7/aeb947982197e8b4f5c4da3961ee473ea5a050b94a6ff3b88baf64621401/multidict-6.8.0-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:883284137e25318ed9735b742ae46341a864888fae28e8b6314c4f84da080f08", size = 88801, upload-time = "2026-09-09T13:57:13.957Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/35/d8/593948c016c3f850e3cd56a4e0144151eb409d2b8690f0c0ce7f7d33dbea/multidict-6.8.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:ca52b9ec80851366197577154c862c4c4c7036ca76ae94cef5cb59c5cfeab944", size = 53376, upload-time = "2026-09-09T13:57:15.94Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/58/b9/097a05bca533027c0477b6a90bf927dbbb4b23cc9090bbb37a2e972af8d5/multidict-6.8.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:91fa75d0a693832106d98f66c849f034f21c828d14437f1fb97d3784aab89e84", size = 51629, upload-time = "2026-09-09T13:57:17.685Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fe/07/938ed21967f12380d0b8861645fb65a942f3669e31d5163ed94d23103b61/multidict-6.8.0-cp315-cp315t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:307c1acd812fe897e7fbe10c6758822e8c04be4e7c60a9f54901cdf8b5ab8bc3", size = 261967, upload-time = "2026-09-09T13:57:19.752Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/89/e8/e66bf843fd29c01712dde9edeb9f4ad0ffab06ab4ada4b721ad7bc73b3d5/multidict-6.8.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf684986a2490628f059a99dd107b566a2d34cf947f8eb8387e0500a1f90c5", size = 265923, upload-time = "2026-09-09T13:57:21.784Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8a/f8/e9be849b225af28a8eee2c6bfea23594a777c753fe97e2ff7e2180c8935a/multidict-6.8.0-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:77745725125d01fd613b6db043362aa7c6bfbfdb23d45dbfc3d92bf58160af62", size = 239380, upload-time = "2026-09-09T13:57:24.3Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ab/67/4dbad08f5081978c591afae9e836ec9ddae90e9e76be6d6ce10757483dc4/multidict-6.8.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8daafaa0b2eb43f76898ced78b1e0fb91b38c4fa50da516c18067f2a2d578c20", size = 271591, upload-time = "2026-09-09T13:57:26.611Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/92/3f/e9c97222d7e104e54e556f118ec7d091ab41a0c10c630f2b97e5b43f5404/multidict-6.8.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c68e0c0649d17c2d0339e3674e86a4aeba4a7e6b21c1e394cf947a95433b31d0", size = 276091, upload-time = "2026-09-09T13:57:28.997Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/26/ca/728e7ce05ac9c0303554e7162e74d91fe49e65bad7dfbb377f783dd32c0a/multidict-6.8.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d8a5ac357ac283490a8d1899b0383355fd1f8634b14ba0d59e4c0dd97db85556", size = 266493, upload-time = "2026-09-09T13:57:31.256Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8f/74/7c658d2769863af16fb7d7c6be50b29659892a06a632858863eee3a31842/multidict-6.8.0-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:46029e6e27a3ec0dc55b53f58df82d10f04c5e111f78248279b530bedad2c30a", size = 245302, upload-time = "2026-09-09T13:57:33.464Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/2c/d4350a20a0e8c66a447d694e8713438262665203fe826c3f4e385f052b72/multidict-6.8.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:8d1046b5427dcafe6e8a0e07527dd74f1ee694006160162f53f3a17f15aad3b4", size = 261016, upload-time = "2026-09-09T13:57:35.651Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/78/83df999c8beb72a012cfac42f2b833c4a48f8e836fd4407747b355a2430e/multidict-6.8.0-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:f1f4a220db6ed7c8fd16b6d644ffd1f082651693204daf3275e049fadc849e39", size = 255021, upload-time = "2026-09-09T13:57:37.758Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/13/f2c0a2dac6d91f74aa124f3e9f07ec497ceae5ed2df2753d249601cd7262/multidict-6.8.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:029897732a9c798737457e382bf84e8c64237eff224a90aea2639f4413c45e4e", size = 263066, upload-time = "2026-09-09T13:57:39.897Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/59/1d/730008d4639ace731bbb1399e1ac13cbdf506f7d6fb861d75044ffb3994d/multidict-6.8.0-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:29be9fd289e9ab8f480996ea2f686e1654b80242033843cb11691688329423f1", size = 266510, upload-time = "2026-09-09T13:57:42.39Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ab/ca/bec67a5d206dc5748e50c93f6f71deec14305c3657cfe250c3887caf7839/multidict-6.8.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:29631224698de1e42abc8fa7658d830e0aed0029785144b5832b695da5adef2f", size = 239423, upload-time = "2026-09-09T13:57:44.304Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/db/5f153fe51fbac7d80f3bb8bd6fab8db8b6cd061e7a11371676dfed3712bc/multidict-6.8.0-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:962f18c59a000f30b084ea2e6b8001521bb315efd4e5f10acf9fb36f366b7882", size = 266902, upload-time = "2026-09-09T13:57:46.297Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/89/0f/9efca48a351551de4dc0c183f523109dbe87c645a4732d5f1c70b4880dca/multidict-6.8.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:c60e50bc5b07faac92fd3a20fa21cc8cf3e3f7204d2867b206c73293ebc19101", size = 260887, upload-time = "2026-09-09T13:57:48.268Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/df/d8/bb879a62e0809448e53f6237e71670066ecf3bbc5896a7a6705b6628d86a/multidict-6.8.0-cp315-cp315t-win32.whl", hash = "sha256:fc5460940f50dff00731b4132366840ba9685286ea88ea104b661899084f3fea", size = 50533, upload-time = "2026-09-09T13:57:50.31Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fe/62/3e5308d8871636e4b9620e4b3acfcf2b5caf79b19d317690ec13f7fc8b57/multidict-6.8.0-cp315-cp315t-win_amd64.whl", hash = "sha256:b367c342327717d644db4c0ddb37ceb655c84822215ea0773a3a36911b74b71d", size = 55572, upload-time = "2026-09-09T13:57:52.301Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b9/cc/d3c10e10ee3bb7a7b4abbb3157306b2ce7e0018c9c2d16b32b468739d2b7/multidict-6.8.0-cp315-cp315t-win_arm64.whl", hash = "sha256:0c1c4debad7337627b86837abdf0237ca3cb3d7e17de7eab0177c263878546d4", size = 50322, upload-time = "2026-09-09T13:57:54.099Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/ee/be4e1a4b7a2b27f4fb6936510d4bebcb41b0562c946930ad26916e069cf9/multidict-6.8.0-py3-none-any.whl", hash = "sha256:75daa15ca16d6285eb2e104b2f05ee6f8d9836c68da3ce5c85f615a0450eed0e", size = 16297, upload-time = "2026-09-09T13:57:56.106Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/82/6a/878cc1097d4035f82bd516658d0c528d2a9955bc7b363afcbd0b07fea11b/mypy-2.3.1.tar.gz", hash = "sha256:47c1b1207258513a9d93495f69c8be9de73916186f0e52703e8c461b7a623419", size = 3992554, upload-time = "2026-08-15T03:03:38.549Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/cf/862010ee800ca9c2bd0c4c0dacf0f092e5411824a09b8f97ad4be8fe250e/mypy-2.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:114dff494000f18bd10d5d95d84b8567b26da60279ecbe838131841df20e635d", size = 13964542, upload-time = "2026-08-15T03:02:21.43Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/75/5a/3f3a2107b41e3e92e617e25daaee121413b91e9784bea733131ed4fecc5d/mypy-2.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8637731bb5eee3671eb2c3200827aa3564ed8a9309ecee4d1afe77e6d031bdb", size = 14168922, upload-time = "2026-08-15T03:03:00.351Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/41/04dc4fe7e63d7820fa4eff272e95157d30cbea921388f3ab3fe77794cd0b/mypy-2.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c80fbc405ed8020f5ff3802dc18cf060197bcdd3fbdd6a26ef2fd34dfdd5226", size = 15244791, upload-time = "2026-08-15T03:02:31.089Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/fc/c3053b26b9054949285aa868cb6af8c10e7591541cacd79c5dcc06a1fcf9/mypy-2.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:84081f538ce27375045c02e3d7f81bd11d853400621ae245d87ce7b6c420ec74", size = 15501627, upload-time = "2026-08-15T03:03:34.128Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/70/4e/d77daab008bbc4e5001374d7928f4a260d28f0e6747af444fc4763f7a310/mypy-2.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:e9144ac16fde007096f9563eb2041b4433c2d705c4218edeb79e7e9d01035ee6", size = 11243961, upload-time = "2026-08-15T03:02:11.952Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/f8/7eb68c136e4abd30569fe31ef2bfcb7eceae9952cab80017c04cd09f5d0c/mypy-2.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:77ad9529e67dca28e511f5cd5671436584ce91f6d3bac159a353158187b986ac", size = 10213219, upload-time = "2026-08-15T03:02:26.361Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/be/c4/42a49d44aeff804edf1b19acce0b49e8bd1a9c57dee9605dd8d980aa43d7/mypy-2.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:192abaedf75da1bc0b1cef104927e70ec49c1ef0031cc4825c7ee10a438ed24d", size = 13986778, upload-time = "2026-08-15T03:01:33.69Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/13/9331fd2dfed7194d66c5304072894a8be3e51e9deda6863c1eceaa35a43d/mypy-2.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf678dffd16efcda2c15cbd30e9ecc0081388e29ea23687a88e686ed92638dc3", size = 14188467, upload-time = "2026-08-15T03:02:40.554Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/78/f7/f4a34edab45667c5465855dc585a20e87978ffa8aee711445b7239d120c6/mypy-2.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e036f06b41630f4c8a1d48f9ac6aa26acc65f8be089973f5519da643318f03f", size = 15225538, upload-time = "2026-08-15T03:03:09.761Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/40/05/534b3590757bd05794f73e07f6666c2a77b8597ffed795c94ce570096aa0/mypy-2.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71af9c8a894e862b58e92abb08e53b05a384a1e5e5d6dc7cda59126211a53d82", size = 15480805, upload-time = "2026-08-15T03:01:41.134Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/da/bdfba852e2562f599624af5bb7d29e36b0b4f526f2b8bac85efe0dd1803d/mypy-2.3.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:3c80cd23d85368bdd9f37d5231dfd97d35bcbf5bf41af96ef3a9b078ad1957f9", size = 7761712, upload-time = "2026-08-15T03:02:36.008Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/98/31/60fc64a74cdba4f2a5d642d32317993e479163e1ac7d91b695e5d15e2264/mypy-2.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:4956f34d145e145562a0a0bf367f642bbc85c04ec2baf47ae015947c3169a85d", size = 11423968, upload-time = "2026-08-15T03:02:06.931Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/23/eb5950b24cd26ba3b78f87707a275568d633c77dae8e61c9661be6055ca6/mypy-2.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:cfb12e360242d23d91f5e978d94f58ea66acf5804c4fb6f2f794a20d4cb1b595", size = 10399323, upload-time = "2026-08-15T03:02:33.671Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/82/c7/f80f4e46c0b9a00eb5f78a79d49dda8bdf56a5230f7257fb33e76be04da7/mypy-2.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e5f1c50bb05b64e2026b52867e8d21106f01313c744a2c4ecc34c90d12e8d6e2", size = 15121308, upload-time = "2026-08-15T03:01:46.053Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5d/74/9b04f17c7074cc5188f02fb63a2ca1d43fedf479e84fe3091c39061a1d7f/mypy-2.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:667196b352f4cf304ded4c10f90cfc179263a1acfb3cdcfa984bdfd340d498bc", size = 15536590, upload-time = "2026-08-15T03:01:35.941Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/26/04/c837ef6208e567774e2ed1f863f8ba6ec4817b1b6dd426315e5d559b6ec9/mypy-2.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9c53e395c12cad2c6d4b67d5da7c6057638a132d85c08b73646b18f802a0045", size = 16791074, upload-time = "2026-08-15T03:01:31.073Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/68/48730230afa45192d5bd429a6a2ff24a6f8dedda90fdf2b221792b54518f/mypy-2.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:18162b128c3f9c703cd35f5537446900b0d21a2549aa7a95d21380d2ef643fb0", size = 17069183, upload-time = "2026-08-15T03:02:28.566Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/ea/ca23fc9c20eeda09a15c9cbcf50015d0e73f409f6ead059e42aa69a608ff/mypy-2.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:30c0477d4aab7b7f39c8397dc877f2c96b9fe5588ec379f372c56eb63d599f63", size = 12154679, upload-time = "2026-08-15T03:02:04.809Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3b/67/8d982126034990869466f73b8db80dcb2234a7ac39b4dad093e047a79835/mypy-2.3.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6941ab3619377bc3f32ca02876b07d27f216f5201604b664d3937ea0fdd23bb4", size = 10969159, upload-time = "2026-08-15T03:02:38.152Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/f7/41e7f2d8117fbc7a7587286162ffe2f688984b69c46ed63cf5f2e4fc3bae/mypy-2.3.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:6f041a6de52c9217ca125e78ba0a335cb7fd98a1c0580978e49ab2b126f70b57", size = 13990694, upload-time = "2026-08-15T03:03:21.919Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/85/8f665811a0c8f3bf6fa1d9acd665ec2d97a2bcc453ae68dcd92340941cd6/mypy-2.3.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5159ae60f5dbc3a498af5ba8365505808ac8031bc63f9e00304ad545d40bdd9b", size = 14203518, upload-time = "2026-08-15T03:01:48.455Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/82/91b866c8546b120bff83b73a439d90d2d63ef3aff113599e6b8e4d566848/mypy-2.3.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47a8a7a0a7f6f6e63995c0ac36fa0c07b127413fdc81f0439b7f3dccafd33561", size = 15220224, upload-time = "2026-08-15T03:01:23.577Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c8/78/c226c99208ee40de7c768369fa533f933afa003dfdc606ff021450724e91/mypy-2.3.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2329c0501293d4e1f33bc15d04d6304d65a1cdda967ee93a05c1e681a3923133", size = 15501512, upload-time = "2026-08-15T03:02:09.453Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/e7/7cfb3f106c393979f4cc37ad6c0586044d50401e3c35b0c003e4f3ba6bc9/mypy-2.3.1-cp315-cp315-pyemscripten_2026_5_wasm32.whl", hash = "sha256:bb26deed807bdb0457cf3e3f1cd7c4a1cf9d66864eaf1b4a61e06805d4c6b1f9", size = 7761913, upload-time = "2026-08-15T03:01:55.65Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/3c/52affefa273b97939a1f474ae4a349c8718635c15b941112dfab4291b0c1/mypy-2.3.1-cp315-cp315-win_amd64.whl", hash = "sha256:375d7013876a8233b2d05be185bfa09f689696cd999ce8b1cfe6acac5c80e8a3", size = 11422533, upload-time = "2026-08-15T03:03:24.101Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2a/b7/75643e70c72a5b346d8a9b1543c967ea8824df2ee3fb7ccba652c272b7bb/mypy-2.3.1-cp315-cp315-win_arm64.whl", hash = "sha256:586b3612214cceabb3c0f588c97e7d1e535393f06a60e912e994f6b3ace97523", size = 10397931, upload-time = "2026-08-15T03:02:55.265Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/ce/53be21f2d4adfcd26f63f1184a13ed797015ab463853f117e2e11e4d726f/mypy-2.3.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:ef0c6335cda9d807f8193d8ff6204a72bc909fa9882aacbca14f43cdb7188306", size = 15118669, upload-time = "2026-08-15T03:02:51.479Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/62/43/20de757cd42989d291a17fad607742c4c74e875ce5cea00e5a5225020ac1/mypy-2.3.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e598c8c66401d26b150872154a286e6d484cf2789c3bb28a7556806298423021", size = 15545627, upload-time = "2026-08-15T03:03:05.132Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7e/fc/092bdf77ad280eaf501422f0f3b966012b528076cc13e41a774861c907d1/mypy-2.3.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eda22fd4efa9dcd39331d1dede9b5b8b8a7fd69af07592e778433da98610d29e", size = 16764157, upload-time = "2026-08-15T03:02:23.958Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/5c/c94c4d62d909b07f552d0d9356d7acc943825558e602a64822ffa2231536/mypy-2.3.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:2a0ba2e57847849fb0d1fcdabb32786d223095ed8bc121dfe322bcdb3d9c46bc", size = 17073258, upload-time = "2026-08-15T03:02:14.573Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c0/f7/511a88b89e478053c02d22039bb8f3ce4183efe8fd7a4f0a5910a8bb0a32/mypy-2.3.1-cp315-cp315t-win_amd64.whl", hash = "sha256:3f7e865dd51f235f60a2dbcd8728a1c095f5ca28f095d48a725b84cd935735c4", size = 12135505, upload-time = "2026-08-15T03:02:16.714Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/71/bf/02573b56964ecb0f7c644f915f53c325ae15c3faec521c5adf11599a32df/mypy-2.3.1-cp315-cp315t-win_arm64.whl", hash = "sha256:8ad80807dc3ab8ea978b1b2b6e4a657194ace1d4ef03e0e731aff1abd517da29", size = 10962647, upload-time = "2026-08-15T03:01:43.712Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/41/9675c7a1e78edecfba0b79e587a52594c56e189368261dc7b3a7fffb9527/mypy-2.3.1-py3-none-any.whl", hash = "sha256:6ed5c7e3419083268e5c9258bd1c1ef91af44a9e89374dbcaf37b775716e72eb", size = 2754338, upload-time = "2026-08-15T03:02:53.4Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "neobot"
+version = "1.0.0a22"
+source = { virtual = "." }
+dependencies = [
+    { name = "drissionpage" },
+    { name = "fpdf2" },
+    { name = "markdown" },
+    { name = "markdown-it-py" },
+    { name = "openpyxl" },
+    { name = "pikepdf" },
+    { name = "pillowmd" },
+    { name = "pypdf" },
+    { name = "python-docx" },
+    { name = "transformers" },
+    { name = "xlsxwriter" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "prompt-toolkit" },
+    { name = "pyinstaller" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "drissionpage", specifier = ">=4.1" },
+    { name = "fpdf2", specifier = ">=2.8" },
+    { name = "markdown", specifier = ">=3.10" },
+    { name = "markdown-it-py", specifier = ">=3.0" },
+    { name = "openpyxl", specifier = ">=3.1" },
+    { name = "pikepdf", specifier = ">=9.0" },
+    { name = "pillowmd", specifier = ">=0.7.3" },
+    { name = "pypdf", specifier = ">=6.7" },
+    { name = "python-docx", specifier = ">=1.2.0" },
+    { name = "transformers", specifier = ">=5.9.0" },
+    { name = "xlsxwriter", specifier = ">=3.2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.19.1" },
+    { name = "prompt-toolkit", specifier = ">=3.0.0" },
+    { name = "pyinstaller", specifier = ">=6.19.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
+    { name = "ruff", specifier = ">=0.15.5" },
+]
+
+[[package]]
+name = "neobot-adapter"
+version = "1.0.0a22"
+source = { editable = "packages/adapter" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "loguru" },
+    { name = "neobot-contracts" },
+    { name = "pydantic" },
+    { name = "websockets" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp" },
+    { name = "loguru", specifier = ">=0.7.2" },
+    { name = "neobot-contracts", editable = "packages/contracts" },
+    { name = "pydantic", specifier = ">=2.7.4" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "neobot-app"
+version = "1.0.0a22"
+source = { editable = "app" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "beautifulsoup4" },
+    { name = "cryptography" },
+    { name = "ddgs" },
+    { name = "drissionpage" },
+    { name = "duckduckgo-search" },
+    { name = "fpdf2" },
+    { name = "httpx" },
+    { name = "jsonschema" },
+    { name = "loguru" },
+    { name = "lunarcalendar" },
+    { name = "lxml" },
+    { name = "markdown" },
+    { name = "markdown-it-py" },
+    { name = "markdownify" },
+    { name = "neobot-adapter" },
+    { name = "neobot-chat" },
+    { name = "neobot-contracts" },
+    { name = "neobot-memory" },
+    { name = "neobot-modloader" },
+    { name = "neobot-storage" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "openpyxl" },
+    { name = "pikepdf" },
+    { name = "pillow" },
+    { name = "pillowmd" },
+    { name = "playwright" },
+    { name = "pypdf" },
+    { name = "python-docx" },
+    { name = "python-dotenv" },
+    { name = "python-lsp-server" },
+    { name = "readability-lxml" },
+    { name = "requests" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tomlkit" },
+    { name = "trafilatura" },
+    { name = "xlsxwriter" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "cryptography", specifier = ">=46.0.0" },
+    { name = "ddgs", specifier = ">=9.0.0" },
+    { name = "drissionpage", specifier = ">=4.1" },
+    { name = "duckduckgo-search", specifier = ">=8.0.0" },
+    { name = "fpdf2", specifier = ">=2.8" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "jsonschema", specifier = ">=4.23.0" },
+    { name = "loguru" },
+    { name = "lunarcalendar", specifier = ">=0.0.9" },
+    { name = "lxml", specifier = ">=5.0.0" },
+    { name = "markdown", specifier = ">=3.10" },
+    { name = "markdown-it-py", specifier = ">=3.0" },
+    { name = "markdownify", specifier = ">=1.0.0" },
+    { name = "neobot-adapter", editable = "packages/adapter" },
+    { name = "neobot-chat", editable = "packages/chat" },
+    { name = "neobot-contracts", editable = "packages/contracts" },
+    { name = "neobot-memory", editable = "packages/memory" },
+    { name = "neobot-modloader", editable = "packages/modloader" },
+    { name = "neobot-storage", editable = "packages/storage" },
+    { name = "numpy", specifier = ">=1.26" },
+    { name = "onnxruntime", specifier = ">=1.18.0" },
+    { name = "openpyxl", specifier = ">=3.1" },
+    { name = "pikepdf", specifier = ">=9.0" },
+    { name = "pillow", specifier = ">=10.0.0" },
+    { name = "pillowmd", specifier = ">=0.7.3" },
+    { name = "playwright", specifier = ">=1.55.0" },
+    { name = "pypdf", specifier = ">=6.7" },
+    { name = "python-docx", specifier = ">=1.1.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-lsp-server", specifier = ">=1.14.0,<2" },
+    { name = "readability-lxml", specifier = ">=0.8.0" },
+    { name = "requests", specifier = ">=2.32.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+    { name = "tomlkit" },
+    { name = "trafilatura", specifier = ">=2.0.0" },
+    { name = "xlsxwriter", specifier = ">=3.2" },
+]
+
+[[package]]
+name = "neobot-chat"
+version = "1.0.0a22"
+source = { editable = "packages/chat" }
+dependencies = [
+    { name = "httpx" },
+    { name = "neobot-contracts" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "neobot-contracts", editable = "packages/contracts" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+
+[[package]]
+name = "neobot-contracts"
+version = "1.0.0a22"
+source = { editable = "packages/contracts" }
+
+[[package]]
+name = "neobot-memory"
+version = "1.0.0a22"
+source = { editable = "packages/memory" }
+dependencies = [
+    { name = "neobot-contracts" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "neobot-contracts", editable = "packages/contracts" }]
+
+[[package]]
+name = "neobot-modloader"
+version = "1.0.0a22"
+source = { editable = "packages/modloader" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "neobot-adapter" },
+    { name = "neobot-contracts" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "neobot-adapter", editable = "packages/adapter" },
+    { name = "neobot-contracts", editable = "packages/contracts" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "sqlalchemy", specifier = ">=2.0" },
+]
+
+[[package]]
+name = "neobot-storage"
+version = "1.0.0a22"
+source = { editable = "packages/storage" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "alembic" },
+    { name = "neobot-contracts" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "alembic", specifier = ">=1.15.0" },
+    { name = "neobot-contracts", editable = "packages/contracts" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/13/01/11703282db468b85f6f7b8c7f22d058de5970d5c7e60a3a8aaa313c3de36/numpy-2.5.3.tar.gz", hash = "sha256:df2d5874ff183595a4ba404edd04f6bd9b5505c1d7708573f6a6c17489a67563", size = 20791231, upload-time = "2026-09-06T16:27:47.073Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/79/e5/8fb89cd46d14e35699d13bf943a5f5f441ecee8667120a1f6105ab89e349/numpy-2.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:66a78fe4556c60aceda5916f9eacd638b18e9e681016ec302dcb4682d6d4d034", size = 16991061, upload-time = "2026-09-06T16:25:00.411Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2f/06/9dc9e48b5e5e941c8b10350c5ff2d721da42a20517d911d15544246775ff/numpy-2.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:92f30e89b8ee0ecf363033576c422b2f58fed6a80bed0aa48dff6d14c654663e", size = 12003676, upload-time = "2026-09-06T16:25:03.475Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ab/2a/98282aa5b8f58b1157d440bb6282eed47e3632a5de53a714fbab17e659fe/numpy-2.5.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f9a2353b37a1a9e78fd82b27ad7e2a32a2d036604d18f02b05e3136c62ca3b09", size = 5439695, upload-time = "2026-09-06T16:25:05.978Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/f9/b6533d777be9d6ffd29dc1be0867e563e6e8cc9a220ff1b716adc317f060/numpy-2.5.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:ccbc4665079665c3cf3bab4db9f6b095370cd6437d66be549b6c2a1fd19e1958", size = 6779395, upload-time = "2026-09-06T16:25:08.599Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/73/85/735720d04ec197c5dcfacdfc9922667c7f1f5f496a279b7ba4d7c74c4cc7/numpy-2.5.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c76d5dde9f445058f83d0c02af00557a4db91de9a9a57c0df87d1535001d654b", size = 15681750, upload-time = "2026-09-06T16:25:11.173Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3a/1b/3b16a9bc514a440a7a0883684111dcb1ef1aee960af2ca95da8fc775f124/numpy-2.5.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5fa86b80fd24bcd1aff83ad23be44ea323de3f787be8f8b15d4a65621e25321", size = 16708577, upload-time = "2026-09-06T16:25:14.171Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/69/c4/386f397831b07328b639c96c5b62719346cf4baf07c68d927239752b1534/numpy-2.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd4cb9ad3c7889b9b3fe0a9a9fb5d2ed26f9879bff2608d9f01aed147a20d231", size = 17042047, upload-time = "2026-09-06T16:25:17.582Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5f/3e/a700ecbf36e85ae8328fd3b0e12eeddc22ed6358a64cb2bd913e0d195d65/numpy-2.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1302b90c0e52281681b2975adfe8a860cb7b12216a27b4b0b4207c44bf7bccf0", size = 18465724, upload-time = "2026-09-06T16:25:20.949Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/41/ee/38e785e88a4045f6ad1d1f2808dcdfafdca48c760260c0587bf171e29fc9/numpy-2.5.3-cp313-cp313-win32.whl", hash = "sha256:1c80eabb4035ecf4ca9cd49cde8a9fdd69a729e63e6474887d1523ade7aa277f", size = 6129003, upload-time = "2026-09-06T16:25:23.664Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/ec/100f2b1794ede74a9b3d7ec6b9736927f56713414c1dfe19ab6c383494bf/numpy-2.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:71cad2b2a7451ab79d8f5e71b453485b6775963d5cf794179144a7463fe6e8ec", size = 12560965, upload-time = "2026-09-06T16:25:26.602Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/b1/7dc825ca94c12acebbce4c37caa5e198695eb31424bc579679f32b1bb49d/numpy-2.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:8e4dd766076855b5ff7ea52fa5f07ce26286726e0f8bff446b7739d02e6ea204", size = 10482343, upload-time = "2026-09-06T16:25:29.772Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/70/78/cf416f15dc29375a229d9dfebf8db6e313f291580b39fa1a568b6052bb07/numpy-2.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:350ba9783ce969cf9f7ce6e6a9a58e1a6e2a19ca025b7ee448c4db727706212a", size = 16998686, upload-time = "2026-09-06T16:25:33.171Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/59/abcc2d8def4fd60eec7d87f92d27c13448ffd9ab14339bcc63a0d7a2fdea/numpy-2.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:012e66aca395d795496446e52aeeb5866312a5d4d3f27da270e5a0b43f70dc5c", size = 12013862, upload-time = "2026-09-06T16:25:36.748Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/75/4640d2d6e4b64a049e48425a82728a41ef4adb61332d2cba68055774878b/numpy-2.5.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:adc1ada2662f8a5f960b8a10d9986897e7499ef07e06d4cfe7197f8cce923c07", size = 5449793, upload-time = "2026-09-06T16:25:39.476Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/cd/625b57ae33d4ca560f32cc0b47b4a5922146d9beb998ddf773900d440a73/numpy-2.5.3-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:54a115e5a73b8fc44f0cebef486365a1894b5c9760685d4558b72b7c3eb846e0", size = 6785176, upload-time = "2026-09-06T16:25:42.069Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9c/72/12918652e7912ef9751e8694c88820fcd1908e0618cb23f5f3caa6004b7b/numpy-2.5.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be5a8381859b6da607c84f4f7d6847725f1cf1853ef8a2c9e115b7d58bef47dc", size = 15703377, upload-time = "2026-09-06T16:25:45.135Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/8f/9beacf79ca7c650688ad0baa80931adb988fe6e6e5d5903c23cc3dbd70eb/numpy-2.5.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b0521d0f4aebb6e06189451025fa17a913287b13c03d5fe05c017333b654ea5b", size = 16711928, upload-time = "2026-09-06T16:25:48.461Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/8d/41d0a56e1ac4c87495c897a211b1368691b7237aadabec8b3b8f3a74d48f/numpy-2.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9deb49575e5b0b94ed72c8a64ec4d033381adc27e9060ae842971f697ba96104", size = 17059507, upload-time = "2026-09-06T16:25:51.873Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/08/1e/0dfbc5cc251d54e2af790f254d24ec38637fa97ec7d5d11de7ffed787098/numpy-2.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b00eefbcf0f292945c4b4dec2ae845389ef5bcdcd596e6e4328051db5b5ba694", size = 18471002, upload-time = "2026-09-06T16:25:55.233Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b5/2c/dfa40f6991f8185c8c30ffd023dfcbb11888e823cfab9557b920f3bb7bed/numpy-2.5.3-cp314-cp314-win32.whl", hash = "sha256:c2381f82999704f818e2c987a865050e285ec3621262c66d40f5a96c8f899f8e", size = 6180485, upload-time = "2026-09-06T16:25:58.157Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/73/d2c08231e4fde7e415501fd02c715d96e98599b2d8384445933944152984/numpy-2.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:2c25dfa72943e4336ddb6b0ee4277b47a0c85bede0807530ec68103bf58e2c10", size = 12698179, upload-time = "2026-09-06T16:26:00.789Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5c/e9/dcdcc9b95cf5f49815055573aee1b11cfbf5299f38a180e437ded050810f/numpy-2.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:15aa985ac73a8db02db7663381aa109510449d3819d37206caed27b33a65a8a6", size = 10769383, upload-time = "2026-09-06T16:26:04.011Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/c4/af8bc08a7ef4e1529a7c0cf24969accce316b783999802089a581ec99272/numpy-2.5.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ac7bb1c52d445bd4f8f7f97fefe6abc3a084dc4d63df50d79b17fa2b78e89297", size = 12132668, upload-time = "2026-09-06T16:26:07.138Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/ae/0f15eb56d4ec5e13c1f7ff04ff407f997d1acbadb45d3e1f2e2645a8f43c/numpy-2.5.3-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e6ab667ba76450084eb64013762c438ea76d9d29cc676dcd6c2e9892ba37f841", size = 5568580, upload-time = "2026-09-06T16:26:09.828Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/23/fb/c72a8f25d4b6e96c354e7ab45ace3b27dc11e5d6a13b6c7d0cd6b08bf112/numpy-2.5.3-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:f7fabeb6cea87d65f3b926de33d03fb016cfdc29314c90974383b5582ae72891", size = 6882634, upload-time = "2026-09-06T16:26:12.524Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/07/a9/968c90ed2ab15060c338e8137f1215b5a60756ae07328e0a60d1c6734df4/numpy-2.5.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fb6f8fb9ff0b3a69f52c66ce397b0246583e9f28616231b0e32ca49259a5fa6", size = 15748923, upload-time = "2026-09-06T16:26:15.092Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/59/08/9df04103947b95e3b6b1f2ed1a70521f325647a31b82da6a2aae3a485508/numpy-2.5.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93e1f5447e2b1e479d7bd74701e84746b86450cff1fc368b132d195e2b8f8211", size = 16746748, upload-time = "2026-09-06T16:26:18.43Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/41/a0/14c8d5fe5b53a334aabb653deb391c0fef49558f491880ea300ed6785224/numpy-2.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c00abe94c1a69d75d827dcf1c025b25c8a45d230b3bcd77a9020883a1b047653", size = 17111561, upload-time = "2026-09-06T16:26:22.113Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c4/a6/d7e96e42f01522e154c32489640f16dfc4f6181d165d05fc3bec8c2c4999/numpy-2.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:536f963710a4e63934d80ac0dc4f478804a83e9a84b6828018f25d09953ada33", size = 18513945, upload-time = "2026-09-06T16:26:25.401Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/25/39/3453afb7119d0449ef11c886874120ff180e2c337760e0e2d88f70f1a945/numpy-2.5.3-cp314-cp314t-win32.whl", hash = "sha256:4c8a6d2ebce6305fd82fbefca827775437147052a976ee7c94b36a0c1b52ac6c", size = 6335421, upload-time = "2026-09-06T16:26:28.175Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/01/22815d2b19a1a746b1d45205cffebb3fe511a18acb75fba6c88491fc9894/numpy-2.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:9a37475425b431b4d060f23b4f52cd2f3aef6bc7c654bd760adf0040eec9d435", size = 12896420, upload-time = "2026-09-06T16:26:31.265Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fa/ee/a7cbba67eeaff038dc29ca8b98a88396c8b0cc9c89d4924f4a27a5c9150b/numpy-2.5.3-cp314-cp314t-win_arm64.whl", hash = "sha256:2d8240cb4c16fd831074aa2b2cf9fc54664d826341d61c372245b96a74a49a9a", size = 10857177, upload-time = "2026-09-06T16:26:34.167Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/56/78194492883ff5eec90423fe56a3a44b154da047d88a6307f629713c584f/numpy-2.5.3-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:a6391fafaba97500887132cd582abc6e19452b1ac775a47caa7b24490e152058", size = 16996531, upload-time = "2026-09-06T16:26:37.287Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/11/39/dd55c0af90bbab564b09ae3b0aa60ec5c02b900fa4f1ba23440525c8b32d/numpy-2.5.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:09d5a423c71ad5feb5625844ad58050e35df43871004b52ac9c0ad44a56775be", size = 12012569, upload-time = "2026-09-06T16:26:40.707Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b6/51/04f67d32e4862b281b1cb84ceeaed3421189a84fb6fb51a391cd6d5009f7/numpy-2.5.3-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:f9579f383d1bf9df80081e72760e84960a7fd4f88cf0c9e535a8597c9bb646f5", size = 5448498, upload-time = "2026-09-06T16:26:43.435Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a3/c9/25b4dc0dd1344ec26c7319e84fd4e9809d2b5628f4e12decd618036e5178/numpy-2.5.3-cp315-cp315-macosx_14_0_x86_64.whl", hash = "sha256:86bff898a431c0fb71f7610b75726e75a54d47b37edc9d537f48de63bb3c0b90", size = 6783026, upload-time = "2026-09-06T16:26:46.374Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fc/c7/29285be1e5232a6e7ee3268a33c85843f5a8ee93350c6465cddd66ebbf76/numpy-2.5.3-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f3ed25271581281f2fccb1adcedfcde4c07362eec69189b50baf6f90e3ae159", size = 15697322, upload-time = "2026-09-06T16:26:49.415Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/49/bbad5335fb4996a16881f853ff3e0ba582f01720e55c89b1c06b8fc42a90/numpy-2.5.3-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ffdc76bfcae6b255dff75202c5e7feaf95b40246bc0a17944facc1fecf9f79ab", size = 16708995, upload-time = "2026-09-06T16:26:53.127Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ef/e9/1df35483760b04a65ea44669f89dc64f30e5aca098b48ceb8b1310b0e0fe/numpy-2.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:116f96cadd935c6122e9228d676fe7ede19e741f5c8bb1c3cddbe0c51ccebea2", size = 17052508, upload-time = "2026-09-06T16:26:56.464Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/99/66e54da8265cc8be8a7382bf96edce17aaa2837d6f484432025932a3caa5/numpy-2.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:09ffa5d903faeaa5c4dd05009cf81c8bab9f2cb37c548b8d39b65b4cfa7c97f7", size = 18468224, upload-time = "2026-09-06T16:26:59.966Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/01/bc/b5e90a91c115168d793dfd2ad9c69c438c2fe7a13a437e770bc5b078e732/numpy-2.5.3-cp315-cp315-win32.whl", hash = "sha256:e01c918ac3d48e18a927cf7b14a26a3e29ff2bdf2eacb976da0aecd6a43ed034", size = 6179919, upload-time = "2026-09-06T16:27:03.166Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/ea/780748fd3985109075514ef8fc64cd25f943e40dde13a6d59141eb268fc8/numpy-2.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:e931e4f499e0dc7ef29d269a8e5b35dd722e5d14be07df6240166ea7c6532fae", size = 12697656, upload-time = "2026-09-06T16:27:06.153Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/16/407be69a2a87c8cab64d95975a8977a426a29e138f07e276ec258f0fe4e5/numpy-2.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:26e15e4aecd8617dfbaecb37d223e365d7b39411fba20454be2670a96aa74cb5", size = 10767601, upload-time = "2026-09-06T16:27:09.297Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/44/bf/a97ffb01e41d50a32a9177aef942a4d0e389a3daf451d04e5f38ef6afb87/numpy-2.5.3-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:6cef4bb1706dfec49243c05d921eefb4e190d41e2528b30d8035ea1f36b4c24a", size = 17090092, upload-time = "2026-09-06T16:27:12.907Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/24/136c02f2c2af9a067a84d0c3aa10c99012c0476fa5066732fa4a4202557d/numpy-2.5.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:d1c89973648c85069c5046ad460f7b8a00218b29a2e42359ac8cc63e9ab94832", size = 12129429, upload-time = "2026-09-06T16:27:16.089Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fe/6c/b47582d6597789bf946d5efbeb6b9e56fd8bcbd5efc6fbf51dbe1ea31eb3/numpy-2.5.3-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:214045a5bf00113a146ab9ee9730c44501af6723cdf1f6830932f7b5ef2e7af0", size = 5565452, upload-time = "2026-09-06T16:27:19.868Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/be/b4/ef3cc6da73774202d4deae16bb321fd8298a4e0561e3539f8c4be237d916/numpy-2.5.3-cp315-cp315t-macosx_14_0_x86_64.whl", hash = "sha256:8617bbfae4486cf99c9f899966699428d19da931d06ca94ad3da986c76e15997", size = 6876736, upload-time = "2026-09-06T16:27:22.232Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/24/e3813329498596cb842703dcacac1741612ed9fb9c4e6a3e0c7e2ebbc597/numpy-2.5.3-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:595d020938c84e320bcf40ad71089e108eac0d377cd018e14a8c094f39e98d85", size = 15745777, upload-time = "2026-09-06T16:27:25.181Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4a/9e/4e7a07fd0776dc2210cdacf2010be8665194d094defc10c419d7dea794cc/numpy-2.5.3-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f24021b9f22bc6301c37b196974a92c1c18dccedb6fef3dd252e95f2d6adbe4", size = 16746949, upload-time = "2026-09-06T16:27:28.576Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/91/db/01674c0e20335057813a00c2ebd546ed25bff9ed7914f9bced00f8c55d94/numpy-2.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:71b39d9f935b6ec0f8753e3e2afb51e3efba6f2e05b68b32a40754d24bcd4a3c", size = 17108994, upload-time = "2026-09-06T16:27:31.946Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/7a/584c5e71f8d378e57cac0b033891ed65c683ef90573ba4854e8c28203db0/numpy-2.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:6b05c171afb3aa07adbd20abc00aea86fe375beb0fdb9ef780ec5b7f63bab1c0", size = 18512266, upload-time = "2026-09-06T16:27:35.196Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/d2/4e1014173aa3c55e6a756e0e567290743a6ab33a288460374d7ef6bcd239/numpy-2.5.3-cp315-cp315t-win32.whl", hash = "sha256:f54660b0eb6b0b9f36e7fe1cdfdff472028dd0d14acd9b9b65098efbad059469", size = 6330292, upload-time = "2026-09-06T16:27:38.149Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6c/b0/ff5658a58199b7bcaad87bf260eef6713d9d42cca4e028f935b4fc5fbac6/numpy-2.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:1aad64d99730d013cfc6debafed22783b4fc5a7f4b8bc744d2d8cf7dcc880551", size = 12884918, upload-time = "2026-09-06T16:27:40.965Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/0b/b12a2df5d1b774bd9007a6fdff9381145b6223d37f11afc9c37ab0efd9a1/numpy-2.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:befa1ae5bd6030b3f512b43ff3fa5290bbed6b84411a44244b14adf835f5b89d", size = 10850807, upload-time = "2026-09-06T16:27:43.868Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.29.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/41/f8/d375facf60edaf41f5732f9f689c98a800fcc52df5cf6ddfb406703eb5a1/onnxruntime-1.29.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:be0f8ed688cfb1d4d5765a137193b7bfab0c8ea214eed99260b380bb525a3a7f", size = 21429708, upload-time = "2026-08-17T22:54:01.44Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/17/b9ad04051a8c4f504852ce0e8e10f9a6b2f1a331eedcdcc503df776dd0ea/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d67673c5367727860922c5262d724472f1b5539fb7ccf4c81a638f9b71719803", size = 20816263, upload-time = "2026-08-17T22:54:04.088Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/83/2c/d8eb945d2a372149df9705a8d5c8d7c6c46c987c5446dbcea9e1ea7f6556/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e2128f31f449e922c62dbe5d8b6b7b079f0bcaf2d56a102fa203cb6e5bb5ab19", size = 23136817, upload-time = "2026-08-17T22:54:06.714Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e1/3b/66b424c63fa92dfaa48d1719efaae66fc8c256b9426a832eda51d8dfe1e9/onnxruntime-1.29.0-cp313-cp313-win_amd64.whl", hash = "sha256:2945e1f82f81f27e88decea88c7861f45baea23818950d467bf3909aa303119e", size = 14001310, upload-time = "2026-08-17T22:54:09.13Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/83/22/d6a700e3a6322fa3d56fbe7cee9ffc53f35e77ffcd6b7e97f4b7722a27ab/onnxruntime-1.29.0-cp313-cp313-win_arm64.whl", hash = "sha256:4b940b0d777590c7e20bf298f5c16af1ea6ad1b400a1c822a6be192f64f4d954", size = 13747112, upload-time = "2026-08-17T22:54:11.608Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4a/89/c4af146de3d60a32c89fea48d5d34bfd044faaf8957270043a03bd1b462b/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:533f8370ce124304e5cb08ab961836cf755631e3dd77adc5f3bbdab70c2b7d99", size = 20826136, upload-time = "2026-08-17T22:54:14.315Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/f2/e6bbacd11dfe8d070613261a758795ea128b9fc9bea391a2a7da2e4c7a08/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c1ad3f437153fe77f9d01a08fbaac0beb030e09b8a80ace1603bcf69b6c95481", size = 23138951, upload-time = "2026-08-17T22:54:17.154Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ff/a3/718e1b83096a1bc7b0fc8014c23d4cf795559fe666961cfac4fc038a4871/onnxruntime-1.29.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e74b278af1d949876f5d91d1268fd6c680e79f2bac194967394eaba9fdf69e7e", size = 21431104, upload-time = "2026-08-17T22:54:20.118Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4e/17/c75e78ddc1fe69b6ebaef7fe88ac83f29bfe10955e3a0d2436d93473c91c/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:939e5d65f332e6d399774b2bd0d3559fd8fa629c1e77833db29d968d2384f23d", size = 20818488, upload-time = "2026-08-17T22:54:23.147Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/65/54/9f197c578d3d3d7bea16971e233e5483981228eec73748585cf7b5933403/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:6c0c37b92f67ed68dd36221ce0403e1d9bd4f7efce724439978a2597848530e5", size = 23136994, upload-time = "2026-08-17T22:54:26.321Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/24/53/4616a55d2495679cfd0195f968feb3d74fe30e26467d168ee243ac97c089/onnxruntime-1.29.0-cp314-cp314-win_amd64.whl", hash = "sha256:4a3129ae56e70d2618ff773920166916310370a7e3cacb60b9e0e8910092725f", size = 14350643, upload-time = "2026-08-17T22:54:28.794Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0a/0f/c338cb5500a522c7e671a3bb1276f4562404fbecce8a0e274565aa968484/onnxruntime-1.29.0-cp314-cp314-win_arm64.whl", hash = "sha256:e417ef8628dcce310d2d53023e750ea298ec14d4341ae6dc3a572bfd9bc7fa97", size = 14124294, upload-time = "2026-08-17T22:54:31.015Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/e7/61064289a9a1301b25c1f0f574fe98aba31c2d388db3c1dbec664f78621f/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:11264bb58f7b7cf6af835ab10d36838d73680580820fd6f51d90124a1ca8f449", size = 20826174, upload-time = "2026-08-17T22:54:34.283Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/60/21/d0c04b561b46e9bff89b5f500fb7415b8ca0669f7902204f76ab06bb0c7e/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1ea91cef3b971506e51ae9c37c16d027774ec64994a524ec1bdfb027d68a9832", size = 23138547, upload-time = "2026-08-17T22:54:37.491Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "pikepdf"
+version = "10.13.0.post1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "packaging" },
+    { name = "pillow" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/0e/6e74dd213537b71c945743a4b3112dbb430896ad68b8a6ad22e4468455d4/pikepdf-10.13.0.post1.tar.gz", hash = "sha256:4b73f926ebae81f04bf14527af330bd00bb268be767e0f189f7c4c3e4ad7ae0a", size = 4973186, upload-time = "2026-09-05T06:49:20.825Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/f4/3636368760840cbc3ee512330024dd6f518d583c1bbbb1b551ca8e18f5e8/pikepdf-10.13.0.post1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:87141ada970386ff6640db54f0bda734d3bde7960d3ba04a76768b48e25028ca", size = 1845524, upload-time = "2026-09-05T06:48:39.309Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ce/dc/7bbfba253a0394a237b81be371a64f904f99636d579ec78ef5d92025fd2d/pikepdf-10.13.0.post1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:55e53b4d8a4b1700f686f76e3a68411e421e962a4c8b1b90d00aab3f3e494a55", size = 1944829, upload-time = "2026-09-05T06:48:41.601Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/a3/10367bfb93501a151cbb96b6973f7c049fef04040aea35cf6cedf579c3e4/pikepdf-10.13.0.post1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8fb8f82dc43056a4b4f891e78ee1db4e3ced75ba3e87b836f8e28c8771228928", size = 2102269, upload-time = "2026-09-05T06:48:43.222Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/bd/a68b5d9b4aef4d4b9c374cfdfd941623f52303d31adea13554568df42abe/pikepdf-10.13.0.post1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3b58ccb30b93ba400e6a6a83315b4830eea49f6f19e18d78241fe6b1c49fec2", size = 2307160, upload-time = "2026-09-05T06:48:45.192Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/59/47bd86d9e338d301c28416d52d0e154a0d6322cf6b957c9df5f3d7828aa2/pikepdf-10.13.0.post1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6b038cd5bcbb6c1952bcc271695eaf24c4199d72e45606ee5e467f837760820e", size = 3739722, upload-time = "2026-09-05T06:48:47.105Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/40/87fb6dddc9dce110429c72449e942174fd500f6fc4c9ff518a6b73057aa7/pikepdf-10.13.0.post1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b7b0cbb135de32ec3f41651a08ab294e3c18ae9fec32516a48d27e64a53a47f0", size = 3951549, upload-time = "2026-09-05T06:48:49.263Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/4c/534f23c8c196b1a7dc8672e503743e2a4766215125db474b261e33f37a9d/pikepdf-10.13.0.post1-cp313-cp313-win_amd64.whl", hash = "sha256:20c76343128ec41d5be58337b23c6f9f620fa7b8256a2d942460a48c07bbfe7b", size = 3407945, upload-time = "2026-09-05T06:48:51.543Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/14/0e/86897bf5325824c1f2d9d8be89839baf11011b5392d92620cb0273fb9af5/pikepdf-10.13.0.post1-cp314-abi3-macosx_14_0_arm64.whl", hash = "sha256:51fae4a4a3c6549aa4c405896ff7010f3e43e0c4f407c0bcee071ef13d271202", size = 1845245, upload-time = "2026-09-05T06:48:53.575Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/ed/923846b7511627f8564d09345e083f14674dfb193de92d27f1cc4650602e/pikepdf-10.13.0.post1-cp314-abi3-macosx_15_0_x86_64.whl", hash = "sha256:8cb976331cb8b03ec3465e06d9e7a3eadbadb7e622be888e70f918ac732a105e", size = 1943659, upload-time = "2026-09-05T06:48:55.823Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/58/bb/fcb09ad4bd227bbb37a7e5b24de86f9ce9d462aa0c7ee18781899bfa378a/pikepdf-10.13.0.post1-cp314-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e18d5a009bbe5f3ab18f916fb9e28f0c5b0d920736e3a85cc10c627ec633596", size = 2099423, upload-time = "2026-09-05T06:48:57.671Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3b/c9/707f9ba96727fa366a650237e46f0e20a73b244592eb6b97a49e401e2b43/pikepdf-10.13.0.post1-cp314-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:414f42c83e5e6029870de1a988625dafc95781ebff10e15d82caeb5e69a83c9c", size = 2303539, upload-time = "2026-09-05T06:48:59.506Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/15/79a2ccc354514a1321a161867a011fc917be158fc01a88da8c78ad18399d/pikepdf-10.13.0.post1-cp314-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f0eb89f06cad9231b9db54d81a22592b03b63924824a6b850febd2b75daa6546", size = 3737772, upload-time = "2026-09-05T06:49:01.245Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6e/85/a17440c2de64da71dc012b42e644b30ee4d98eb540c14d4e9f3538b73a9e/pikepdf-10.13.0.post1-cp314-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:544f1be1b1e5630a79cd182a8663c439504099eb9eae0d342a50173d9825bdf3", size = 3948342, upload-time = "2026-09-05T06:49:03.27Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/ed/c64024ce23f0f3149217679f31dcf51f42c687d35d597894342e93321f6e/pikepdf-10.13.0.post1-cp314-abi3-win_amd64.whl", hash = "sha256:b69b89577b50617248185b6ad73cda0e4f15c57da11f7da8cc4032bf0d7d9ebe", size = 3500024, upload-time = "2026-09-05T06:49:05.259Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/65/15a796a3cf9fb17d41acc1ab6719e7d3dcdf1260e76909d0dd32ecc97ba7/pikepdf-10.13.0.post1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:ef4ed47d40aa44deb063feb4a88e8bcf1c8fa0183ce526dc4295f7cbdb1292f8", size = 1853638, upload-time = "2026-09-05T06:49:07.184Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/f3/5d49a511fd13b59b94c5ad673695d331fce5d2846ab1501646c2a3b35b5f/pikepdf-10.13.0.post1-cp314-cp314t-macosx_15_0_x86_64.whl", hash = "sha256:571efcd1d54e0dd817973c76c253feb6fb758c93bb0c16a893cc68f2a178d404", size = 1951768, upload-time = "2026-09-05T06:49:09.048Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/de/f6bbd9653695f6e2ed3494a439f11f3a89450c004fe9bf8ee583201ea759/pikepdf-10.13.0.post1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2db9a18074ba112e7c517e8c21dfd8894cc13b8a37ccf49a5841192170fb68eb", size = 2107137, upload-time = "2026-09-05T06:49:10.788Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c0/aa/43b355681f05ea0b5808a26cba9e8e764686fa8dcebe0875db612664de40/pikepdf-10.13.0.post1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7962a75cf22d0d683b49ab19b8966e94dc7014d9aa6806f3c0d2b37fb9ae607", size = 2310991, upload-time = "2026-09-05T06:49:12.455Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/46/77574e9c4bded01afd7a3fe538f5432e396c3772c9bc1eab5d287aed00df/pikepdf-10.13.0.post1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b948e11f7dd3710f939194f00b4d75b0df87a30d53b31414128768ac25da77d8", size = 3744358, upload-time = "2026-09-05T06:49:14.428Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/89/a8/4857df72cf4773553c2e6a82f93ee5e98c02f1c4e4877379e84d27384982/pikepdf-10.13.0.post1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:99f6afccd6119233e7133bd4c2ade48461de3ddd4269cc28a4f90cdf7c1372f5", size = 3955964, upload-time = "2026-09-05T06:49:16.656Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/48/33/7fc9d6fcdbbcc419792eab6a4b1420bbe484b7c41d256a94582bb80ddade/pikepdf-10.13.0.post1-cp314-cp314t-win_amd64.whl", hash = "sha256:fb05fb7b42d85754219b55111aa61beff4e48da56069e971de1e5aca380c0ac1", size = 3532156, upload-time = "2026-09-05T06:49:18.742Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dc/01/001f65b68192f0228cc1dbbc8d2530ab5d58b61037ba0587f946fea607cd/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330", size = 4161736, upload-time = "2026-07-01T11:54:51.156Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1a/d2/0219746d0fd16fc8a84498e79452375be3797d3ce4044596ce565164b84f/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217", size = 4255435, upload-time = "2026-07-01T11:54:53.414Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5d/dc/8fdce34ec725a33c81c6ba122b904d6b9024e50ea9ac7bede62fab54506c/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139", size = 4162063, upload-time = "2026-07-01T11:55:37.941Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/76/66/2044b9a63d3b84ff048228dfcb7cd9bf0df983e8470971bf7d4c57b693de/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402", size = 4255549, upload-time = "2026-07-01T11:55:40.022Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
+]
+
+[[package]]
+name = "pillowlatex"
+version = "0.1.4"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "fonttools" },
+    { name = "pillow" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/9f/03870a4d413cce36874a43c6ff3df2a6d7ced2a648a51bcb2fa56dd21772/pillowlatex-0.1.4.tar.gz", hash = "sha256:2b4382bda10390e2637fe6235985790d6226f01c55edc351e4338a127edeff98", size = 815027, upload-time = "2025-09-24T03:28:39.108Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0b/b7/e15b317e7ca69cd60b4265610f20e06873baa80c28f0c19b2978990b4f00/pillowlatex-0.1.4-py3-none-any.whl", hash = "sha256:2f2aa65149e608ade31ead009de0110fb7124eb2341d92d3e43eb7d61e5aabd4", size = 812948, upload-time = "2025-09-24T03:28:37.43Z" },
+]
+
+[[package]]
+name = "pillowmd"
+version = "0.7.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "fonttools" },
+    { name = "httpx" },
+    { name = "pillow" },
+    { name = "pillowlatex" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/e8/869d3bf879e84c2e88d7e0f8a21ab31221cc0f29ff77b3e52cd2a2828d14/pillowmd-0.7.3.tar.gz", hash = "sha256:4be5c16768c5dad643b897784a097fd038059514cd5abdd005150e057559edd8", size = 19964046, upload-time = "2025-11-12T07:59:03.437Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/be/7860ebfdbbb32b9454814569c62b9f5cfc5a8ba88e415eea65840d6a9b45/pillowmd-0.7.3-py3-none-any.whl", hash = "sha256:13fe0200905f159919cdb05052e0e4d54b806db7c0e96a99e479ba8a3b6f6bfc", size = 20166326, upload-time = "2025-11-12T07:58:05.024Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.8"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/53/18/f3bb8ef0d3b930692343da8aa4d3cbcd6749477c053959395ac81965a6e9/platformdirs-4.11.8.tar.gz", hash = "sha256:f23abafea7dd4276d1f29104b83598d7dcc567cafd07c9c951e66665645437fc", size = 37182, upload-time = "2026-09-08T22:20:42.866Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f4/e1/5b7b8bbb55084d1425bcb9bc823ff519e1b2be05f6ebb0089e2eacc38413/platformdirs-4.11.8-py3-none-any.whl", hash = "sha256:52f2f181bbfde907966932cc8312d967d02976422d66d537ea16092b8e291081", size = 24027, upload-time = "2026-09-08T22:20:41.537Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "primp"
+version = "2.0.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bc/2d/ca248003402f6863375acc77a886b0ab638efc6defb1be0ae9f99249cb66/primp-2.0.0.tar.gz", hash = "sha256:714ec75081b7a84f63d83f966eb36649b9a8ba93625113b142400c317f6e83c5", size = 1152502, upload-time = "2026-08-26T15:48:08.043Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/64/15/571bae369c3bb3ba2c5917fde3e6fa6db212bcde033f6c2b99fd94434c01/primp-2.0.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5de7c1a2c3437394d77dca87841796a0cb704bf00e764dcbd2f7c073a11cc969", size = 5652784, upload-time = "2026-08-26T15:47:19.729Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/76/8d/c62601ab82b831e12b1dee9ad9e7de2082c33a8774c4e71a76c3f0f76af3/primp-2.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c55f8ab86b7cc076b34ee0316ded6c30e9932ea010aeae3f8fe5cf30d9ecccf7", size = 5253591, upload-time = "2026-08-26T15:47:21.681Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a7/f5/f29096e299afee742e4bf3e3aa0bba8bb10b187fa5ace15b8299a21d1310/primp-2.0.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd191d6f381eb814e1a7cb34b7eb5f47df81e73abdaecd8a99a8635a866357a3", size = 5663102, upload-time = "2026-08-26T15:47:23.305Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/ce/496162339faa9a3016557b332bc9b9c55b87b9e7efb87df64902d2e77236/primp-2.0.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d7c48b027246e09540ad645536d28966f618e09c6a4dff148db4c221ccf858d8", size = 5274167, upload-time = "2026-08-26T15:47:25.674Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d2/ce/fe272baed222c65ec5fad80346bd2a6155b170302ec69cbe5169b2df8c32/primp-2.0.0-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9179d4d7839cf0f912700d201af239b1a87ca22225101e2a43d1a34c2a46c95", size = 5615512, upload-time = "2026-08-26T15:47:27.359Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/0c/203318c90bd2edbf5f6c7cf20d0d4b0de237caf3b0bf19d6507d55ddeb3c/primp-2.0.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d46cea402c5c0e70d65c237d946d41b46ef1a550fe3053ad6b66a3776decb759", size = 5756508, upload-time = "2026-08-26T15:47:28.929Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/31/08/99c7e41d117ac3bed5b8814df9b295394420beb5a2249dad878927e64517/primp-2.0.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e8e16a3efc6a523da721fa56a7e4eab8ee62c36db910fb62782999398320d0a", size = 5914038, upload-time = "2026-08-26T15:47:30.597Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a8/d9/2e7e75ccc0af97aa0a1b8506151c07453c2c5a1ec1a571f8ba8670ac8881/primp-2.0.0-cp310-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:e8d9354b078b8dc891d2546bd8e9109aa81f1351609262707f4c7cd2db5a7876", size = 5987036, upload-time = "2026-08-26T15:47:32.371Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4a/91/b5feb484e792359a674c9435a5a109f4ef7775321951316556adde0501d4/primp-2.0.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:75960909d205a88e234d4e50fbd4c7c36d8235ef51b0c085da67bb171900cadd", size = 5825231, upload-time = "2026-08-26T15:47:33.885Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/df/19/1b876edc4814cc7a56cc8c4daa4ffe5989743a16f7a0b1947c928bdeed52/primp-2.0.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:5ccc2f3b333254d80a63f291b6d3e122a3eebe445833995b136ed1b5ae5c66e7", size = 5511105, upload-time = "2026-08-26T15:47:35.324Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/89/82/474b834cb241cc2a655b7f78588b438a5bf1e7fa6c9ccf93fd618a69b4a2/primp-2.0.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:2bd730ca8d86912924a3e4b775ad7befbe2115e26d0cf5b3c214d09dee80cfba", size = 5695984, upload-time = "2026-08-26T15:47:36.853Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ad/ba/75b8b2fcbea6ac2c8d073ef95337a9b363350c7d9d6a0de3aecc15e08895/primp-2.0.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:196896fa89c6b1eaa11331b14fe2cf539b9564b5e3398df8352c71ce30c46d84", size = 6173518, upload-time = "2026-08-26T15:47:38.725Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/34/8ce5c50363aa627b45f7fedcc38676ae9e71642839130bfff8620f5a193e/primp-2.0.0-cp310-abi3-win32.whl", hash = "sha256:0776fd400adcc940e47bb70896fb474f6607ffa545f5f7107ccda8d055fa02c9", size = 4820008, upload-time = "2026-08-26T15:47:40.289Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/97/92/2307030e0ade6503b7e959daf0b2e7819a896c32816a60a4252c97512e74/primp-2.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:7f205260fd41a0a409157deec95e6c4ec670476a79d9b4810d4c767ee7f9e49e", size = 5218051, upload-time = "2026-08-26T15:47:41.872Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/3b/d3f21f6fbfa5f255685dc475af5fa6ad976f4c3b787bc9bb75d912649c4d/primp-2.0.0-cp310-abi3-win_arm64.whl", hash = "sha256:caf90ecc042a12b18414e4110ce767f4f1b0cfbc70310c5df39af948cb3eb516", size = 5115469, upload-time = "2026-08-26T15:47:43.529Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/78/88/c7aa2c139282b417d447d05f441f7e70038fe6634b15673d1de230e7fba9/primp-2.0.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:2ef2652eb2fd0072e474452663ddc790531f337dafed280a62a43a36f95d2c76", size = 5654299, upload-time = "2026-08-26T15:47:45.186Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/fc/e470167fbd7fc0c9894e637edd49576398b4c6e09248cd1785edd42969b6/primp-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fdc9abaf01b82e0e4b5ea925273bf690c31338c3bb7bc28f64420bf93f66647b", size = 5243997, upload-time = "2026-08-26T15:47:46.927Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/38/70/45699bf87b0ad15822dcd4e6790eecac944dbcb72f3df9b7413513c22151/primp-2.0.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b88af1baeaa70fb168a9cd8567cf40396b4d023d39895b4bab25b3e7dc6ddb20", size = 5667842, upload-time = "2026-08-26T15:47:48.424Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/44/43/99c1adf495a0bc677fc7039efbbd28fb768a3e6a89735b5f2c0d5491688b/primp-2.0.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:db6a9efabcef034918e0ee92a78c21c2ccd93bdb994550c49f3c0edf207a0bc4", size = 5265143, upload-time = "2026-08-26T15:47:50.138Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2b/ed/515452269a2e47928b34300ea7043cf478be96133e87a7def2de7f52bdc7/primp-2.0.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e820ed0573d67b5d495252dcf29e6dba14c279453c5c2134955eb2b0fd3d258", size = 5603987, upload-time = "2026-08-26T15:47:51.712Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/96/15c9241d1848a9317be413201395e5e2b316be03ac8200fef7f300dd3f64/primp-2.0.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:819f1480be4efc1d0dca46fac7b9a3ec40fb0b89bc11932165b5abc7872dae00", size = 5760260, upload-time = "2026-08-26T15:47:53.296Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/30/758ab1b0e7a22ad5d738fdc04d0e01728ba266138453ce895fabc56fe1b5/primp-2.0.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c97a87afd27c490b5384433748bc664ecd358a8d0a688abf48716a6baf03050", size = 5921145, upload-time = "2026-08-26T15:47:54.752Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3d/8f/e46528c0829204eb01a9145301fb19c6953eb5cb48b2870e7c656ccde730/primp-2.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:ca4efea30417cf1119aac732ead82fc649af40978d0c989a9c280e901f6d0b3a", size = 5985385, upload-time = "2026-08-26T15:47:56.277Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ed/6e/6aa7c98636a6d9381784af830e5734908f3a78f0896591e50aa91eff5f2e/primp-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0ea78a7a2fc5d48a825fa73182911b956bcb58940297cbd60958963ec30375d4", size = 5831995, upload-time = "2026-08-26T15:47:58.011Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/79/68/161b26b1b6d1d6a9e21250a88f4791adb8bf3f05d5190a8bbb3e563bdbb5/primp-2.0.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0f309642cff4e9f966fb8f312bf19239df04c7698b1b4ae142285528d08c4ddd", size = 5503388, upload-time = "2026-08-26T15:47:59.52Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/52/35b48f1ecdcc9baa9b9f8bba0739c4b506995fd17e3776700752c11d4d6a/primp-2.0.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:422001e516110a3b2d44b106ac65d248c431fb98e1d6cad034e0a6ee8f1d6eb2", size = 5683792, upload-time = "2026-08-26T15:48:00.913Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c8/7c/13f8d3e4465e5cd5968c79c6cf951475c286bf7605e328b23378dd744c34/primp-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1abcdcd5d0ef7b918bdd6e56ce07baeba5b2fd136e9df1fe9f9443c35a6af9ec", size = 6182628, upload-time = "2026-08-26T15:48:02.281Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6b/f1/406105407cf42d7edbce6a9332a16303d05987efc76322e7b79ca5eab004/primp-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:8756ae0df3dda65591ef478e73c588588a4a07919ee5c8d871fdd4e78fefb357", size = 4811104, upload-time = "2026-08-26T15:48:03.688Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/05/34/3844343afe7154364be0767ff3fe03347aef5dc6a506522a4ac0c99fb720/primp-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a83bbfd798c1a9c2c7f1c8b02bbfb38f91fd63ac9072add967915e2463d68aa0", size = 5220594, upload-time = "2026-08-26T15:48:05.049Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4d/b5/a194a527120442f76a417e4da89bbe25490a65be7756c8f785ebd9110fd8/primp-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5dfad2f926451a64bcc3a6d84e76593ec82840f77c5500d080e98387c7a018b8", size = 5112361, upload-time = "2026-08-26T15:48:06.592Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/09/f049e45385503fe67db75a6b6186a7b9f0c3930366dc960522c312a825b1/propcache-0.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:099aaf4b4d1a02265b92a977edf00b5c4f63b3b17ac6de39b0d637c9cac0188a", size = 94457, upload-time = "2026-05-08T21:00:36.355Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6b/65/83d1d05655baf63113731bd5a1008435e14f8d1e5a06cbe4ec5b23ad7a31/propcache-0.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68ce1c44c7a813a7f71ea04315a8c7b330b63db99d059a797a4651bb6f69f117", size = 53835, upload-time = "2026-05-08T21:00:38.072Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/12/a6ba6482bb5ea3260c000c9b20881c95fa11c6b30173715668259f844ed7/propcache-0.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fc299c129490f55f254cd90be0deca4764e36e9a7c08b4aa588479a3bbed3098", size = 54545, upload-time = "2026-05-08T21:00:39.319Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/19/7fa086f5764c59ec8a8e157cd93aa8497acc00aba9dcdec56bfffb32602d/propcache-0.5.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6ae2198be502c10f09b2516e7b5d019816924bc3183a43ce792a7bd6625e6f4", size = 59886, upload-time = "2026-05-08T21:00:40.621Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/e4/5d7663dc8235956c8f5281698a3af1d351d8820341ddd890f59d9a9127f2/propcache-0.5.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6041d31504dc1779d700e1edcfb08eea334b357620b06681a4eabb57a74e574e", size = 63261, upload-time = "2026-05-08T21:00:41.775Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4a/4a/15a03adee24d6350da4292caeac44c34c033d2afe5e87eb370f38854560f/propcache-0.5.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7eabc04151c78a9f4d5bbb5f1faf571e4defeb4b585e0fe95b60ff2dbe4d3d7", size = 64184, upload-time = "2026-05-08T21:00:43.018Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/c6/979176efdaa3d239e36d503d5af63a0a773b36662ed8f52e5b6a6d9fd40e/propcache-0.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4db0ba63d693afd40d249bd93f842b5f144f8fcbb83de05660373bcf30517b1d", size = 61534, upload-time = "2026-05-08T21:00:44.507Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c8/22/63e8cd1bae4c2d2be6493b6b7d10566ddafad88137cfbc99964a1119853c/propcache-0.5.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dbcf7675229b35d31abb6547d8ebc8c27a830ac3f9a794edff6254873ec7c0a", size = 61500, upload-time = "2026-05-08T21:00:45.796Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/60/5a/28e5d9acbac1cc9ccb67045e8c1b943aa8d79fdf39c93bd73cacd68008ea/propcache-0.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d310c013aad2c72f1c3f2f8dd3279d460a858c551f97aeb8c63e4693cca7b4d2", size = 59994, upload-time = "2026-05-08T21:00:47.093Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/40/db650677f554a95b9c01a7c9d93d629e93a15562f5deb4573c9ee136fed2/propcache-0.5.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:06187263ddad280d05b4d8a8b3bb7d164cbebd469236544a42e6d9b28ac6a4fa", size = 56884, upload-time = "2026-05-08T21:00:48.376Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/45/70b39b89516ff8b96bf732fa6fded8cef20f293cb1508690101c3c07ec51/propcache-0.5.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3115559b8effafd63b142ea5ed53d63a16ea6469cbc63dce4ee194b42db5d853", size = 63464, upload-time = "2026-05-08T21:00:49.954Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f9/e2/fa59d3a89eac5534293124af4f1d0d0ada091ce4a0ab4610ce03fd2bdd8d/propcache-0.5.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c60462af8e6dc30c35407c7237ea908d777b22862bbee27bc4699c0d8bcdc45a", size = 61588, upload-time = "2026-05-08T21:00:51.281Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0b/97/efb547a55c4bc7381cfb202d6a2239ac621045277bc1ea5dfd3a7f0516c0/propcache-0.5.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40314bca9ac559716fe374094fc81c11dcc34b64fd6c585360f5775690505704", size = 64667, upload-time = "2026-05-08T21:00:52.602Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/92/56/f5c7d9b4b7595d5127da38974d791b2153f3d1eae6c674af3583ace92ad3/propcache-0.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cfa21e036ce1e1db2be04ba3b85d2df1bb1702fa01932d984c5464c665228ff4", size = 62463, upload-time = "2026-05-08T21:00:54.303Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bd/3b/484a3a65fc9f9f60c41dcd17b428bace5389544e2c680994534a20755066/propcache-0.5.2-cp313-cp313-win32.whl", hash = "sha256:f156a3529f38063b6dbaf356e15602a7f95f8055b1295a438433a6386f10463d", size = 38621, upload-time = "2026-05-08T21:00:55.808Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/fd/3f0f10dba4dabad3bf53102be007abf55481067952bde0fdddff439e7c61/propcache-0.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:dfed59d0a5aeb01e242e66ff0300bc4a265a7c05f612d30016f0b60b1017d757", size = 41649, upload-time = "2026-05-08T21:00:57.061Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/90/ec/6ce619cc32bb500a482f811f9cd509368b4e58e638d13f2c68f370d6b475/propcache-0.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:ba338430e87ceb9c8f0cf754de38a9860560261e56c00376debd628698a7364f", size = 37636, upload-time = "2026-05-08T21:00:58.646Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1b/82/c1d268bbbf2ef981c5bf0fbbe746db617c66e3bcefe431a1aa8943fbe23a/propcache-0.5.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a592f5f3da71c8691c788c13cb6734b6d17663d2e1cb8caddf0673d01ef8847d", size = 98872, upload-time = "2026-05-08T21:00:59.889Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f4/d4/52c871e73e864e6b34c0e2d58ac1ec5ccd149497ddc7ad2137ae98323a35/propcache-0.5.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6a997d0489e9668a384fcfd5061b857aa5361de73191cac204d04b889cfbbafa", size = 56257, upload-time = "2026-05-08T21:01:01.195Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/f0/9b90ca2a210b3d09bcfcd96ecd0f55545c091535abce2a45de2775cfd357/propcache-0.5.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:10734b5484ea113152ee25a91dccedf81631791805d2c9ccb054958e51842c94", size = 56696, upload-time = "2026-05-08T21:01:02.941Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/0e/6e9d4ba07c8e56e21ddec1e75f12148142b21ca83a51871babce095334f4/propcache-0.5.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cafca7e56c12bb02ae16d283742bef25a61122e9dab2b5b3f2ccbe589ce32164", size = 62378, upload-time = "2026-05-08T21:01:04.475Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/65/19/c10badaa463dde8a27ce884f8ee2ec37e6035b7c9f5ff0c8f74f06f08dac/propcache-0.5.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f064f8d2b59177878b7615df1735cd8fe3462ed6be8c7b217d17a276489c2b7f", size = 65283, upload-time = "2026-05-08T21:01:05.959Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b0/b6/93bea99ca80e19cef6512a8580e5b7857bbe09422d9daa7fd4ef5723306c/propcache-0.5.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f78abfa8dfc32376fd1aacf597b2f2fbbe0ea751419aee718af5d4f82537ef8c", size = 66616, upload-time = "2026-05-08T21:01:07.228Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/83/e4/5c7462e50625f051f37fb38b8224f7639f667184bbd34424ec83819bb1b7/propcache-0.5.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7467da8a9822bf1a55336f877340c5bcbd3c482afc43a99771169f74a26dedc", size = 63773, upload-time = "2026-05-08T21:01:08.514Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ca/b6/99238894047b13c823be25027e736626cd414a52a5e30d2c3347c2733529/propcache-0.5.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a6ddc6ac9e25de626c1f129c1b467d7ecd33ce2237d3fd0c4e429feef0a7ee1f", size = 63664, upload-time = "2026-05-08T21:01:09.874Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/1e/a3a1a63116a2b8edb415a8bb9a6f0c34bd03830b1e18e8ce2904e1dc1cf4/propcache-0.5.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2f22cbbac9e26a8e864c0985ff1268d5d939d53d9d9411a9824279097e03a2cb", size = 62643, upload-time = "2026-05-08T21:01:11.132Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e4/03/893cf147de2fc6543c5eaa07ad833170e7e2a2385725bbebe8c0503723bb/propcache-0.5.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:fc76378c62a0f04d0cd82fbb1a2cd2d7e28fcb40d5873f28a6c44e388aaa2751", size = 59595, upload-time = "2026-05-08T21:01:12.387Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/86/3b/04c1a2e12c57766568ba75ba72b3bf2042818d4c1425fab6fc07155c7cff/propcache-0.5.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:acd2c8edba48e31e58a363b8cf4e5c7db3b04b3f9e371f601df30d9b0d244836", size = 65711, upload-time = "2026-05-08T21:01:13.676Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/34/80f8d0099f8d6bacc4de1624c85672681c8cd1149ca2da0e38fd120b817f/propcache-0.5.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:452b5065457eb9991ec5eb38ff41d6cd4c991c9ac7c531c4d5849ae473a9a13f", size = 64247, upload-time = "2026-05-08T21:01:14.936Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/1a/8b08f3a5f1037e9e370c55883ceeeee0f6dd0416fb2d2d67b8bfc91f2a79/propcache-0.5.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:3430bb2bfe1331885c427745a751e774ee679fd4344f80b97bf879815fe8fa55", size = 67102, upload-time = "2026-05-08T21:01:16.281Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/34/68/8bdb7bb7756d76e005490649d10e4a8369e610c74d619f71e1aedf889e9c/propcache-0.5.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cef6cea3922890dd6c9654971001fa797b526c16ab5e1e46c05fd6f877be7568", size = 64964, upload-time = "2026-05-08T21:01:17.57Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0a/aa/50fb0b5d3968b61a510926ff8b8465f1d6e976b3ab74496d7a4b9fc42515/propcache-0.5.2-cp313-cp313t-win32.whl", hash = "sha256:72d61e16dd78228b58c5d47be830ff3da7e5f139abdf0aef9d86cde1c5cf2191", size = 42546, upload-time = "2026-05-08T21:01:18.946Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ae/4c/0ddbae64321bd4a95bcbfc19307238016b5b1fee645c84626c8d539e5b74/propcache-0.5.2-cp313-cp313t-win_amd64.whl", hash = "sha256:0958834041a0166d343b8d2cedcd8bcbaeb4fdbe0cf08320c5379f143c3be6e7", size = 46330, upload-time = "2026-05-08T21:01:20.162Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/00/d9/9cddc8efb78d8af264c5ec9f6d10b62f57c515feda8d321595f56010fb23/propcache-0.5.2-cp313-cp313t-win_arm64.whl", hash = "sha256:6de8bd93ddde9b992cf2b2e0d796d501a19026b5b9fd87356d7d0779531a8d96", size = 40521, upload-time = "2026-05-08T21:01:21.399Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e2/ea/23ee535d90ce8bcc465a3028eb3cc0ce3bd1005f4bb27710b30587de798d/propcache-0.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:46088abff4cba581dea21ae0467a480526cb25aa5f3c269e909f800328bc3999", size = 94662, upload-time = "2026-05-08T21:01:22.683Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fc88b26f08d634f7bc819a7852e5214f5802641ab8d9fd5326892292eee1993e", size = 53928, upload-time = "2026-05-08T21:01:23.986Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/63/b1/4260d67d6bd85e58a66b72d54ce15d5de789b6f3870cc6bedf8ff9667401/propcache-0.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97797ebb098e670a2f92dd66f32897e30d7615b14e7f59711de23e30a9072539", size = 54650, upload-time = "2026-05-08T21:01:25.305Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba57fffe4ac99c5d30076161b5866336d97600769bad35cc68f7774b15298a4e", size = 59912, upload-time = "2026-05-08T21:01:26.545Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4c/29/fe1aebec2ce57ab985a9c382bded1124431f85078113aa222c5d278430d4/propcache-0.5.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:583c19759d9eec1e5b69e2fbef36a7d9c326041be9746cb822d335c8cedc2979", size = 63300, upload-time = "2026-05-08T21:01:27.937Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b4/18/2334b26768b6c82be8c69e83671b767d5ef426aa09b0cba6c2ea47816774/propcache-0.5.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d0326e2e5e1f3163fa306c834e48e8d490e5fae607a097a40c0648109b47ba80", size = 64208, upload-time = "2026-05-08T21:01:29.484Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2b/76/7f1bfd6afff4c5e38e36a3c6d68eb5f4b7311ea80baf693db78d95b603c4/propcache-0.5.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e00820e192c8dbebcafb383ebbf99030895f09905e7a0eb2e0340a0bcc2bc825", size = 61633, upload-time = "2026-05-08T21:01:31.068Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c4/46/b3ff8aba2b4953a3e50de2cf72f1b5748b8eca93b15f3dc2c84339084c09/propcache-0.5.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c66afea89b1e43725731d2004732a046fe6fe955d51f952c3e95a7314a284a39", size = 61724, upload-time = "2026-05-08T21:01:32.374Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/01/814cfcafbcff954f94c01cf30e097ddc88a076b5440fbcf4570753437d40/propcache-0.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d4dc37dec6c6cdad0b57881a5658fd14fbf53e333b1a86cf86559f190e1d9ec4", size = 60069, upload-time = "2026-05-08T21:01:33.67Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/68/5c6f7622d510cc666a300687e06fd060c1a43361c0c9b20d284f06d8096a/propcache-0.5.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5570dbcc97571c15f68068e529c92715a12f8d54030e272d264b377e22bd17a5", size = 57099, upload-time = "2026-05-08T21:01:34.915Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/27/9cb0b4c679124085327957d42521c99dba04c88c90c3e55a6f0b633ebccc/propcache-0.5.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f814362777a9f841adddb200ecdf8f5cb1e5a3c4b7a86378edbd6ccb26edd702", size = 63391, upload-time = "2026-05-08T21:01:36.231Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/9d/7258aaa5bdf60fc6f27591eef6fe52768cb0beda7140be477c8b12c9794a/propcache-0.5.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:196913dea116aeb5a2ba95af4ddcb7ea85559ae07d8eee8751688310d09168c3", size = 61626, upload-time = "2026-05-08T21:01:37.545Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/0d/41c602003e8a9b16fe1e7eadf62c7bfba9d5474370b24200bf48b315f45f/propcache-0.5.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6e7b8719005dd1175be4ab1cd25e9b98659a5e0347331506ec6760d2773a7fb5", size = 64781, upload-time = "2026-05-08T21:01:38.83Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/f3/38e66b1856e9bd079deea015bc4a55f7767c0e4db2f7dcf69e7e680ba4ce/propcache-0.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:51f96d685ab16e88cab128cd37a52c5da540809c8b879fa047731bfcb4ad35a4", size = 62570, upload-time = "2026-05-08T21:01:40.415Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/95/ca/bbfe9b910ce57dde8bb4876b4520fc02a4e89497c10de26be936758a3aaa/propcache-0.5.2-cp314-cp314-win32.whl", hash = "sha256:cc6fc3cc62e8501d3ed62894425040d2728ecddb1ed072737a5c70bd537aa9f0", size = 39436, upload-time = "2026-05-08T21:01:41.654Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:81e3a30b0bb60caa22033dd0f8a3618d1d67356212514f62c57db75cb0ef410c", size = 42373, upload-time = "2026-05-08T21:01:43.041Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/44/68/9ea5103f41d5217d7d6ec24db90018e23aebec070c3f9a6e54d12b841fd8/propcache-0.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:0d2c9bf8528f135dbb805ce027567e09164f7efa51a2be07458a2c0420f292d0", size = 38554, upload-time = "2026-05-08T21:01:44.336Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8a/81/fadf555f42d3b762eea8a53950b0489fdc0aa9da5f8ed9e10ce0a4e01b48/propcache-0.5.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4bc8ff1feffc6a61c7002ffe84634c41b822e104990ae009f44a0834430070bb", size = 99395, upload-time = "2026-05-08T21:01:45.883Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f5/c9/c61e134a686949cf7971af3a390148b1156f7be81c73bc0cd12c873e2d48/propcache-0.5.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:79aa3ff0a9b566633b642fa9caf7e21ed1c13d6feca718187873f199e1514078", size = 56653, upload-time = "2026-05-08T21:01:47.307Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/73/daf935ea7048ddd7ec8eec5345b4a40b619d2d178b3c0a0900796bc3c794/propcache-0.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1b31822f4474c4036bae62de9402710051d431a606d6a0f907fec79935a071aa", size = 56914, upload-time = "2026-05-08T21:01:48.573Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/79/9f/aba959b435ea18617edd7cf0a7ad0b9c574b8fc7e3d2cd55fb59cb255d33/propcache-0.5.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fef48778b5a2a756523fdb781326b028ca75e32858b04f2cdd19f394564917", size = 62567, upload-time = "2026-05-08T21:01:49.903Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6c/a1/859942de9a791ff42f6141736f5b37749b8f53e65edfa49638c67dd67e6a/propcache-0.5.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8b73ab70f1a3351fbc71f663b3e645af6dd0329100c353081cf69c37433fc6fe", size = 65542, upload-time = "2026-05-08T21:01:51.204Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b5/61/315bc0fd6c0fc7f80a528b8afd209e5fc4a875ea79571b91b8f50f442907/propcache-0.5.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5538d2c13d93e4698af7e092b57bc7298fd35d1d58e656ae18f23ee0d0378e03", size = 66845, upload-time = "2026-05-08T21:01:52.539Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/47/f7/9f8122e3132e8e354ac41975ef8f1099be7d5a16bc7ae562734e993665c0/propcache-0.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd645f03898405cabe694fb8bc35241e3a9c332ec85627584fe3de201452b335", size = 63985, upload-time = "2026-05-08T21:01:53.847Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c8/54/c317819ec157cbf6f35df9df9657a6f82daf34d5faf15948b2f639c2192e/propcache-0.5.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a473b3440261e0c60706e732b2ed2f517857344fc21bf48fdfe211e2d98eb285", size = 63999, upload-time = "2026-05-08T21:01:55.179Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5a/56/387e3f7dfce0a9233df41fb888aa1c30222cb4bbbf09537c02dd9bd85fe2/propcache-0.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7afa37062e6650640e932e4cc9297d81f9f42d9944029cc386b8247dea4da837", size = 62779, upload-time = "2026-05-08T21:01:57.489Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/9c/596784cb5824ed61ee960d3f8655a3f0993e107c6e98ab6c818b7fb92ccb/propcache-0.5.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8a90efd5777e996e42d568db9ac740b944d691e565cbfd31b2f7832f9184b2b8", size = 59796, upload-time = "2026-05-08T21:01:58.736Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c2/3d/1a6cfa1726a48542c1e8784a0761421476a5b68e09b7f36bf95eb954aaba/propcache-0.5.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:f19bb891234d72535764d703bfed1153cc34f4214d5bd7150aee1eec9e8f4366", size = 66023, upload-time = "2026-05-08T21:02:00.228Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e4/0e/05fd6990369477076e4e280bcb970de760fddf0161a46e988bc95f7940ec/propcache-0.5.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:32775082acd2d807ee3db715c7770d38767b817870acfa08c29e057f3c4d5b56", size = 64448, upload-time = "2026-05-08T21:02:01.888Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cd/86/5f8da315a4309c62c10c0b2516b17492d5d3bbe1bb862b96604db67e2a37/propcache-0.5.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9282fb1a3bccd038da9f768b927b24a0c753e466c086b7c4f3c6982851eefb2d", size = 67329, upload-time = "2026-05-08T21:02:03.484Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/d3/3368efe79ab21f0cdf86ef49895811c9cc933131d4cde1f28a624e22e712/propcache-0.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc49723e2f60d6b32a0f0b08a3fd6d13203c07f1cd9566cfce0f12a917c967a2", size = 65172, upload-time = "2026-05-08T21:02:04.745Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/07/127e8b0bacfb325396196f9d976a22453049b89b9b2b08477cc3145faa44/propcache-0.5.2-cp314-cp314t-win32.whl", hash = "sha256:2d7aa89ebca5acc98cba9d1472d976e394782f587bad6661003602a619fd1821", size = 43813, upload-time = "2026-05-08T21:02:06.025Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.36.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/86/73/f66c748df06e7fe24e658eddd600d19c4b40bad836c97ce2d0ad9851fb6b/protobuf-7.36.1.tar.gz", hash = "sha256:d0f6470f0ce2b84e3feaea2d4b816378b37ba4d4aa08a274305373de93e2d524", size = 512499, upload-time = "2026-08-31T22:40:04.667Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/6c/3a54a58f2948b0f485df9ecdd06590f15d0a7abf46a89d50c3de709ff4ff/protobuf-7.36.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:3cf2ee25d006cee57294a1196ea43b37feb78e0dcd1e8af5c1aeddb777655aca", size = 456046, upload-time = "2026-08-31T22:39:56.865Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6e/08/9f9548793c771095245c0eeaf0c84b76b16a5ef26158043d456f551344a0/protobuf-7.36.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:43d3d37b1eb24c113b9b7d02008cac44e423f00b611b7781ae998d7623972969", size = 344226, upload-time = "2026-08-31T22:39:58.263Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fe/51/1bdbd612fa3c51e42ea6f45d05e84dc748ddcd2663e1aa1e89a00a33facd/protobuf-7.36.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:39c518c05586c016d7874ff6079ee115bcec1ea5fbb1d177fbf7867ef4c67e44", size = 357229, upload-time = "2026-08-31T22:39:59.198Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/df/c799fe7a05ef16ba853a59db01f3a2c5f7d0676469589ccc4874f76a2a88/protobuf-7.36.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:97198b77e369a0abd8e262b8f6c7266c55ddb796a3a12c76d7b8881188ed83aa", size = 343228, upload-time = "2026-08-31T22:40:00.179Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3d/33/d4724ec5d86d496fe4108e220618aa0837ad3423a7af7ccdd9684ccc77c8/protobuf-7.36.1-cp310-abi3-win32.whl", hash = "sha256:0b53ce95272aad50ad25d7ff03373743209822e8ba42ea7fad27d2bee1547d00", size = 443002, upload-time = "2026-08-31T22:40:01.32Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/db/37/155788a0d8daded960375af604202805308169f9b859419ea0aa370946e2/protobuf-7.36.1-cp310-abi3-win_amd64.whl", hash = "sha256:51139351435d9b43d88a55eaa49fb6f737fbb478fb0cbf2cf694d1a04a9d3363", size = 456518, upload-time = "2026-08-31T22:40:02.494Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/39/ca/c47f91d3cab175b01fd8c4f0d80fdf8613be876cc616e66ad281a59c5ddf/protobuf-7.36.1-py3-none-any.whl", hash = "sha256:7d951e46b3f963d6c264c367c437921de9d5aedd9c3f9612b9077736b4e3ad5c", size = 179813, upload-time = "2026-08-31T22:40:03.54Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.5"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750, upload-time = "2026-08-28T14:04:00.916Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589, upload-time = "2026-08-28T14:03:59.136Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.5"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262, upload-time = "2026-08-28T10:01:31.677Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f5/37/5abe39a8372a61d3dc3c1338fc504281c01b32fdb3169cd7187153b56d3e/pydantic_core-2.46.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:b7ca9034437b6022f941f4857459562ee00a560b97e7cce8a0ec5a74fc6766e0", size = 2075885, upload-time = "2026-08-28T09:58:47.856Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/21/43/6323b1f8b217780454c61304bcd2b38ae4762f50754414124603ccc90bb2/pydantic_core-2.46.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f332f0e72a5a0400141f830744e141bf9f97917878dbe968669e8a7fefea78ff", size = 1922768, upload-time = "2026-08-28T09:58:49.58Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0f/a3/c05ca796e1197618a774b01e596aeedfefc2f7d8c01ae3054e910b120e8a/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:193375f3548919d3f0b60936ca113ada3e38f264f91b9b8e0508efaad57be931", size = 1951241, upload-time = "2026-08-28T09:58:51.511Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/32/33bc39ac705c52cffc908e8389f9754fdb208aea5c69cceddf4eb3ce99af/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:79bdfa52f843137045b2d081cc05c120ba6665d29b7559c2c47690906f39279f", size = 2031975, upload-time = "2026-08-28T09:58:53.166Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b0/70/2333e885c0f6a67bc105c5916965dac9b57f2718ee20d81d1a06a4ebdc13/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:24922243639cbdac66c75fcb6fd6495a9cb52b213d62f9a0d16f0310b1ff8038", size = 2208542, upload-time = "2026-08-28T09:58:55.017Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/ea/296debfb4264207bbda5936133892e027c0a58875ad53ebd512fba8ec3a2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c76fe65e607be28c7fd4d56fc3c42b1583aa058ce3408b7ad0fd540171d31f9f", size = 2264692, upload-time = "2026-08-28T09:58:56.767Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/f2/9e4de77a6271e07a76d2d58b11c091a979c191ed2939bf80067568b369d2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f7b393a8b3da82f5c1fc0751e6d01ac6c55b93c18226a60bdfba4a724efafd1", size = 2066633, upload-time = "2026-08-28T09:58:58.531Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8d/db/f9e9d0c97445987b2084823d5c240de88087338f04fc2cfaa2df186b8049/pydantic_core-2.46.5-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:7ac031912d54f3d83ef3b3eb98dfabc1608802e2202263d25957eeed40b94761", size = 2105235, upload-time = "2026-08-28T09:59:00.421Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/07/c5/79169b047b3b2c3e99e04bc76372af9637e0bf6db638274fa927df96369e/pydantic_core-2.46.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:837b396ca3d7b74091ca623f6cbd8351bd42d670a79c2683e79fb089f06a2de5", size = 2157367, upload-time = "2026-08-28T09:59:02.442Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/26/b5/ba6057afb7c291bd449f51b867f95aef2072941c4ce4e5c31d6ffd132d3b/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5ee239d575f80b08eca11f6e20f90c4c695de7825c67eefe6091fbf20dda648e", size = 2158420, upload-time = "2026-08-28T09:59:04.2Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6e/28/2057abecaafdc22912afa819603a51f0a62d40643b7c4871c51721fea9be/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:e80675d75ae2cd14372cb65cad5400d9347a3d3f6c13000183f22dfd027283ed", size = 2309588, upload-time = "2026-08-28T09:59:06.048Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/71/9d/881156dc404e27479c4246128d73538464cab4a239bec61995e227644c30/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:9c4b71f10dd532fb7a5cbc8f58707779e64f03a258c2bf8bfbaecfcd9970b519", size = 2341866, upload-time = "2026-08-28T09:59:08.539Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5a/38/d66f443a259f84d13babdceae568e572b0ed26da17ca5d0a649ebb110a67/pydantic_core-2.46.5-cp313-cp313-win32.whl", hash = "sha256:97bf8de4d541598c94a59344eeb988a94c08ff76b5723c41f6567ec18c7892ea", size = 1938580, upload-time = "2026-08-28T09:59:10.402Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2c/1e/1d5371213f4cc9a7ed70c0bfcc7911de22311ee99a662a56077d7292d2ac/pydantic_core-2.46.5-cp313-cp313-win_amd64.whl", hash = "sha256:15f4a94963c95accac15b7b657bb177d3ad82bb90b0d0526d9a9b85079925db5", size = 2041980, upload-time = "2026-08-28T09:59:12.396Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5a/48/4222d90b1c67568bace4dec6dca6271449c66de3595d72b6d098f5fde597/pydantic_core-2.46.5-cp313-cp313-win_arm64.whl", hash = "sha256:d22a945598fb91236b4dd793a6e42e4f3dd7740bb5aace5ebd7d4c08d13bb575", size = 1997213, upload-time = "2026-08-28T09:59:14.245Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/8a/14596f2a8367da50cf7cbac48169ee5d9c8e11d486a3b527082384630c72/pydantic_core-2.46.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c1c43ad4339643d70ebb8124e1305a7dab423001eff58bb41a0f731adbc98355", size = 2074081, upload-time = "2026-08-28T09:59:16.141Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ae/d5/d8a4eb6d6c7f66b91dd37c576d76e9e60fba900caf5372c17bcf949febc2/pydantic_core-2.46.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a353f84de772f423b5ffb11d7ae352fbbef0f446f3c0b0af0f8236d7233606e", size = 1920497, upload-time = "2026-08-28T09:59:18.065Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/26/092079428f86e927e030b2c0ced87df69dbb1c875cdeaa67bf42ea2be746/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5086029a57366b8cf81b130a43908738095c270c21a8d7f0e8bdfdb89718e2f3", size = 1952130, upload-time = "2026-08-28T09:59:20.476Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/08/c3/8ec0e290a9ebaebd64047bf5fda94be835c6b1551b02437e4b76778fbcd7/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46c25dda9d092a06c08db76ffe0a197107904d0dfac653f7d5306bbcd6d6119c", size = 2026371, upload-time = "2026-08-28T09:59:22.227Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/01/72/4fd20ad520fb8da0157f95b27a7eb05a72790ef08138e7701ac972c342ea/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37ea7b83c935e5b0d68c9449b82651accf78a10828b2c02b2f2d9e9496446c21", size = 2202822, upload-time = "2026-08-28T09:59:24.277Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/31/b0/d16e0771206b29314f0d52198b720be21e8a99ab2bf11e3bc0d7c9cebdff/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e64e88d5585bea9ce95861079de72006c7fa6d3df4e3a3b65ba31eb979c15c9f", size = 2262756, upload-time = "2026-08-28T09:59:26.608Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2c/9b/59634b7ac631c63b2a37760eb6943af3e29573d6b59a4abc5e7f019d4cee/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d510bac3ee52247af28ed4bb18a1e799f040ac60fd2bf5ccd4c92f1fbe786f", size = 2068352, upload-time = "2026-08-28T09:59:29.044Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/08/7c/570abb1ad2155348dc754ea91be22e5aaa18eb6d69a6068f7c6f2679a6ed/pydantic_core-2.46.5-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:a2a5e1d0ff29adddc9f6d6821a66302e4493f8ca898b715b6b1182c2c201ea0a", size = 2104777, upload-time = "2026-08-28T09:59:30.95Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/25/5bf74adc65a1ac5b7be3f6cb0bcb5433615c1598a801c19d830d84c98ded/pydantic_core-2.46.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:03b9666e41e35d8909852ba191a0607520f81b74eaf12ccf8737005dbb313821", size = 2156312, upload-time = "2026-08-28T09:59:32.604Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/90/6a/2ef38830675e050121040618135564ed56b860b45433b02d9b4ebece46f3/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:a91c17edf6eea2402cb5457b4c89e99bc5ed1004aa34c4adf1d4258c1a5c22c2", size = 2150067, upload-time = "2026-08-28T09:59:34.453Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/90/ef/a7dbb03a14a64c2a4621f989c615ed9a892535a6cad938fc27079f919d80/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b49924c73a235e969511bf2aabdff3beebf9820931f646c80274d5d780010c47", size = 2304516, upload-time = "2026-08-28T09:59:36.194Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/f8/6bb4c4b80e8a6fde1904c64a51c62a1d04fcdfa3ea521a66b2ddefa1d885/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:2cbd9a5eff05e51c447c34dfa4632145b26b09120cf04bd0c871e44c1a5e1c9a", size = 2335223, upload-time = "2026-08-28T09:59:37.931Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2a/80/f46b8c681195190b2c1f1c7c0a81abce60663e987613e09ef64d433dd96b/pydantic_core-2.46.5-cp314-cp314-win32.whl", hash = "sha256:2d5d76654becf5efd62c9e51c3756c67b49498b0c9a40884934c40807adbd074", size = 1934827, upload-time = "2026-08-28T09:59:39.836Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/3c/60674207246bc0a4009d2391b7c7251c7159f279c8d2ab8aae8ef46f3dee/pydantic_core-2.46.5-cp314-cp314-win_amd64.whl", hash = "sha256:fa10ef4112775900e7a0661068635eb67b2ab824fbde764de6e0e21982a93db0", size = 2042648, upload-time = "2026-08-28T09:59:41.792Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/69/0c/117c562c7c1babdf44576b72a5e496906506c93690387ecfbca7c729ae2e/pydantic_core-2.46.5-cp314-cp314-win_arm64.whl", hash = "sha256:045ab3b6d308439e32b81cc173bba5b9018bc6ed896afd0c65b3b009b1699af5", size = 1989652, upload-time = "2026-08-28T09:59:43.702Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e8/66/9336ae58f9eb68c41d121894e52c4c89eccb07eb8f602a04ee9c3f37736a/pydantic_core-2.46.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8816f3d218beb4b787de5c9759c259b8fa61f9dec42dc7811f320a33771778b7", size = 2065829, upload-time = "2026-08-28T09:59:45.364Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/02/bc19b47a96c2d3109760711acf22369e56bd7e405ca52f7ade164d2ead57/pydantic_core-2.46.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bce57638e08ac148e5778cce7feb968307a727d66f8e2274a543d0cf0c9ad6a3", size = 1905716, upload-time = "2026-08-28T09:59:47.18Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/a4/70b47c0509923dd98ccfed04fb3e32ea3849c82a0ff2205bb41009b43c00/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:976e1128455aa595ea04c79ccfedff1aaeab96ee013fcc916bed120c4f0ad94f", size = 1934216, upload-time = "2026-08-28T09:59:49.241Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/ab/aa03b65f7bb198585edf806b906c3223ecf1795543e39e23aec4cce27ad2/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b891faeedeafba41b2983e5001a81b6a915b69544c7e7570d1989ce1c36ac7", size = 2010635, upload-time = "2026-08-28T09:59:51.692Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3c/8b/0da06343f30b84ec549aafd309c6456223d5dc8bd36af504c573faad561d/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f194189415698233dd1114a093a9b56e61e2c57e11b469be3b0506f46f0771c", size = 2209369, upload-time = "2026-08-28T09:59:53.582Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/5b/844c4defaa34a3df66eb9257087d121d70c201298b96abdf9f492fc2f1bf/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82a36973cf8a2ef5406f4fe2edbf8ed0c99629535d959e0b100c76a32535a111", size = 2253238, upload-time = "2026-08-28T09:59:55.484Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f4/64/a4e536cb16d7f61a7fd3120b46c577fc7fa7325992f69c4f52bc786d77d8/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdbb78909f52b981d3b2d56b97328d71eb0b974c36bd77c920123a7ebb192829", size = 2065740, upload-time = "2026-08-28T09:59:58.038Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5f/75/aaa38c6bc2d085f6605b34eabdc6a8a4e0b2e61fc9c8e6e52b28e97b3125/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:52e24eacdb536cade636aa90fb851835222becff8484b7001fdc78cb0290f2aa", size = 2087425, upload-time = "2026-08-28T09:59:59.898Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/ae/fcab4cfc39aba3689e1d20c8b5250ad280957022c09af2ed9cd585602a5e/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:37ae34309d7bd8c0d61ab839668058f2a7962ea1fc51d105d2db228fe0618034", size = 2139306, upload-time = "2026-08-28T10:00:03.057Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/f4/f1d03a4bc9d9acbc62f4d742b8a319af52f71885079868b2ff8e48a651ee/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:0cdbada856a1c69a7624a64d3d9aefe79300bd6ef827b43a4f265010b9b55184", size = 2144589, upload-time = "2026-08-28T10:00:05.645Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/83/f3/7a53bb1356de514a4cd295f25b6ac39237895620c0462d2592b76c16e114/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:545f26c504b27c3758439a5e6d9349931f0a04f855668d5fe323c89e82300a38", size = 2288882, upload-time = "2026-08-28T10:00:07.931Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cd/94/5a81583660c175c59d49ffb09f4b3a44debeaf86a19fca664ae1cdd9ee32/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:ff218293c9c806138dca139765e3b067621be52bcd93cdc14c7711be7ddc90a9", size = 2335210, upload-time = "2026-08-28T10:00:10.177Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5a/9f/5d685c2693b972d1a59c998586e8823712b66603aeff47ee60a4bdaafd37/pydantic_core-2.46.5-cp314-cp314t-win32.whl", hash = "sha256:97cf3eb53a8cccacf9d46686a0926186c9bfb5574f2ed66d3639d5fe117cd3a9", size = 1921180, upload-time = "2026-08-28T10:00:12.35Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/70/12/5c94ee16d65a37a15f9e869f5e6256df111154491173801a4c5e800ab548/pydantic_core-2.46.5-cp314-cp314t-win_amd64.whl", hash = "sha256:d2f9fc07a8042a8f95925b35c4f04f469707c981fc33245b6ca187cf5d2dd290", size = 2020515, upload-time = "2026-08-28T10:00:14.774Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/63/19/67830dda664e6bdf9285ee2e40f355d0d7d6b92aa0c42e8d217bb8d33d36/pydantic_core-2.46.5-cp314-cp314t-win_arm64.whl", hash = "sha256:acf8a67ba51f4ca9ddbd0e6b3000a65ac51ab734661778b3e7ba64d99a710f2f", size = 1989276, upload-time = "2026-08-28T10:00:16.984Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pyinstaller"
+version = "6.22.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cc/2b/836d9def811c02522e0921d8b8cdf0c16b0545a216e97e71041758057859/pyinstaller-6.22.2.tar.gz", hash = "sha256:89b65a3ad07d9dd5832253e37bc45f31872d10d7f9d5c9fd0fdd6088a83829dd", size = 4092631, upload-time = "2026-08-17T20:53:22.231Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/57/39/08cd53632276de70426e7c273820277a48253fee397b4048301ec03c3566/pyinstaller-6.22.2-py3-none-macosx_10_13_universal2.whl", hash = "sha256:ebd1b1ca932d7cf25d7366ce691aaf79a5ff9425811ed7328b5116e4471b6d6d", size = 1062734, upload-time = "2026-08-17T20:52:17.635Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/74/22/2d865896782cbb41e2388c7314207c17a98acdcc1b8e5eef668873505c9f/pyinstaller-6.22.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:f5ccb847451df4207bce18bf53a57b124c9bb4e7e4bad08c5ecc627bcf00b28c", size = 755697, upload-time = "2026-08-17T20:52:21.676Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/91/2b/6c11e4d5a76e716ea68da1946ab706a4bdf6d8e68b0e1dea314366d046a0/pyinstaller-6.22.2-py3-none-manylinux2014_i686.whl", hash = "sha256:becb47ad78272bede87acf2ed830d7545a8f65ab11d06a68fe2b99ba1afaac6d", size = 768870, upload-time = "2026-08-17T20:52:25.511Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cf/e2/dbfea6a58b68acf644f7193b11d570476d6ffaed57381b6d1dd9e898a971/pyinstaller-6.22.2-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:06d7b3827a8049db4a2d47e3ec4ae2f69a1041577d8833b8f169745cde573ab4", size = 767445, upload-time = "2026-08-17T20:52:29.629Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/db/f24a21af2f87ce1df4e07fdad95eec65ef9f284267a7c1e5eeea40f49aa4/pyinstaller-6.22.2-py3-none-manylinux2014_s390x.whl", hash = "sha256:7bee432404eca5dc3ef37c36811c266561b03988f6d3e70ab0fa5352dd5de9e4", size = 762113, upload-time = "2026-08-17T20:52:34.025Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2b/07/b304ff3f5f8333778065e3658b604b0e108cd934b920f3fbab825a0dd5b7/pyinstaller-6.22.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9622686ecc5d5fa492fe6cde29d47df9dd41138cff8177be9f901ca3260f2096", size = 762173, upload-time = "2026-08-17T20:52:38.477Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6c/9b/0af69d93dfad2e3d590a5de5828d5bcd903747c0224bd9560ab476904dfe/pyinstaller-6.22.2-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:0260eaad6be3f6fbc1affffe6dc7b8e5b636dbca51b463224daba971610b6fc1", size = 761674, upload-time = "2026-08-17T20:52:42.646Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/4e/28b6094dcbd1e1bbb868daf4f8752999a20c1020ab64569232be42af2be8/pyinstaller-6.22.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:8c2c4b14caad38c1f3df8e9bf5276fc265e27fe8b4180cab4a37864288427bc0", size = 761053, upload-time = "2026-08-17T20:52:46.594Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ba/2c/f91b63fd01422111ac04e3b9bf61c039da5a3292acb4fe5248905f0be688/pyinstaller-6.22.2-py3-none-win32.whl", hash = "sha256:9a078877caa3920558a3242d0a7019fe5b825cff4b65ed380c7d1e1bd200ddd9", size = 1344474, upload-time = "2026-08-17T20:52:53.108Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3f/53/8ba1d0f6159b490f700eac6161a4be5f0d4672608a6dae9fd73679f183ee/pyinstaller-6.22.2-py3-none-win_amd64.whl", hash = "sha256:9b990fa6bbe143572f06644a984ad0d7aa2e2ccc6929d4916031343a5888e9a7", size = 1405725, upload-time = "2026-08-17T20:52:59.667Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/1b/9a3062cc34c939f694d4262c4754681f6ffe853c21c124209ad2d08b8e84/pyinstaller-6.22.2-py3-none-win_arm64.whl", hash = "sha256:afb6f9a95d19b6dcd3a7decc40d9adb6ba9c4f8802ddd6c972dfb552953f384e", size = 1353806, upload-time = "2026-08-17T20:53:06.222Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.7"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/26/60/d881fa1ba8c160c18d8e6f782bb16ec4640c08bc08fc50f704c368ad4f9e/pyinstaller_hooks_contrib-2026.7.tar.gz", hash = "sha256:5fbcaacb22c4f4aac869a127dce283f67a4b4cfcc37d496f2446603e6d68aefa", size = 175992, upload-time = "2026-08-24T21:26:58.713Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0a/67/350377af7b50416344ab8792756d414eef7629c618a73e9a0b13bb1552d9/pyinstaller_hooks_contrib-2026.7-py3-none-any.whl", hash = "sha256:24257a04c7a5a7a034cf28e39dcee20fbeeb9f043076729480f2e1b69904408a", size = 459445, upload-time = "2026-08-24T21:26:57.274Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.18.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c2/c3/9fa0666f280552bd3833562d985b785fce1ddb3804937edd2fd6a3f2bdb3/pypdf-6.18.0.tar.gz", hash = "sha256:ae58b7d93c22c169ffb02c3b06321c45c4f223b4916536568adb57d789d95d01", size = 7024871, upload-time = "2026-09-07T16:48:16.444Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c7/a5/d5922a078c9a612327681d4793404f82998f4d66213add6fdc0659245856/pypdf-6.18.0-py3-none-any.whl", hash = "sha256:05b762b77bcb9dcb4a7c91fcf5dded585b25bee7269ab3d3001d7c55fa1b324b", size = 393848, upload-time = "2026-09-07T16:48:14.254Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
+]
+
+[[package]]
+name = "python-lsp-jsonrpc"
+version = "1.1.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "ujson" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/48/b6/fd92e2ea4635d88966bb42c20198df1a981340f07843b5e3c6694ba3557b/python-lsp-jsonrpc-1.1.2.tar.gz", hash = "sha256:4688e453eef55cd952bff762c705cedefa12055c0aec17a06f595bcc002cc912" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/d9/656659d5b5d5f402b2b174cd0ba9bc827e07ce3c0bf88da65424baf64af8/python_lsp_jsonrpc-1.1.2-py3-none-any.whl", hash = "sha256:7339c2e9630ae98903fdaea1ace8c47fba0484983794d6aafd0bd8989be2b03c" },
+]
+
+[[package]]
+name = "python-lsp-server"
+version = "1.15.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "black" },
+    { name = "docstring-to-markdown" },
+    { name = "jedi" },
+    { name = "pluggy" },
+    { name = "python-lsp-jsonrpc" },
+    { name = "ujson" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e6/63/7d6af072a5b77a0d1f61306b7a72a7a2bc3f29ec0f8a8c85eb23f5ba7716/python_lsp_server-1.15.0.tar.gz", hash = "sha256:85fa090262c3d1aef09b759d98811d6cb9ad5bbc58af15d588608ae8c1925801", size = 123773, upload-time = "2026-07-27T18:26:30.953Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c2/4a/b4abc04dcc65c985fa66d6486393ad3051ff485ccabd9727aea43a242f88/python_lsp_server-1.15.0-py3-none-any.whl", hash = "sha256:d6ac11b467021310498f2dffb2edf09629bbcfe0d3073156db2337334a60463f", size = 77445, upload-time = "2026-07-27T18:26:29.53Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.3.post1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/48/fb042503b6ca6cd271261dc559fd6432f7d8c713153e9ec5c591af4dfc1c/pytz-2026.3.post1.tar.gz", hash = "sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d", size = 319745, upload-time = "2026-07-25T15:12:07.385Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl", hash = "sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815", size = 508283, upload-time = "2026-07-25T15:12:05.782Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "readability-lxml"
+version = "0.9"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "cssselect" },
+    { name = "lxml", extra = ["html-clean"] },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/fb/e7c40afabd660f121fca9f0993e39dc042974c80a6c04ec4b27d7fbd7323/readability_lxml-0.9.tar.gz", hash = "sha256:f7a5f88ee194ed6c5aa36d14593fbfb20c5d7bb8f3f5bc57734288d45a5abe26", size = 25187, upload-time = "2026-08-27T19:29:59.964Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/2c/0555d2c8d6c99152258d888f709ec1d46d64ae928a16313f760a2b264c41/readability_lxml-0.9-py3-none-any.whl", hash = "sha256:f43cf9ee74a15996581ae9ba1968d224d54344f6d134738bd0a5d5ea4b3ef55f", size = 26463, upload-time = "2026-08-27T19:29:58.692Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.9.10"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b9/5c/f403115361de25809e8f785686ec7096e30fef73be9ae35aa51da4e80abb/regex-2026.9.10.tar.gz", hash = "sha256:1e321e2c84f0e52c457f5ea5944f796d6e8e09cb99738ea98dcc1bfe402a128d", size = 417072, upload-time = "2026-09-09T21:00:21.521Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/20/90/d4452bf1ef7dbe406980e8b921a257024482203c1dafac535eae207611bc/regex-2026.9.10-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ef5a059ea1c6ee5d1c7e99a2484e628608d010921efe876c6f0e2029d2f35eca", size = 496408, upload-time = "2026-09-09T20:57:36.757Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6a/35/c763c6424a0f99d021d46dc1f9065147bb5a40c2b2cdf28d2ebdbcd96508/regex-2026.9.10-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:dce932f8e3ba936475ea3d0d8b59f7b050a9e206e994f53f8fd80299871e87da", size = 296931, upload-time = "2026-09-09T20:57:38.811Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fa/68/241f88458b17c46ed2f80147a60a03b2ada7fb815c23b6bc76c298abb0a5/regex-2026.9.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d8c668af8f7bdb1d18739c27d30cd9f4b371495a883f75a002fb7a39d740fecd", size = 291741, upload-time = "2026-09-09T20:57:40.482Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/90/9e/974d6de404c63e2d09525f4ddb99874c7ab8e1f781ccbe0dd3e26fa6f6e5/regex-2026.9.10-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aebdd9a946de328b3f6f61dbf48dd064a36eb6dddf96e34ae6651d37f6e9383", size = 800088, upload-time = "2026-09-09T20:57:42.098Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/fd/3875b73f9e7ba3321dcaa02c19f650c05c61345328acf84599ac6f45ceed/regex-2026.9.10-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f2374c27deb189b282ec7e16106752c22ad39b056bbd8018960b1e4cc95d67a1", size = 871212, upload-time = "2026-09-09T20:57:44.03Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/f5/2358e791c0e171194dd6a8b97b520579098a21397fb79dbe6b7edc9e3fa7/regex-2026.9.10-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e0dc78251154b66dc60211563fc115345da332eaa881e4e2523fb1edae3772f4", size = 919752, upload-time = "2026-09-09T20:57:45.691Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/20/3b/000c79c3f9c06b7542225a5d3a7f9a85405da7224b3b9af94a491d07abea/regex-2026.9.10-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bafa41b0dd63669e5c0f8adf3d24819efeb73c847f492eb011212eb352e69041", size = 804578, upload-time = "2026-09-09T20:57:47.548Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/6d/195eedb1de87f26639191e7487e41eb81e2ce255bc7563a64f3f5a95eb08/regex-2026.9.10-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ebb2ba68e4641a994061f70bf44ed448fba0b9b1d18c94ffb9efc1cca805b39b", size = 777345, upload-time = "2026-09-09T20:57:49.63Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/79/11/11fe2b313fcd92cb75c583648f2746031b9f4da9e9ed4241204a5e8b3721/regex-2026.9.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:048a89ee797db10160bd2bd519286577a6b43a100279bd4b7d8456a3d69c80a0", size = 790556, upload-time = "2026-09-09T20:57:51.27Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7a/c0/07ec9b4c43b0e16d62454971a5ab3886eccb0bfa161300a02d801ab28620/regex-2026.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:79e9432995e14c749d34209413de5e621ec8e67789bf4f46dbfabea9d06a2406", size = 865572, upload-time = "2026-09-09T20:57:53.163Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/19/07/43bc9a9cf9fc8e37d2ba47980dfe4a6e151d2cf3ab969e0031e2a9b21484/regex-2026.9.10-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5847e22bbf959764d776937d791d034cc2d19b787e361c88d97e859e8dc68502", size = 767971, upload-time = "2026-09-09T20:57:54.805Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9c/49/3b9286a3a94f3c89ed4ddbe74e72bdde21c1a5eadd520d5f4ed4a61936cb/regex-2026.9.10-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c103b3b14e011774af4fb7e4617ad4d72b9171905cd3b231a70a4efd76e477d7", size = 858835, upload-time = "2026-09-09T20:57:56.627Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4a/9e/e5d27ce9fee8e3ef95f886c7b6ecec211efa4cfc18bd73bd5cf26cca4741/regex-2026.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6b34a778c695d24e77c140e3b4c95da69282e34f2f6b02b55656aa4a0379f643", size = 791793, upload-time = "2026-09-09T20:57:58.313Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/63/03/c28a6bebedc3e2d86ee27ec2de16f7ec0419dcd10e771d43dcc9c58a2e99/regex-2026.9.10-cp313-cp313-win32.whl", hash = "sha256:7abb38b8c40f3a235235a44da452c64b7b5c1d650ec6351027db0e090804f2e5", size = 267298, upload-time = "2026-09-09T20:58:00.009Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cd/fd/5c85fa6cfb8e034080bda5a72fa0a4df2b7777a35eb7e73c2799c2adda7a/regex-2026.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:20e8bfb07ad79a282f8b95b56fe67f9750b1b7f775724e4ba1f23cb296115ce4", size = 277894, upload-time = "2026-09-09T20:58:01.731Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c1/28/f5a25f6f65501675977fda35d9f61abb1468c4b87c0f73e536d8b21a60b8/regex-2026.9.10-cp313-cp313-win_arm64.whl", hash = "sha256:3bdeed3318a8eb2bbadc9c56347e0ff651639e934a47e168d05a3b12929fd0e7", size = 277436, upload-time = "2026-09-09T20:58:03.422Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5c/ed/98e9b07d8bb9c765d07774f0b2c19b301b96d51f44630fea48951051c94e/regex-2026.9.10-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd6bd89b9fc06018d35851cab0240adb7dd84d51941b19f6574ac90cd54e3ae5", size = 496662, upload-time = "2026-09-09T20:58:05.118Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/a8/9dfe9be48378b47c5a8f04b0f200ea225f9ee0f8e93f010433f661a37878/regex-2026.9.10-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ef4c0a9dfdc90581b90b1b95a8c3d1557f8ff8f5a2a53536d26314de699d1468", size = 297115, upload-time = "2026-09-09T20:58:06.822Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2b/e4/5d1f005a3825ec49842ad349061c1c26e6d42f47ccf105e6e5aa6aeed392/regex-2026.9.10-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:14caa05ce39ec70437af5aac8814c50ee6628f4a90353871c059692f448a164f", size = 291896, upload-time = "2026-09-09T20:58:08.675Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/be/15/44ce83fca50c6058f42b62fa8300a8030eea7e4e5a973a2dd33db0f557fb/regex-2026.9.10-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3264132d576847ab5f88bb83e7debe67854bf165b3ea613bd467312b6099536a", size = 800534, upload-time = "2026-09-09T20:58:10.339Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/af/6e/a62e070a5a033643b287489576f02ae6a9c584c337d62349e340a2b4d001/regex-2026.9.10-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5cef9f3d14796500ea834c41dbe688f1f6b23c7024dc23e8a794d7ebaf5d71d0", size = 872038, upload-time = "2026-09-09T20:58:12.186Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/06/8b8e2483949b1329df10c5b615e85d332066deb426b11332b799629b9201/regex-2026.9.10-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d278ad30ec83b6b9202685b0f80b741a51ea3ca7f0595ebda96e7628b6398876", size = 918927, upload-time = "2026-09-09T20:58:13.903Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bb/64/9b56f69100d3afdbc9c4fa6e302764f9cb717fbc06a9d50558d98ca89cd2/regex-2026.9.10-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb018cfe7144585fc83882405906ff84994a2d154afc2509ecc7752c51f864", size = 803694, upload-time = "2026-09-09T20:58:15.949Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/07/43/d00d59a7c8fd0e070ae8457a8743597f45ad9682b100f57b9c9c405fbdfd/regex-2026.9.10-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6fd555fc9abef50c530869690b2daca054c8811a7aff632d11f9a7b2590b2742", size = 777770, upload-time = "2026-09-09T20:58:17.628Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/46/6b/a11d0446484efbc9eb67abec133f254c6d66a1568b8f3fb36d39a73a1129/regex-2026.9.10-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8d5c4518235a2ec1611e57af85fa488d529c1106aacff12adadcedf8687012cd", size = 791234, upload-time = "2026-09-09T20:58:19.476Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/12/09/bcd24e78b373fd4f98090caa43eade439223f6703b909be79b9efd9ab0ab/regex-2026.9.10-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:175cf49ce7a994c88b8f15e3cb17cdb66a48ebb2d36de736b8205033db950f89", size = 866259, upload-time = "2026-09-09T20:58:21.683Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/c6/c57ba5e94222a813260af4c17ced92d40cdb44737eb6b50979688310b6a3/regex-2026.9.10-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b71649169a9fcf30b395ee01047fa7ad6654a4c900ca75b23c04dedcce6a1f8c", size = 768219, upload-time = "2026-09-09T20:58:23.842Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7b/a2/3820037587d00901ace96c5864335c2cd1b899d5263ea0dd2261359e0bee/regex-2026.9.10-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:8ba1f78bd4fef2d8f84b894ec28ac3481afe6cc07aaa253ad4717ef7b3fe6bcb", size = 858582, upload-time = "2026-09-09T20:58:25.607Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/47/f0/f9a838ca6219ae4821de0175e4548db73ef56de5ec08d032fb427732fa07/regex-2026.9.10-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:217e98ba5fc8908ed8ffd4ebac04753a0c831067cbfb495b9821b94cc61eaa76", size = 791405, upload-time = "2026-09-09T20:58:27.406Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/bf/67d71cc4e13ae2e0022d21243ca069e0868701a99eb29cdecd13d356e694/regex-2026.9.10-cp314-cp314-win32.whl", hash = "sha256:b298cdc33c5cc6969ff07f0fba19cc73e0fd8576373c50935feadaca2f6b4405", size = 272702, upload-time = "2026-09-09T20:58:29.116Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c1/38/40a93e72703a741235115ed1b1e5f6b869917677b7643005034ce1611d70/regex-2026.9.10-cp314-cp314-win_amd64.whl", hash = "sha256:c32818b28bcd153b25b63038348a9fe9b9fbcddb60df43f204c3ab55eeb57f77", size = 281170, upload-time = "2026-09-09T20:58:30.899Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bf/ac/e95387f00617c16bb41b786d900bacd17eab88afa81b4f263df532b3a731/regex-2026.9.10-cp314-cp314-win_arm64.whl", hash = "sha256:75242f44a3e283106077be4ab717bc535e4701c9d54ad69e195945c22f137a1d", size = 281511, upload-time = "2026-09-09T20:58:32.594Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/39/e5/a4b12262edc488a8a7a95b672db317dd8aa9bf2fab98297f9c91bb11ad4d/regex-2026.9.10-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2dd9286093c71afc8f55ef035c5b9d2776641fd72c6535f1febc92d0b0be9666", size = 501128, upload-time = "2026-09-09T20:58:34.306Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/c8/9ca31c0fa5197ded8614c8ae0e105bcff2d979025ffa3c75580baa334e2f/regex-2026.9.10-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:71879292c9c7ac67b1680345b16daba1be937cb027362cfa04e68f65db2dcfdd", size = 299428, upload-time = "2026-09-09T20:58:36.296Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2b/d1/ee7662561735f90475443c3ca1977e5cecaeaa8f29620dec75580aebc839/regex-2026.9.10-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5ccd139b2061132e7b265cfb4b4721baeb9f8928b81415304abf1ec7e3181c26", size = 294494, upload-time = "2026-09-09T20:58:37.964Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d9/b1/333168e45ed6cfe71f6d17e21e5f54725f44d171f84edd12469a2f739227/regex-2026.9.10-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7327795089ddb44912dce1434e1d7244be2e9fb48fcc2d6782936af7a3062db", size = 814925, upload-time = "2026-09-09T20:58:40.438Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bc/a5/df1b38536d0a3b24a030eb4130ce98b403cc925220ff530f5313a7c436eb/regex-2026.9.10-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ff4d7b14ea19e50c8d9d6d83f45bd9b45cbb624c07ac1fa54db0a019049abed7", size = 873323, upload-time = "2026-09-09T20:58:42.349Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/93/ea/aa71fe62dd63a8336bbdec1ff002a6c53b40ccfca95961c18ee4f09bf03c/regex-2026.9.10-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4f0407474ffac8e5e89d93ca41d60891e29f0ab8423eb66ff292d850a86a0843", size = 923080, upload-time = "2026-09-09T20:58:44.488Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/86/38/49f8d6fd34fc1a9c75b5b96364ebdde702a8144e5ed63d2213c58d454c27/regex-2026.9.10-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ad10a135fa0b4e4a462a61d07c6654d7518cfdb5cb8da08f9ff7d61384af1fe", size = 821284, upload-time = "2026-09-09T20:58:46.56Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/32/45/91a977c96d4be13d1ade8208c260c26841c836d4c91745e1828a30589070/regex-2026.9.10-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9fbd2e5d8002dc49a6129fb321ec51c57a025e752ed525ddce0ba9223c4350a7", size = 789256, upload-time = "2026-09-09T20:58:48.473Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/79/4d110bf01bf9651bf9b3f88a6d9fa7e643e0586921a18432b25a478edbfa/regex-2026.9.10-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4a761ea45f2ad74c575ef5850ea514cef97302a552d3c7c9d1a1a870d4661d6c", size = 803722, upload-time = "2026-09-09T20:58:50.286Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e7/67/b587a0d3bbac2635309ed9c40c197120c39e1ec0afb8813cbed1338fdd75/regex-2026.9.10-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:75aa39d3f4f1650eea84e46b0d8cefe77dd5478c10e3d0aaf0b0f00493475a7a", size = 870085, upload-time = "2026-09-09T20:58:52.224Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/07/fc/0827bca20ddba1d70fa5111a2a64e6b6b38bfdab43fc435022b54172a111/regex-2026.9.10-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f5c629df03adec31ee505dda3c8988f106c9390e4cbd343600036eb8b3d6724f", size = 776970, upload-time = "2026-09-09T20:58:54.478Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9b/03/ab9d08d30568ca868791bfb99551db60b947f05e2e65dcd1261e87083c21/regex-2026.9.10-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3a66e40a1a20de96a2fee00ed67e11012b62d85b277688258677fd19997addb7", size = 863611, upload-time = "2026-09-09T20:58:56.432Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/6d/8063ae86b543ae878a7d6e7ba21ebf0af4af06161230e0012e2d652320c6/regex-2026.9.10-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:968c1e33edd9a104d1bf24c8d476c72de7e3839ae7f894b37e9e4f4739fdeeca", size = 804064, upload-time = "2026-09-09T20:58:59.066Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/63/b19305c4b8d3d7867699f7d83c43550273d91a2f31793452d87edb1d259f/regex-2026.9.10-cp314-cp314t-win32.whl", hash = "sha256:fbc4e2f3cb7ce8436154e6483079e7d35eeb321a952fa936e180300630d8b873", size = 274607, upload-time = "2026-09-09T20:59:00.942Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/32/b8/1695072a512a49060294024e23b945eeb87675b02c06e53a92a1b42b0bfd/regex-2026.9.10-cp314-cp314t-win_amd64.whl", hash = "sha256:c37fa93bf18bf4f90b01c0fa9f11ea567ee4b7dd8bf96e63663e5edc37aa38cf", size = 283944, upload-time = "2026-09-09T20:59:02.876Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/9f/65bac17f39991a67e22f8b3c849fdc02a56147c97029b5351494341959b4/regex-2026.9.10-cp314-cp314t-win_arm64.whl", hash = "sha256:ffc2da104e43db716ce30cef9f28049a1faa6aca385dd8771b033268d0730b07", size = 283780, upload-time = "2026-09-09T20:59:05.009Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/ca/1d1f83bc2f8fff4f186266ac82d73254e686565530cec9ab5228fb5c63dc/regex-2026.9.10-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6afcad14310f1311d077553ed374b42a5e538f85a8c884b4e38e52de091c8077", size = 496869, upload-time = "2026-09-09T20:59:07.051Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/33/42/4217510286501a2ebcd372b781b4754ac961e043fa13ef8dce803c44d89c/regex-2026.9.10-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:3fb4ae8cf83ef4e9addd43b2da31a9f45be816a8036fae8af59c8998b72718e2", size = 297121, upload-time = "2026-09-09T20:59:09.007Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/a7/595468ed0bbccd94be92c6b5d67736ba128b204d942429a8485c2693914d/regex-2026.9.10-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:f7d4656e17ab736e9415a6442a345bfc97bb8b7dcce47884bb74a37f70f08d0c", size = 292139, upload-time = "2026-09-09T20:59:10.859Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/1c/ac92c123e0ab9bea75a904272171b356940bd6139e4a35de44f2254dca8f/regex-2026.9.10-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35ba3bab0c45079735f55ac61526774de1d84bc4a0333cc554e1a4ab74913924", size = 802375, upload-time = "2026-09-09T20:59:12.823Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8d/16/d349f6fa9f908162359004e4f067353a0146e8074d24989490778244be44/regex-2026.9.10-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ff6b3267318661dfddf6b3628663e00e5946bd0a5c8fa678537a1401f0388f91", size = 872328, upload-time = "2026-09-09T20:59:15.352Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/df/81/251b5aef23147057e926346fdb7c8c352d0568f65a492e4e9eb6120f6446/regex-2026.9.10-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:030fa9e23624e39b3b94e46b90a5abd1a1678eb2f58fcdd3fd6c27526bf91c7e", size = 919594, upload-time = "2026-09-09T20:59:17.31Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/6e/1f25319dc1b9cf4b7ffa303f3d16ca53260fe92aff45e81aa1b3c6c7cba2/regex-2026.9.10-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fbc8314436353e097c050e11b01a6c11433579437ed0579730157676ef59e2f", size = 807394, upload-time = "2026-09-09T20:59:19.328Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cc/fc/3da6b3dffddf12d5e96cbbe6f5e65ebcd64f92e3388a6690a53e0878232d/regex-2026.9.10-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e6c0b5ec6ddee4032247585dc491b0fa58627745b66a705728703a3f0331231", size = 786018, upload-time = "2026-09-09T20:59:21.592Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bb/6f/1cc86dafddc912ef44c5ccd4f729060be8c6735600932664eb6d0e25469b/regex-2026.9.10-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:bf29611e5376fec8f795879bb5c6153a76c3a292573d173c26784042b01eb840", size = 793504, upload-time = "2026-09-09T20:59:23.734Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/cb/11692e29388d006211163627fcefa0c79917ab9f94d46a1b2254fe5efc81/regex-2026.9.10-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:ec8855f08c17895a26fbf5f19ed829722e19b34a96629e49a43c92974924026b", size = 866766, upload-time = "2026-09-09T20:59:25.798Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5d/78/3631df969830f94d83fcfc5fc71a7b39caad905e18f7b17350a94135d625/regex-2026.9.10-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:94c5ce3bc41d226b4eb89ca3f842b2e28c031487fb1f34eb2153d98235831325", size = 775825, upload-time = "2026-09-09T20:59:28.51Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4e/8a/762892a8e3e21d119eacaffde848aa247e6cf4e1d90c46011671e86b1b9e/regex-2026.9.10-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:9ce239acb15843ab03976626af810a4424b0409689ec2bbc52088ab5479ab487", size = 858901, upload-time = "2026-09-09T20:59:30.656Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3f/f0/78048fada5c2f61d795efb26ea24f820a5564c4aa26574920284d45cd656/regex-2026.9.10-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:c22df8dd6373bbe3898e77429ffc85594300e39d752fd0e68a31e59d37899376", size = 796208, upload-time = "2026-09-09T20:59:32.852Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/58/632681f7b9aaa3d83b40e5862ba46364a453c8eb2bc7d43fece3dc31f972/regex-2026.9.10-cp315-cp315-win32.whl", hash = "sha256:1aa309ab7ba89a62d6cf70dbd38d4176440bce3c7001ab86256704cf4c18c6eb", size = 272704, upload-time = "2026-09-09T20:59:34.927Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5d/64/81cce28754c37037b1fe740b6d7a556d51d97cf935ea4547bfab104f43f7/regex-2026.9.10-cp315-cp315-win_amd64.whl", hash = "sha256:58da726d3e766c0b3f5a3997dfaf0275898a1107b8191cdd6b0437fe45fd817d", size = 281182, upload-time = "2026-09-09T20:59:36.86Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/33/28/5a13a340c9c759e863a0e7f765d323601d03d6538c8a627ed628662e083b/regex-2026.9.10-cp315-cp315-win_arm64.whl", hash = "sha256:75f9297b16fcb588a1f8d8a55dabef3c0c20b0c7bac43c87ceaaaf1a825c12f4", size = 281512, upload-time = "2026-09-09T20:59:38.875Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/38/a3caebcd5105be90708071db20bd261b0961b8ea4fe5e8be45c2632519b5/regex-2026.9.10-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1270cdec69248592bbe38a0b263ed58d907b891bd2b93703e225c317e421bda1", size = 501336, upload-time = "2026-09-09T20:59:40.987Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/b5/ec8887b2658bf0a5df143c7c1fcd562b0abd2fa208c04ebf15c6607c9bb2/regex-2026.9.10-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:681ed38664b64c6617d3c3c332018d1948c77e139c5ea667c1886efa671e426f", size = 299318, upload-time = "2026-09-09T20:59:43.039Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/58/84724a9eccf6e8cd46f7e4534576093e2476a5eeb55e2453aa6606e86059/regex-2026.9.10-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:8e127d9a80cbf1c3276bb465c6d047e8705e97b58c2b8f2f0c0a69c336b44b37", size = 294847, upload-time = "2026-09-09T20:59:44.954Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/50/03/70ccc5e53905984abf8eab63eebd3ce740522ef8c8d392622b64d79ef290/regex-2026.9.10-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:990797e765d89a423880052c68b61c31afe701de94a8c060f61c40605ca6c727", size = 814359, upload-time = "2026-09-09T20:59:47.194Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/53/40f7a11ec547e4a947883c9d5e8a075f6d4f59af2b8dbcaa8bf5b504aca0/regex-2026.9.10-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e5e4a6e0734a685d13b9685622bb503bdbb2927f8b0df025a5085f0ea067475b", size = 875586, upload-time = "2026-09-09T20:59:49.537Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0b/9d/83f3e022d99ce601727c4ef5f7b527753901ce4509ed89a1bb6a2263380a/regex-2026.9.10-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:63bb62cf62217dc38c8a6b2b61b165b0e4eb8fa93b0aba12139251c0986a8fa3", size = 920990, upload-time = "2026-09-09T20:59:51.776Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b2/64/dfdb367d8f4f5c9b8ccb4b59789c2ce996f2c69c3b8192aa986fe7d92ec4/regex-2026.9.10-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cb76a9c4e07a6a47849726af0ed14c41741a182f097f134a8cf29c1bc0f4dde8", size = 818660, upload-time = "2026-09-09T20:59:54.428Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/88/a6/fb7d0b64487913845834f319aa84f8377d55305958a5db7e19c128798366/regex-2026.9.10-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:31e4df2b11d48f61d511019bc1ee9b477055f17c352b68fe72db7a98b14d603c", size = 794976, upload-time = "2026-09-09T20:59:56.799Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3e/1c/23484edaae387ea0d31f4d414463211e3516c8aa210ce8d0640f5aff3502/regex-2026.9.10-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:cf377960d2ac37d987394a9dbaa75e91338c41a46d41e1d25e90125e7b3ee2dc", size = 804081, upload-time = "2026-09-09T20:59:59.39Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/e1/e30d138f13aecec99ea9aecef7e31563de6ec6a2f5ce1d65fc506aee33fe/regex-2026.9.10-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:c8fbd9cb30c68c1686b94029b9ef845d5870d3d65baf66cb126b676849b9d72b", size = 870430, upload-time = "2026-09-09T21:00:03.304Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/53/dc/81f9ce86f7ae4f57901543597c95751fa01c41a672ec1636dd913f8a000a/regex-2026.9.10-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:53e182b6b04d0011909b47d51a2d72d908de07c7b1c7f16b3adda2204d723bc1", size = 783327, upload-time = "2026-09-09T21:00:05.68Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/1b/d7bf8f91534740f6a8ca17e5ac9c5337903baf527c8de240fbac1bbedfd0/regex-2026.9.10-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:0aa7589394230e0f0a422ab6b90841ff12c87e855e7aaf75d192a54a5f124548", size = 860874, upload-time = "2026-09-09T21:00:08.41Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/1d/52cc88364aca7c9013dfe9abe0fea67f8d394efe384d07798300a6e2f27d/regex-2026.9.10-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:1b891f77554bff991804cee24b78b40789f7d5993a24c7907bc7025fd2a70c8d", size = 806705, upload-time = "2026-09-09T21:00:10.768Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/51/37a194df7707f92f33173260ba7b221d4ec376419a53babaec50019a2804/regex-2026.9.10-cp315-cp315t-win32.whl", hash = "sha256:5bef622850cf760154719d4e0d74b0a855962432995168e250069899ae12fe8f", size = 274780, upload-time = "2026-09-09T21:00:14.003Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/77/12/3227a52970d90908b230f15b2c86df903f49ac72c9eedf4f6e8b5bb5e1a7/regex-2026.9.10-cp315-cp315t-win_amd64.whl", hash = "sha256:07b45ba5c94b8fcb30cb6c56a11f715c57533a3017964504322ea52690a27b72", size = 283936, upload-time = "2026-09-09T21:00:16.275Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/bc/c567c5a61671f04d30e83f20b496b465432879196574d051007285576205/regex-2026.9.10-cp315-cp315t-win_arm64.whl", hash = "sha256:f70b9f0e39c2dba1d9da6bf7ef7c377cad7277f8440e9a69be05ede529ff024c", size = 283747, upload-time = "2026-09-09T21:00:19.113Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-file"
+version = "3.0.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3c/f8/5dc70102e4d337063452c82e1f0d95e39abfe67aa222ed8a5ddeb9df8de8/requests_file-3.0.1.tar.gz", hash = "sha256:f14243d7796c588f3521bd423c5dea2ee4cc730e54a3cac9574d78aca1272576", size = 6967, upload-time = "2025-10-20T18:56:42.279Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e1/d5/de8f089119205a09da657ed4784c584ede8381a0ce6821212a6d4ca47054/requests_file-3.0.1-py2.py3-none-any.whl", hash = "sha256:d0f5eb94353986d998f80ac63c7f146a307728be051d4d1cd390dbdb59c10fa2", size = 4514, upload-time = "2025-10-20T18:56:41.184Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.6"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/7c/6adb35d70e7c027e308274557901c7e00fb3407750faf3620c184ae058cb/ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050", size = 4921251, upload-time = "2026-09-03T16:57:29.037Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/28/9cc1b79639e284ec103f43c88c644db4eb58cbd0ea1ca11f1193435369ac/ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8", size = 10015638, upload-time = "2026-09-03T16:56:40.986Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/71/11/627d342ef727ea7794edf74fe23d60a074b02c3acc2e9436684e782286ca/ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32", size = 10220762, upload-time = "2026-09-03T16:56:44.681Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/43/d9/b75668ce41e4c8d073d18d6d08672ba6906ce45d5c06ea4fdb2e84ce3853/ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c", size = 9835082, upload-time = "2026-09-03T16:56:47.142Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/97/123ab10b05cde889c107c20f5a9774955104b5552796a2a8584b089ae8eb/ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876", size = 9949304, upload-time = "2026-09-03T16:56:49.813Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3e/58/a4a2c59dd2e5b85929c912d9cac3056eb9ee8c7e75e9b9fe3e109174966b/ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d", size = 9840612, upload-time = "2026-09-03T16:56:52.368Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/6a/ff8c8626a786c4f49d48ced4a752dadbca65f5263005f9c2416578194694/ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1", size = 10543465, upload-time = "2026-09-03T16:56:55.089Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ad/bb/c47535923365f337b82e28192e4e9eef2176511007cfd99a62fc22df5dad/ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70", size = 11267576, upload-time = "2026-09-03T16:56:57.791Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ba/50/e5119a5212b5cd63b51e1f4b25e7bd636a6668fc069a3160b108ad7e3c16/ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3", size = 10781993, upload-time = "2026-09-03T16:57:00.666Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/98/083d8b4ef3c51a0d19db84367791cbe9f44e4b53343d19dfa83556e1cd9a/ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757", size = 10317748, upload-time = "2026-09-03T16:57:03.428Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/29/68f7ff2c5ad95f19f00627ac2de95644e25fe47371ea60b2db1fd952315e/ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e", size = 10540096, upload-time = "2026-09-03T16:57:06.182Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c4/f9/79a8f6de85968641d68a7863aeec577551924ef066a990a48ff93167beab/ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4", size = 10100494, upload-time = "2026-09-03T16:57:09.194Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d9/e8/b81a22d9b90c00b892ccf2fa2ac36fa95de4c13ab85aea3e73795cfe4651/ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88", size = 9843663, upload-time = "2026-09-03T16:57:12.168Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/39/aa/54f516ec5e5a11c4afdceb1c454ebb054ffb96e4f4a1705580b4346abd35/ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953", size = 10282461, upload-time = "2026-09-03T16:57:15.077Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/0b/38d0aa8aa32372b96dc44f97b22e576c4147808271aab7b2cb1e353d4445/ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718", size = 10728808, upload-time = "2026-09-03T16:57:17.797Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/e5/9e274e24eeb027640ffc7442f21239f16d17f47acec15ae34f32e03a5c79/ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25", size = 10049212, upload-time = "2026-09-03T16:57:20.55Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/31/72472449414223ed1a2da236b992adbb1a2ae59e34794574810f60ce068e/ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39", size = 10556402, upload-time = "2026-09-03T16:57:23.501Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fc/07/d781f8f8e1ac24bef9f3269cf62ffb1407ca24c3a8f12e5e22874f90528c/ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5", size = 10412850, upload-time = "2026-09-03T16:57:26.416Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.9.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/69/99/a6ca3beb3ccacb41fb3321d8a60e5566f9e6467601ef8eba6a17e1b89778/soupsieve-2.9.2.tar.gz", hash = "sha256:4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74", size = 122445, upload-time = "2026-08-07T00:57:24.801Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/dc/ad025c1ee131eba60c69f4dd5779b18fcf1e6b21a343e2162a84d5d133c7/soupsieve-2.9.2-py3-none-any.whl", hash = "sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823", size = 37370, upload-time = "2026-08-07T00:57:23.524Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.52"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3b/21/77b4c147963073040dc3c3a5cb7a8c3001a1893c0209432cb77f9df836aa/sqlalchemy-2.0.52.tar.gz", hash = "sha256:5e2d46356ac2ccb7d268ab6c2319ac6a2b42f1b8d5fd8bd3d46855cd82abee97", size = 9945637, upload-time = "2026-08-11T19:07:09.829Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/18/e30c6fe1eca1bf34a39fbdd6066121cc9974c850faf6f349eac563697a26/sqlalchemy-2.0.52-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2eb3c6a64b1bfe6704777cfd504e7b8ad093a5f3e03ce67663a5e6742f294e43", size = 2167724, upload-time = "2026-08-11T20:58:12.679Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/56/2e17d161a4f7ecc1c2ffb93e607b4e1898bb551b451b283235acb8f6ce47/sqlalchemy-2.0.52-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:923bb183c1dc64fdf7b717965e3d59938ec4f8b8710b419a21ce403e5da9a9e1", size = 3321189, upload-time = "2026-08-11T21:02:41.932Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cf/b8/8490916e893f3f8d74dc9cc54c078619364999dee37047a188e73abbc852/sqlalchemy-2.0.52-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:651d6d8782e80679e6151707c7b490834d46ada526328895abf567f25e63d29c", size = 3338185, upload-time = "2026-08-11T21:17:02.597Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/f7/752cc8ee453da222829b3f5c4613614bf750d97429363b70414fa10478e4/sqlalchemy-2.0.52-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b08cddb8989775e3c88799d86704bdfc3ee6e9846118201aa5997f16f27e3a15", size = 3271698, upload-time = "2026-08-11T21:02:43.963Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/51/e6/074ade0c07b9e4c8e8bca46820320ed94df9702afdb6f2af06623068d2e6/sqlalchemy-2.0.52-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ab66fa9618269390d4dfa222f2f2f88f7bc4bf5da13905131b818217db7e8057", size = 3308936, upload-time = "2026-08-11T21:17:04.172Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/66/07/557c0d04716705599227945ac14e0a17ad0338e899f37d8c2ddff4dcc663/sqlalchemy-2.0.52-cp313-cp313-win32.whl", hash = "sha256:c63bda077685c85ca513286547a531ba57e7a68cf0a7ed3bafcc2bbd18896f4d", size = 2127308, upload-time = "2026-08-11T21:14:53.879Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/4e/226eda27654318ce525d043025221f689abef883da2c7126f9065121618c/sqlalchemy-2.0.52-cp313-cp313-win_amd64.whl", hash = "sha256:9876b09b9f1ce7398b0ffece585c0a911244c53191187341f6bcae640e133751", size = 2153876, upload-time = "2026-08-11T21:14:55.527Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/f5/71cb30af58c9b80a4e1fac0b73bb48f86d497a774a6a2eb6d2f1e657bb73/sqlalchemy-2.0.52-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:410d52be41d17f1a236d19520fbe776257dc16516ed06bd16d433311842aefd9", size = 2169537, upload-time = "2026-08-11T20:58:13.855Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4c/93/d07ebd645d1b07b6b5ed63450a70f063a346a7e0f2c8810daf2e532400cb/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfe9ce533dbe4d0a2ae1486546619bd30b76bcd670539a44d910361376175f5e", size = 3319606, upload-time = "2026-08-11T21:02:45.829Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ae/5c/290c84c7c2566ecd3b65baaae0fddec9bc33b033b398a06123bb86fbfc6e/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:812bae5138bfc0aa46fb0686da0fc7f581f68e2bbb05bc24c3713bebaedd1437", size = 3323642, upload-time = "2026-08-11T21:17:05.675Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/13/f5/2cc160590ca49173359557880b92a0572293ccb899e8f6cedf150c5a3ddf/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:50bff43b632a56fbf5ed9afdd76307e1512b62051bcd5afb341ae67205bbb6c8", size = 3268125, upload-time = "2026-08-11T21:02:47.649Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/35/f3/ea8933fc9f7d1353e9c2ff9965eae687c4cef181120574591ed2fa0633e1/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:49565daf5af554f538e23aef1fc81a95a4e49658f152285e45c02f5fc44f04cd", size = 3289516, upload-time = "2026-08-11T21:17:07.267Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/67/05cf86541c1e1716fca1e4a996954a439cd74501707cda607fb7cb02ef50/sqlalchemy-2.0.52-cp314-cp314-win32.whl", hash = "sha256:ab9da41e61b9979b910499d633b241df20c51ee5037e5405b11c2faac3cbe1a2", size = 2130249, upload-time = "2026-08-11T21:14:57.273Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/d7/8ac6ffa1e36169e762ef65bd835046abb2251b1bc17f8f6708e14ed8d31f/sqlalchemy-2.0.52-cp314-cp314-win_amd64.whl", hash = "sha256:a593db51b3bae75db17a5738ad5f992244b3a03863f83c28117ee482c6a3f76d", size = 2156718, upload-time = "2026-08-11T21:14:58.667Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dc/4b/e01a737eef378e734cc6394a82248a6ce13b167dfa36c731075ce9fc9c64/sqlalchemy-2.0.52-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1e61d08bdf4ee2f41024569e3400de7d6734ba498144766b11260936ccfa582", size = 2190344, upload-time = "2026-08-11T19:53:21.393Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
+name = "tld"
+version = "0.13.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5c/5d/76b4383ac4e5b5e254e50c09807b3e13820bed6d6c11cd540264988d6802/tld-0.13.2.tar.gz", hash = "sha256:d983fa92b9d717400742fca844e29d5e18271079c7bcfabf66d01b39b4a14345", size = 467175, upload-time = "2026-03-06T23:50:34.498Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/90/39a85a4b63c84213e78b3c17d22e1bf45328acf8ebb33ef93be30d0a3911/tld-0.13.2-py2.py3-none-any.whl", hash = "sha256:9b8fdbdb880e7ba65b216a4937f2c94c49a7226723783d5838fc958ac76f4e0c", size = 296743, upload-time = "2026-03-06T23:50:32.465Z" },
+]
+
+[[package]]
+name = "tldextract"
+version = "5.3.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "idna" },
+    { name = "requests" },
+    { name = "requests-file" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/01/a9/ed5d3be29bfaf90c00b7159d3884b311f3880b55833d1c7be764164dc288/tldextract-5.3.2.tar.gz", hash = "sha256:c017431bc0800f2d3d1b57cce36e06668f0930f60a6d8c4615d4e2b8da298fa9", size = 191971, upload-time = "2026-08-08T20:53:13.732Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4a/3b/930310b274dfe3b9a4fe64ef8b24e5faf376c9a6f94bba6fc6e438058598/tldextract-5.3.2-py3-none-any.whl", hash = "sha256:6c90d2a259f5c89f4fcf01f97af15708416a59ffedddff006d67222ab30d0fb0", size = 106415, upload-time = "2026-08-08T20:53:12.675Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/1e/bc6587c5ab643b2e17776cace9070a2ae73549c86bffac9934a600bf3c31/tokenizers-0.23.2.tar.gz", hash = "sha256:7f0f085686b9de0d0079e6f874ae053600db64c5d13049e0bbc0119926d25aac", size = 385745, upload-time = "2026-09-03T08:55:42.89Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4d/ed/8a443528baa6fac8dfe8c3b75b038c63ac92bb539bcabe311e227c718173/tokenizers-0.23.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:85a9a357a3764aecc904ee76bdaf8cf1ad8e5a67a1b929a487c4a39b49ed0e90", size = 3148852, upload-time = "2026-09-03T08:55:30.874Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/49/22da045a91732384d3a3771816bf188dc5a1f702c32e635afa7c679c0bef/tokenizers-0.23.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:986670e43691469dcee610ea0f846f91a8f84e91fc6f7a48d4c064414c0ec2bf", size = 3101593, upload-time = "2026-09-03T08:55:28.587Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2e/4d/8f569ed49372a3ed8e57099bd515055fd48d7c95912c4307cda6973c2168/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a37039b5dfc4af84eb3ef0a92f4307e28936c8f9adccba2629d36f652e9bf7a2", size = 3516830, upload-time = "2026-09-03T08:55:14.741Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2a/de/e2f14c8919d5bf51874051d00d6c7b7e0e8bde6c6a2dbeddda7f642896ff/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7b7e37ba198f24150f523e1242e83c4970de4a525480586be5dcc24d9add32c5", size = 3407975, upload-time = "2026-09-03T08:55:16.842Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/bd/93c69152d02ef06ce47aed8b2bf4952dcf733c935a62791873932b2934d9/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43e4f2071e3cc8d5d86421c874aebc82659bb51a68bcdef5a0da75ee89511ccb", size = 3748165, upload-time = "2026-09-03T08:55:24.769Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2d/b7/56b84b80bc96942bba8eb23751a9e8a1fce4faaf4390425e7083f721c98c/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:325fee2e0418a9dc6c9ecf736a5f5f0db7875183ace9549ae339da76f7a1fbb7", size = 4024165, upload-time = "2026-09-03T08:55:18.806Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9b/8a/0175e216f005c2fe08238292663aa41e4c802b216e71047a69a0e9fc6fa3/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:950d7c9426fa72406a0ffeacdbc0bb9985f5db20eb8b263f29c79aaf83105703", size = 3591899, upload-time = "2026-09-03T08:55:22.752Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2c/ca/ca6b93c7820df123b2662a9469e8facc826ccc94e98fdd0d615f6431e73a/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41c2f84d172449b4dadb9cdc508e3e364076613c35b16e76ecfe47a60d1e3305", size = 3386843, upload-time = "2026-09-03T08:55:26.584Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/a4/4f9106d317b14a80aefea9f0e3a8d07ef25f856a7607eb7f5ab894281fcb/tokenizers-0.23.2-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:12f0835dc2ee694746a76adf7b1567d4346a4a502ebe93fb1f5f80ea49799b78", size = 3577314, upload-time = "2026-09-03T08:55:20.825Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8d/6a/1552b70fb0d9ab074fd3fc961435d01364e79c9058481822c3af6e8d402c/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eb2f9c8a24da020ea8c11a01a19c1c2547912d92121ae4a01cfbca46125dee40", size = 9967367, upload-time = "2026-09-03T08:55:33.188Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/01/3ccb3a956c7528b2507b8a9714155c4baf86af593039db6ea375dd0c96c3/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f486f402f6f9abee5bb032553736813af0c710a86b2e0ca592634c55cea1f835", size = 9811886, upload-time = "2026-09-03T08:55:35.642Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fa/73/7038e612d48bda1599457f712f6bd3854eae1a9dc9c13aa47f835349db48/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:bef235815a067b2648caf6dcc7a71091b0b0fff9ee8057f6451eb9335fae52ef", size = 10146224, upload-time = "2026-09-03T08:55:38.391Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b5/d8/8e9e4e0b287a338d8f88976729628c9d22e8a54cfaf9777018a7f7cb58a0/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5c56bda1511921587789163e524d196ed8284174ac23abd7685d5ea8da6c4718", size = 10256304, upload-time = "2026-09-03T08:55:40.977Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/1f/c79a01f671a49728ebb0b61f7ff9ea45663b66cab40bc0858e9859b25c16/tokenizers-0.23.2-cp310-abi3-win32.whl", hash = "sha256:debf978920d93ba9c219bd67cc4bbfaf912c9039e41e7a28b91ec15e3728c95a", size = 2592809, upload-time = "2026-09-03T08:55:48.02Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/db/f7/0a69ac6b82dbccf3f71add938a161c497952749294b8dd6dfe03a819dc40/tokenizers-0.23.2-cp310-abi3-win_amd64.whl", hash = "sha256:2e96f5699d5249c9c64aa8412e044f727aae3a4098cf830f9901ec1afc361cde", size = 2863236, upload-time = "2026-09-03T08:55:46.193Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d7/b0/dee84cb44175be1b4c35bd2f770727494e78f0bb38e571a623ade94dbebb/tokenizers-0.23.2-cp310-abi3-win_arm64.whl", hash = "sha256:e49c394456dd9985787fec76132438ba3fb8911f857b1bf3d40119f9292d41aa", size = 2729352, upload-time = "2026-09-03T08:55:44.345Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "trafilatura"
+version = "2.2.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "courlan" },
+    { name = "htmldate" },
+    { name = "justext" },
+    { name = "lxml" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a3/96/737133a93e73e967f9c888e6cfb1f2c31b2083d27263edb19fd65a9aca02/trafilatura-2.2.0.tar.gz", hash = "sha256:8c2cabb84066465228d03183fb698ce0b1245b81c58140b8ae0de57fddf3aae7", size = 314748, upload-time = "2026-07-31T16:06:49.444Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c3/01/af18878398102a5a5afa0811f4f8f2a8a94a60cc16e8e9cf54bc95f96808/trafilatura-2.2.0-py3-none-any.whl", hash = "sha256:ac43592a6201264dfc4f9c361cbe3eb3fea96e54437010a159d5e7365360ed98", size = 151906, upload-time = "2026-07-31T16:06:46.485Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.17.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0e/9e/750649904a065007a838981785b2bd8d9ff26154c6c341ac67d0b7f82c68/transformers-5.17.0.tar.gz", hash = "sha256:a153be279169b55b92d8000bf4af294aed684503d091cca7804da2dd8a9de000", size = 9817878, upload-time = "2026-09-09T15:39:56.886Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e8/d0/c502b60d684adbd98a8dc7d5bb866842772b816ac4354e4608be240041ae/transformers-5.17.0-py3-none-any.whl", hash = "sha256:78ec1ce21579b38dfb83950a0658cd119f87212a2fcfdff478096ce9d6c03801", size = 12295140, upload-time = "2026-09-09T15:39:53.746Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045, upload-time = "2026-08-28T10:26:55.046Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130, upload-time = "2026-08-28T10:26:53.752Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.4.4"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/5b/879b2f932adfa7a053c360d50bc896c977fa6426109185f7c12ebdd0cb9d/tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4", size = 31170, upload-time = "2026-06-29T08:03:40.026Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/a4/017a7a6cbe387d961a688ec31364ae60a5c4e22c96ae9921b79a947c855d/tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15", size = 18115, upload-time = "2026-06-29T08:03:38.666Z" },
+]
+
+[[package]]
+name = "ujson"
+version = "6.0.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/64/7c/e1fa3fb70b53192436d751b5cb671f0ee960baa188b8351a7fec735223d3/ujson-6.0.0.tar.gz", hash = "sha256:80e23393feb707582e0ad495c397a4477b646d08094d2df64f7316f9fafd8aae", size = 7169158, upload-time = "2026-09-04T03:55:42.983Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bd/32/c67df85215ba0ebcdca8f8b1b3a856fd2434da87f84f9757e275ef99bd40/ujson-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fb37ec7d7542e2f23fd7ca8fd034c8db7221c5e86d6a6a3a170711f993eecf15", size = 55113, upload-time = "2026-09-04T03:53:55.285Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b7/a0/e5c7ae933fab41be06f0ff7976e3483519cbbf9e2492a217a5550af95c18/ujson-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ad11c9153c775087d261634410da7cfaac2743d79bc9ab573177d9e3398f00c6", size = 54247, upload-time = "2026-09-04T03:53:56.383Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/10/0993497a08f9fcff34cbcdcd6da46491f415e711a459c5d81f594e89769c/ujson-6.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:2dbe0b6d417b458164ccf1f59e081d6bd65c1fb2f626e0daeb6fb88c436f9643", size = 58497, upload-time = "2026-09-04T03:53:57.791Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/70/55/06a578dd00551b10bc94d68889387e5de11977ee92cc53921eb02713146f/ujson-6.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:455e6ae6c925eca6358110e665a31e5bbcf0a93dfe9822a26b954c9351de2c3f", size = 52377, upload-time = "2026-09-04T03:53:58.859Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/9a/cc0d306e93d1a8f1d48d54f52cb2cae39b56a4c990e2cd8cf328697bbc80/ujson-6.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5376a8c14d0eaf80789bdb10e21ae12582cdf526eb921a47f57053ef08c63f8c", size = 53718, upload-time = "2026-09-04T03:53:59.962Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/15/48/0462149003b03afe83450f6bdad3ebff9ac9aee315690eb0670bf2a6e342/ujson-6.0.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8bd6743ad58fe6067ea1677d5df4674bd7de143b038bcd4129c3a6ced483ae8", size = 57191, upload-time = "2026-09-04T03:54:01.005Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/ad/26f40cdffaebd1158b1083d6c89efd9e056badd706022386a0e9567ae499/ujson-6.0.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3967550c8952bc516c79c40726a54313aceeb3162a8d5cc655362ab83d0957c", size = 56413, upload-time = "2026-09-04T03:54:02.019Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/62/60/7f0d5da6198fcad7037dafc68e6c76aebb6536b323c07a2d1f82bf692099/ujson-6.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:619b2152aa77c57a535e3e7eaf88ec8e25beac6d380378b2ade10362cce50f75", size = 1037442, upload-time = "2026-09-04T03:54:03.104Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/83/bf/21cd9110b8b33ff1530d854f38b7bd2b8d2be41af67590fccffb418fb29f/ujson-6.0.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2e36269e715c8deea036d263557042e2598e79d52110233c1a623ed9e7c1cf0a", size = 1196458, upload-time = "2026-09-04T03:54:04.39Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ed/51/2e3b3a19b36862f72300a306051fb7a265ba0f5a72d6e2eebd30f2722b44/ujson-6.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c626f68524a19f50d9a9babc17f9c379d1b2a9f2a3da5ac3c40a205cc736259f", size = 1088718, upload-time = "2026-09-04T03:54:05.787Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6d/f5/faeb3439f844e61040dc4bd2744c58745541ec1a94e68f08994fe4f41ee1/ujson-6.0.0-cp313-cp313-win32.whl", hash = "sha256:cea0a63173e4ae98cd960f484096233da76a62550ac10c53312a69ad9f3545b1", size = 229128, upload-time = "2026-09-04T03:54:07.5Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/05/19/55a89733b9078a88605f5884763e0457409fd8d04d2e47d4d761052e28d6/ujson-6.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:88b237680c705fd37bacbaaa335106fecb234a47e1df0737d949b8e32c7eb5f9", size = 227518, upload-time = "2026-09-04T03:54:08.653Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/cb/807314a66fb495d600718b11f7639af07138a25ea301b91234a18a43af59/ujson-6.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:ec570979304a529a8be1bf9ea28889742a2ff5de9af1c6734584dfe1645da3e6", size = 400244, upload-time = "2026-09-04T03:54:10.006Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7c/40/c22e49f786f5a0a71bae6323d0e6fa9a4a47b7b68c9f00631fdd78f147f7/ujson-6.0.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:63eefaa34abbe14167493710619b840d3fc167ba86e5fbe0c4a5eb01686aa3a0", size = 55208, upload-time = "2026-09-04T03:54:11.403Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/86/40/90a47580ae4246134a080b0f76637e038476271461d7ab227c1c4431822d/ujson-6.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:af85ae40c71d422fad944aa8666d59374e4fa92f77899fce34b984037db41420", size = 54303, upload-time = "2026-09-04T03:54:12.467Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/62/63/a275e218f7c5f49c0e31b446e9eb581267b7d3393d4dfbc25f397967e51b/ujson-6.0.0-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:2145005321a4b175486dd890946b036bb8730e4e8e17744f5abce23ea014e024", size = 58509, upload-time = "2026-09-04T03:54:13.472Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cd/3b/11fc8994c579a325c5c2075f03c70c967849d2c63cf97197507f31aaa739/ujson-6.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2c670cd7aaad2a3bff450addb32b26aa831f82a8b6c2c875ec19bb282a6c45d", size = 52422, upload-time = "2026-09-04T03:54:14.475Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/73/a7ecfa39bb08cfe57d35064b4be21712fe671bae47574a4c9901a9a1ad2a/ujson-6.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:63b56e3fcccc339e2c1332e75adc779bd145964e1a47a39a229fa01b2e25618a", size = 53707, upload-time = "2026-09-04T03:54:15.657Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/c3/e6d76ff353d179dd0dca2e5df6afdd170874031eb73284acb9a327dd7f52/ujson-6.0.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab7b316bba31be494635dcc5db87e429f2478073d15d2c54925c32fd9e1947f4", size = 57234, upload-time = "2026-09-04T03:54:16.793Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cf/b4/c52aa5b797b76a2ca10da513010120809d70bb12acdfc27ad7875a652fee/ujson-6.0.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9d26982045b28db1937ac60682a9940fdb72f9cab3421a5d56c03f2207c99e9", size = 56411, upload-time = "2026-09-04T03:54:17.979Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/ad/5e2dd3fbbadee85811279e57dee23f346d8cc099809c14f7bb01d1a5a879/ujson-6.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fc115cca04dbdfd98a67ec89ba5ffd8a87f3201171af54980cfd550997611c41", size = 1037485, upload-time = "2026-09-04T03:54:19.215Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/61/73d5ef4020716e08de4992519d090785908bf229a3d464abf0a067f06c21/ujson-6.0.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:90f766c5f8e55de2fe65e4241e3e2e46ed7528e7931255a7ed0dfcb5ce622b15", size = 1196525, upload-time = "2026-09-04T03:54:20.759Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ed/4d/d63aafdf83ecb52a76ab46b0450e5431462b713e0b2576539a1b80ed6afb/ujson-6.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dfceda99f3105e9e6fce8dfd157f80894ad20247dc9ffce368c8b7883e7a2aac", size = 1088718, upload-time = "2026-09-04T03:54:22.056Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/92/504ccce4f8b56612dd5ebb1f221b5cb6435bc33d357dafbdedfe5b0b691f/ujson-6.0.0-cp314-cp314-win32.whl", hash = "sha256:22eafdd4f8ee6fe2db0737285c75b15f7486dc53c07b09a4b3699c92c407c3e5", size = 235844, upload-time = "2026-09-04T03:54:23.399Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/11/c897b08e00d9778a0dea895d5e88031180812941e3cd7fc63fa26034767a/ujson-6.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:9d522e95bffac7338178757a7931b81639b9e0f2a3ee6e8c7ffdf867f2bfed36", size = 235353, upload-time = "2026-09-04T03:54:24.587Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/cc/69a625656d73634af2e7bb8854b05f0d47a4650954e0876e28515965a522/ujson-6.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:bc6df52a60b521c7b7d69de0c14856397d3cce1e39aa22cfe439c350d6f52524", size = 415010, upload-time = "2026-09-04T03:54:25.781Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bd/53/cdc879e035a9b67e50fa34aa13d2d9160a826801a5fcf2993f48b9768944/ujson-6.0.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:222389a616f6407eb40e1efa80a35c1ba468903e50a305faf425c26e3c32bdb9", size = 55660, upload-time = "2026-09-04T03:54:26.996Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/51/29/33891cfee86cc13e00a1de6fa326378a637dad786078aaf56ab6336c60cf/ujson-6.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:593acfa0f36ada24e89c07147441fe364081fa1631db73ee55f40893c196e0b9", size = 54730, upload-time = "2026-09-04T03:54:28.106Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/16/f6/2d4bd6fb364f8ded5840854bdda58032c8cd11614d70ce0c125a52dfb7a9/ujson-6.0.0-cp314-cp314t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5b3afbe992e2d1b8c1e4e7a0da2c77da23f29545e5ba695a4a9241702234f20e", size = 59301, upload-time = "2026-09-04T03:54:29.215Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/fd/7baf38f591fd964558891a1798e9b49078558346a24020b7c27945389130/ujson-6.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:65e0e0c21ead4d0087c9c65a82eb2446c4bd51d36388d41035ce773517e7a3bf", size = 53364, upload-time = "2026-09-04T03:54:30.327Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/63/c0/640ed28e4443c81e3ed9cbec2b216f4c3943388f4f45b703e8e0993c4f8f/ujson-6.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0f3eff1f93d9d1f0bd5eee35883b9c71ad9befcfcd0ddc7cd5862c69fba21cf6", size = 54447, upload-time = "2026-09-04T03:54:31.527Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f8/f7/3688adc11a3e22e4b26563256404c6557682efe62510f988bf7dfc09d8b1/ujson-6.0.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4579b8c96824f65888d4a615463c2dc2b7db6c6f0c7f83ece2a58714fd1a8123", size = 58263, upload-time = "2026-09-04T03:54:32.587Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/c9/9ab8d5ab9ca362381d0fcc8c6e6a831e96385a908792b2378db6282a374e/ujson-6.0.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8af54166141d5c8ebeebc044c3569ef10edfcdf6fd8ecb487a2bf33c776ebc8f", size = 57154, upload-time = "2026-09-04T03:54:33.698Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/23/01/82ed9b5594d770f6490334ce78af22c754b91b8de12efd3ddfaa1d23da9a/ujson-6.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ad8bdad17cfc64aefb049e53687ff8730a72e2c3d99edcb36001683122597846", size = 1038449, upload-time = "2026-09-04T03:54:34.784Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5f/dc/3cea633a17cb79d8b642e06b6c07f21ac31072a4b3043cc41df74db54fa5/ujson-6.0.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0dd8981828f6b515ba5e9f2473f433aa59bebe4784182b48695b71af52033b4f", size = 1197332, upload-time = "2026-09-04T03:54:36.441Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f9/1d/3fcc1ae871d8cd6ee40ec7e92556d9641fdf248875656780c4feea33c793/ujson-6.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:97caee7e4c3e20dff9e6adca0b7443c3cf9d7546ed5d0750954c5bb5456bad86", size = 1089519, upload-time = "2026-09-04T03:54:38.866Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/86/af921b0c127f2c2d953836abfd277178bcbdfdf72318f26b4793d04a0c9d/ujson-6.0.0-cp314-cp314t-win32.whl", hash = "sha256:3bd770b553bebc408b49d6fdb46efb1dc568368d949ac7813a07fcccaea044ae", size = 236539, upload-time = "2026-09-04T03:54:40.163Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/79/12/bb371cd75bb779d3282e5c1efaeb5e20bada1faecba6d83cabdd36756031/ujson-6.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:683501475e3dfa935574bfd2b3d26f7393b4a880a745aeab63cc3d013027bba0", size = 236201, upload-time = "2026-09-04T03:54:41.568Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/82/f301c155669dd0bec9e569ecd5013b61e88528b7587bec2457b96b7fce23/ujson-6.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:e1fa46cb8ddbfba2adf8277b8225e2ebf5bae435e2251c730c17bc0020f63c5e", size = 415482, upload-time = "2026-09-04T03:54:42.809Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c2/2b/020feca4cc502b274029cd1514d428908e334a17386761d157da32447fa6/ujson-6.0.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:b2ab962524adb39dbad565fd259e15a1c26b8944fa978c24ed6dea5ab1eeefd0", size = 55210, upload-time = "2026-09-04T03:54:44.1Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4e/0e/1cd913419d17260f6d4c9869ab1208132b1281f4db00d3f07b664712ffdf/ujson-6.0.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:dae3765f731779faa947715485f6794bc5984802be4584478a3e9e5143dd62e1", size = 54370, upload-time = "2026-09-04T03:54:45.249Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0a/0e/876719d6f04bb48560806bb508a038550f6a8184558f0a7274bc3015e1fa/ujson-6.0.0-cp315-cp315-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:34c0403b485d8ddd86bd29d879cc9f72223579b57188b0a2bc07a8b06f8cfbdf", size = 55682, upload-time = "2026-09-04T03:54:46.34Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/99/92/b59b4827a9c6ba0d12939b0d6e790b8629946873b7a655ff5a06735bd173/ujson-6.0.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8d56340493496d50ccc41b460610c1ce6a197aac710733b5f36910e8c9f3ba6d", size = 52648, upload-time = "2026-09-04T03:54:47.641Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6c/49/3d702afd9beb434f5140b12ffdf88198c144c1de5bd17a2a3a6fd7872b22/ujson-6.0.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a38a21efd05384fb82d35bed81fac0ff6056ea39c3dee3c293885ce910879dd0", size = 54007, upload-time = "2026-09-04T03:54:48.714Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/52/fb/4dd3f307f62f0b22f33b9d760efbfa7c7890a76591e6867c72bd27070966/ujson-6.0.0-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee87d8c4a4ebbef1c7cb2cf251a1d77726ef06a1597ed04d3dce92709b8fe0f1", size = 57412, upload-time = "2026-09-04T03:54:49.753Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f2/12/03ef04cde2e056f9ec699046f78bf2e8c1339ebfe0f29486098bf965e9ca/ujson-6.0.0-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:928d83b72808dc73a5df530b7fc27101052be1baf013a5dd75a1535de6cf107e", size = 56439, upload-time = "2026-09-04T03:54:50.795Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/26/d6/5cd07dc0732de702101e2360b07f2841ba50a77d2d758b0042623caae049/ujson-6.0.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:cd835565b660ca125f5895105981d691c708c15367b88a69fa4d92ddbe24504a", size = 1037774, upload-time = "2026-09-04T03:54:52.087Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bc/a3/59bcf91336ceebeb6a54716987c7069f9ddf99579488e513252300beb6ba/ujson-6.0.0-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:e6926204905e1a2f278bacf92ff2fe31343bcc7fb9ff08fdd42be66b3a217ef0", size = 1193839, upload-time = "2026-09-04T03:54:53.548Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0d/1c/fb168acf568b8d1312cfb3b079ae4a91ff95130219551ce2a3fd5edf71a4/ujson-6.0.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:7a1472649bc9ef3b9ce3ab279e9e812368bfac25210b7ec96bd544767c019577", size = 1088955, upload-time = "2026-09-04T03:54:55.287Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/c2/6fe4524ff1edc26234f67b1dc9077e05c70dd59cdc736297dea18b171bd5/ujson-6.0.0-cp315-cp315-win32.whl", hash = "sha256:aea27aa0927b0423a0cfb167bd505c2dc59d1df65c66372204e43ba94fc964a8", size = 235843, upload-time = "2026-09-04T03:54:56.797Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/26/bc/1a118013f92236150444d6ff931e78e698bf45f2bb9e9688d625970f3557/ujson-6.0.0-cp315-cp315-win_amd64.whl", hash = "sha256:102ddbb1677540f0cae80cc36f5db9663a626c7b3bf872ed10f10fe72343a3c9", size = 235351, upload-time = "2026-09-04T03:54:58.02Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/db/001d7bd04cde9cd35fb0635239026ad0ae8b57cf12e770db3427dfc85217/ujson-6.0.0-cp315-cp315-win_arm64.whl", hash = "sha256:9ef1920b423effe2837351d19a2278d7a516404a07200cca30b881077a2d7877", size = 415004, upload-time = "2026-09-04T03:54:59.741Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/60/5c91a9e9e7f0b433dd782c57c388f7e764f162a1de433545f30fe93f48c6/ujson-6.0.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:7168df25a051fd2a60f8d123b2123b60ead7c1f22cdd467ab7c2bba0fad0aec1", size = 55668, upload-time = "2026-09-04T03:55:01.139Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/dd/1dddba1b0f74092f433e6a26ce4cb0f419a7a93575b54fcbb0c6d64e616d/ujson-6.0.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:987e191700873419cc23d94d4212e57a85df24eebbe9a33785907b0c99a5a57a", size = 54828, upload-time = "2026-09-04T03:55:02.353Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/70/2d/6e65a3a336717d65cd8035ff870ad507b5a6375b8bc992718e744d620891/ujson-6.0.0-cp315-cp315t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:0eeef12ef46e129278b50ca4c66c6b35c318f2fd09346bacddf218ed378cc0bb", size = 56651, upload-time = "2026-09-04T03:55:03.39Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/a4/89d2bfc97fd073a3fe44c90beea19eb402c48101f83d46626d4b4d32c9d4/ujson-6.0.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68d623416ad997666bd8ea899b15554462b6250e803f4ce084c7dfd06a775314", size = 53687, upload-time = "2026-09-04T03:55:04.587Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/02/5b/ff1227377dbd1b1bb5834d59e3410ff27ef9c1eac1125fbb610e220f0e47/ujson-6.0.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7253ae5cac107d2940226a113165738630a98c19cdeaec1e6d6d6c3a7c307b95", size = 54873, upload-time = "2026-09-04T03:55:05.828Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/55/49/f80678f440126a3bd20253b91cf5bb200f1233bc5822f90024c7c94cfcd0/ujson-6.0.0-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b6494d29f7103a97d930cbd25f23fdc4d77e145a931e743660d697a200fd831", size = 58581, upload-time = "2026-09-04T03:55:07.009Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4c/2d/742897add5ea6b4ac9262208fba4bcb463e3f1b60606b6d79f05c7f27f17/ujson-6.0.0-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d56d408ccfb9b0e5c2b4ea687396df30ca42ebe2aedac88362069620ce65402", size = 57408, upload-time = "2026-09-04T03:55:08.105Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e1/b1/8747b3acf29d6219b042e8983f840fd4866dd9c65e5da9457311d4fb4fa1/ujson-6.0.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:add6b3827cbd6ce068ad70b1b890d44271801386a726e2bafe5bced784466642", size = 1038904, upload-time = "2026-09-04T03:55:09.313Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3f/21/deab9b41b6a8737210cd2460054e915f10b878bfda824e2dccc3e5f0db5f/ujson-6.0.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:1cda9f81e58120675dbaba7b254849ee59698e5dee83c4383a3c1a96ca92a679", size = 1194845, upload-time = "2026-09-04T03:55:10.988Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/31/40/b25a5f2b7bb6a5940692dc9d10bd89dad0c1e7d5af64c473d7391ec94513/ujson-6.0.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:d7945560fc6ce687ea83aa0bc375aa8a1101d9eee1fcbd085c5e0a5b6c6ac8ad", size = 1089861, upload-time = "2026-09-04T03:55:12.564Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c2/ce/baf673bd0ebe6135abb5bee5a4dcf162d2a79608bdd18fbd0e47bb7371ce/ujson-6.0.0-cp315-cp315t-win32.whl", hash = "sha256:54ab6b66fa6f67dfa8234e109df132074e155af3b299ad83aab13ba4b6db9b3f", size = 236549, upload-time = "2026-09-04T03:55:14.153Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/15/e8/39a55080f06270c7fb9a9e6384a2cc8a9d24094ffe90c6447fea6724f346/ujson-6.0.0-cp315-cp315t-win_amd64.whl", hash = "sha256:801ff407fda799f4ff98d960342128b065a14113eaccfc116b50092342636861", size = 236190, upload-time = "2026-09-04T03:55:16.018Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/40/76/ccb45390fb2bab53b69c7a49c0cec655a93727eeae0b3912132fa7150649/ujson-6.0.0-cp315-cp315t-win_arm64.whl", hash = "sha256:a2e699d5f290f81829f42638f8bc6582e3e73452d8607edf749ad3e1843946fa", size = 415495, upload-time = "2026-09-04T03:55:17.279Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/36/57/ed58088fafdf4c55a0ad6bde846502567645424d7ebf325230b9237f4085/wcwidth-0.8.3.tar.gz", hash = "sha256:d128512515fbf4612e0ff21fd6380399210318b7b54a9af59dff8454cf9730eb", size = 1458450, upload-time = "2026-08-28T18:10:06.875Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl", hash = "sha256:d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4", size = 331669, upload-time = "2026-08-28T18:10:04.909Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d8/cb/a5abcc2891249f393827c650c6296660ce40374ac22d99ab9aea41f9d2a2/websocket_client-1.9.2.tar.gz", hash = "sha256:0fcb57545848be86992e128218fd96dd87a6769ffdb1a968dff79632b85604d0", size = 84110, upload-time = "2026-08-31T14:08:40.964Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/d2/cc4dc1271e464942db7ee278baae2daa99ee77cb2af744025c04da585a3e/websocket_client-1.9.2-py3-none-any.whl", hash = "sha256:e1a673830a9c7bfa47b1cd3d5e4178f4c9651d80a4eab02c9c23a1c3ec6250ce", size = 95786, upload-time = "2026-08-31T14:08:39.899Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "17.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/72/fba934cb3dff7a85d811820efffcd141ddd52b5a2a01637f64551373ff4d/websockets-17.1.tar.gz", hash = "sha256:acfea4c20bf54384883ea33b1240fc1db4f52e190823a4e2b334bc3e8bfca96a", size = 187520, upload-time = "2026-08-26T17:25:33.063Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1d/31/5f6450a7879f4f063ef08897cc385ea3ce3f1fe17f08b11e3fd959abdf27/websockets-17.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2a0162a6372110a5601cb5c9fd826635cedf69f3e110c545dd19774e040b970e", size = 217006, upload-time = "2026-08-26T14:56:10.509Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/2a/c1b006fc861695d2aa4e35327b842015ce1d98cf8f99241829b3d6460bfc/websockets-17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:829dba1bc049779de9b332088c1a6a9858e96bd67e50b6b644a95e02b67836bc", size = 214690, upload-time = "2026-08-26T14:56:11.681Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/46/69/66e5b7d01445e0eeb1d4ab419c30315f2c90cf7a8a8cd4ecc47f894dba54/websockets-17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fd8f47dbf2e8adb15c847215f83436de3fdb120b51fdae0fbbdf69fd97a3ad80", size = 214947, upload-time = "2026-08-26T14:56:12.923Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/07/ce/033cafe2d2538562efa876b9149a2c7a0f7787870a4b1bb6e28adc9ceb6b/websockets-17.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9f4c0377a83e163a303514fdfab501dbe379bdc13e5b9312a91d112658b29dce", size = 224329, upload-time = "2026-08-26T14:56:14.212Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/34/c7/e1c2e8a67f6cc0aa43abe0046fb3b7a020980649e6a843751dc7ce9eb170/websockets-17.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c3241d684a76eaaef8b2dc789afde4343cd3aad55ea81e4e8ab3605b529bae51", size = 224611, upload-time = "2026-08-26T14:56:15.702Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/be/de/07c6d48eb3d2069709410c851e7de10ab83d752c4bd09862899627c2729b/websockets-17.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e5f5c7a893507d0e83a80b88aefd6522f7e882cd53f9722c6f23f5a020c9557c", size = 225848, upload-time = "2026-08-26T14:56:16.962Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/dd/3c68572d20509648cc2fb6f50ccf3deeb4b87270f2c8966e99476e278ea3/websockets-17.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:00bf34b64501e3477e81fc281532ff3cbf4da26633c10b63979d5085d46602d3", size = 227290, upload-time = "2026-08-26T14:56:18.204Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0a/4a/8f6651c8a22093539c9215af0c5bbf217b87b382c99d2112039b92d593c2/websockets-17.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ce0305b702b20d1e1d60a9aaace6bc89970e1753565543f310d549eab22c2435", size = 226476, upload-time = "2026-08-26T14:56:19.459Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f5/be/f6fc33cea86b1127fd1297b18c107e81580ab55a73a39f9a934441ef321f/websockets-17.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29176d8b429cfa0fa443c473878d37a5c06cfd0cb36b71ba4314accc71e05906", size = 225233, upload-time = "2026-08-26T14:56:20.939Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/83/65edaf05f7c9b1dea82f4d252fdc37706a84571646f06119a27b0a16fe19/websockets-17.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3709a1ab30b4b922027d22f68d2b61a0656a91680ac894a537624e6be7dd7f7c", size = 222488, upload-time = "2026-08-26T14:56:22.208Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/07/42/d1169c2f7f1f0032b0d4b0c00f0711a070cd7c735de37bfeb876bc0f9606/websockets-17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:43bd0c1ceb924d67f5c1a5254d8361dd9d94246e6331a726064dfa2917880780", size = 225295, upload-time = "2026-08-26T14:56:23.445Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a6/f4/64e2a386c3899b917c2933225c9b47887874229d159797f3bf1a11c20d51/websockets-17.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:1fce0f43e0d41422e0b2cad6561e1970df22f212f4c7e884967df7cf591b031c", size = 223891, upload-time = "2026-08-26T14:56:24.647Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/26/b3/dfb5c482f7e310a3432fdbb045ddfe6d34114680e89a233d4ff900a32961/websockets-17.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4031152769179ab8dcdeafc7b0e58052a49117560a28671700b47b2c7b717aad", size = 224661, upload-time = "2026-08-26T14:56:26.027Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/cf/94865130a336029f46412adc127c4fbe380f46172b90ce251369e35c4302/websockets-17.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a06f3b5085176763182449559e20391d7ce616a8972a9f7a33deda87ea6d4f3c", size = 225766, upload-time = "2026-08-26T14:56:27.455Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/34/eb8c658f86dfe562ed49a887a27424bfe9e618c26ea6f865b093d075d3a6/websockets-17.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:77b37cceca17291897c3c73bd30a7c7c7909593554b5da574ec852af83c1742a", size = 223323, upload-time = "2026-08-26T14:56:28.807Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1b/7e/2629609652ece5ca0c7ac235927dd4511b08131e3a5d53439b798fddf002/websockets-17.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d8e83333385cac6030a5167fd18bf96cc6c58b914c308e683f05b0cf94bc8dd0", size = 224276, upload-time = "2026-08-26T14:56:29.991Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/6b/8525737fe840b38e5f40956c198fb586a4fac1e07144d41a5b949b989cf8/websockets-17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:073c5c3f7e127041fa9d34a9e29ceefee8c3cafbd267ed2927318f425144380d", size = 224558, upload-time = "2026-08-26T14:56:31.184Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/74/ab/3a958c6cbcf74b118f601c20a80ac8bd5e8dfec0bcf7345116feaeefb121/websockets-17.1-cp313-cp313-win32.whl", hash = "sha256:2afb58c7ba48b329d56769f8dfd89f394efe587b65ef806bae810a484d6d3608", size = 217475, upload-time = "2026-08-26T14:56:32.431Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/36/fb521f0f2994c25509651f169efe5582dddd8713d57a0757ba87859372ef/websockets-17.1-cp313-cp313-win_amd64.whl", hash = "sha256:0340bbef6bfbe16da888b3983d666a4db4954ac3253c38f13bc7aba0c7db5a2f", size = 217784, upload-time = "2026-08-26T14:56:33.608Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/92/9b8419584681a12a7534b746dfb2737c466efe2455483e2fbf8b941a04ec/websockets-17.1-cp313-cp313-win_arm64.whl", hash = "sha256:7a72efa3bf4fa3a6669a54420a472ad056da3973d827f10e3a536da463f926c2", size = 217715, upload-time = "2026-08-26T14:56:34.865Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/90/0d/500cf5daea09d4669dff3a7d67159094a0bd6c4ef130381404f6edd3eb5f/websockets-17.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0c9982938980e086da59f70d05f9418cd143401a601a0faac10fa48f7bb1cd3e", size = 217048, upload-time = "2026-08-26T14:56:36.03Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/97/12/5b12c6168aa269cffbfd24d177cd492b130120403a418c7e89462e27b4ac/websockets-17.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:57b39dc8541cf7ed3f639da82bf7451060483967f9e733da1f8173e4095f0642", size = 214737, upload-time = "2026-08-26T14:56:37.43Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0c/36/e453e5106e4e2416f008ac222837c2f1637a063b08008afcd1088889b631/websockets-17.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:96abdecbaae746851b87c3a36cb4a661df93ca3d92f114270f79228bf1d00de6", size = 214955, upload-time = "2026-08-26T14:56:38.71Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dd/30/0204bb86176db02cdfc678ce65ed808a66fab87d250ce61a8790800a60b0/websockets-17.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d9fc873e239c5abeb150bc24dbd1a7af23a9254526383ce0a077f5e20adbeb19", size = 224331, upload-time = "2026-08-26T14:56:39.924Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/46/c8/d8372256e00c4e3cab1115c45075d1eeedb642a3f2b42bd70c4deae03f06/websockets-17.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6f42912fa9eb4cb7c7ec9fde9b3332ba339eb8a8811981043d4029599f3d950b", size = 224685, upload-time = "2026-08-26T14:56:41.169Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/12/7d/650355b8f67f908ff99603351d4458d1a0b787d627950a47c38db7e25308/websockets-17.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f98bf378d7a5be047a044a1a27c987a8f355e10e3b5754617dbe756248cbc5ce", size = 225927, upload-time = "2026-08-26T14:56:42.359Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/34/6c/a9ffa5b903579eed76017870f055d75ecc73988d9d0c9b65a92ba0bf2a27/websockets-17.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d334d11398086bb5559606cb42d51c013ea7c061c7db701521392373d3c087f5", size = 227300, upload-time = "2026-08-26T14:56:43.538Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9b/5d/4551c2269066af7481ee44605a0813770961615b5b5da3e87a8f5cb859ea/websockets-17.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5c27336b1a0ac56569493e858497870347854372395f50483725f8cdacc5a45c", size = 226533, upload-time = "2026-08-26T14:56:44.669Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3c/43/237a99233e5c445759a613831b3a92e91905afc064dc3bd0ad33c35fd1e2/websockets-17.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67258b00302a5aaf0b267771c7014b13429abd7ea17eebc4c55bd935ff101555", size = 225280, upload-time = "2026-08-26T14:56:45.83Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/b5/e9407a91613d1d1cd932414143a1012096b26674a782fc55a0bd23217ee4/websockets-17.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:455ffeea0879d313205df1e745e5883e1feb7f31ecd26be882f5f0babd3db04f", size = 222540, upload-time = "2026-08-26T14:56:47.053Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/db/d2/db76628db0577b783205d9779f64d8e373416b04c62d1546be4b75dc8540/websockets-17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f7233eaf441a345a5943a929fd4b5ea3278f11aed35a9ed0f3106b8cb3ca846a", size = 225354, upload-time = "2026-08-26T14:56:48.32Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/4c/2174181c067b89a74ae18e2650c2ac29959f4b796afe876ab3f4d30d642c/websockets-17.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c65da239a5ad553619804c1f9d65c1a0b3005381c6158ee14da2c7444cbd0c78", size = 223867, upload-time = "2026-08-26T14:56:49.579Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/df/75/274decb9a8253561b5be3261e02a6676fc8ecdf31e95b722e53d5bfb8fd2/websockets-17.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9fa1ffa08c81a4f809cdab6129f8e55bee4650b9d6d3461019dda73aacd146b6", size = 224652, upload-time = "2026-08-26T14:56:50.885Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9f/e6/49824f1fb4db7656d2f7492b1d8be16147b759d909490e32f4776843ee64/websockets-17.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:406b8107943a43ef4649b1e0cb0cdc052bbf08fe1c8905a623c4af9586e5cebb", size = 225822, upload-time = "2026-08-26T14:56:52.356Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/6a/5dc43838c0b02a95f42c47a0de33c5ddd7767a9feeb4d0d8777ac1cfefe4/websockets-17.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:4e8ffcb486c8490a34a4cef5e4409d8da5a1cb1681e5bf7d786ce5e84aa8540d", size = 223379, upload-time = "2026-08-26T14:56:53.699Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c2/62/585637cf06d6b321232f79c55dc14d65518d12cf87c94c44f5864068810e/websockets-17.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fb88076df585b69c5761c387c0081aa87d7b9eb1b205a6535ca4777e25650d81", size = 224330, upload-time = "2026-08-26T14:56:55.184Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/68/c3b234a6a1366b6ab5bbfaa4434a1b946e1dc4e8ddd6824bfd93a8835b7f/websockets-17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5d4724255fb8398acd9e583b97eb2279cec20e0bd0f9a94bf75f6056ef9f13da", size = 224622, upload-time = "2026-08-26T14:56:56.393Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6a/d4/84cf3d1376f5d8207f55f43c1c818babd6b89447f5dcd01f18a6d5526796/websockets-17.1-cp314-cp314-win32.whl", hash = "sha256:be3f0129c5654517b2abf07dcb75bb1d9479759a4ccfb569e8293579e9fc029a", size = 217036, upload-time = "2026-08-26T14:56:57.652Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/0f/9e7ac63c5d7cb642952200814f584318e65146df008b7d375d5d9c6b2c97/websockets-17.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a4dc6ef83f4559e0d05f313a375cb38f63c986096a9da99fe94fdd779d313e5", size = 217382, upload-time = "2026-08-26T14:56:59.065Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/54/bb/1ae6b91f7f3ac05f5c9f14a72dc2181c115ff370bcd8a7f10f02c174adfd/websockets-17.1-cp314-cp314-win_arm64.whl", hash = "sha256:46c0331c9eaaf73a559f3a9e388466be0df96eb83d40f06f1ca6ab6613b35c82", size = 217268, upload-time = "2026-08-26T14:57:00.654Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/f0/f65644d0e0b2b90918a8c41503841cc4072a58f2bf76c09bc36e751fc0dd/websockets-17.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d411ea5ca18ac1b12c0c94be88b60c18ca641ac43bcdfdf1c9f79d46cdbe1603", size = 217379, upload-time = "2026-08-26T14:57:02.181Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ff/35/4c46d1f620ac1a30f92b6eae78ee40a772a93f568647ca7ccdc5ea283cf8/websockets-17.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:07fa3e7c30e2c577928d359b56bf872a3e0cbcc15553eaa0907c1ee86344b56f", size = 214911, upload-time = "2026-08-26T14:57:03.478Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/04/6e/4587e8406d7c1188e97b9cf466c081e93399380d447f885bfce81626cd37/websockets-17.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6de9acef07e3a78e9567fcd26c29011a4da8f050b13004bbf880a0fd82a6eea5", size = 215115, upload-time = "2026-08-26T14:57:04.692Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/06/1381c8fff525041025909eb80ace32489194a00ba22a0a8d428030afcc84/websockets-17.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ea0ed9373b880115911d9d39634bccc95b8ce590c9c42e8589f5cacc3ef3cee2", size = 224696, upload-time = "2026-08-26T14:57:05.899Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/36/9d/9034e867dc85340be058619751742b895f722326e83100d110063461ca07/websockets-17.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50903d335bfda026c2fa11dd9aed09d8cbee0c451e3a85122a9acb041b7dc69b", size = 224975, upload-time = "2026-08-26T14:57:07.262Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/40/eb/ed03aa3cae748ebf6397e5d44028f433f746bad09dc568ff754fda3a3c9b/websockets-17.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a74531ce81af587f906ab42f194032388fcff8fc7938402e5917c9147a39441", size = 226151, upload-time = "2026-08-26T14:57:08.524Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/c9/cc1964a096d16f3b73cb1ee5f14f277f5a3bcac07c6e8f9a1dcded99f4c8/websockets-17.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8fbf28e639544503b7d1c96452a5e5e043e4108d89b1f3fa02910603622d19db", size = 228292, upload-time = "2026-08-26T14:57:09.846Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1a/26/46da6dd0363c2db2e4876fd59a40fd40c1943a82d7018d0a33afbce47d52/websockets-17.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f612dc57f00c07cf4aa2673f7cbceabd654ad2457b7e639f061b794d6e11f9fd", size = 226722, upload-time = "2026-08-26T14:57:11.118Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/78/98/ecd8f5e1c5d0e54c08ebc5c66852271112166db68107cb0e17ca1bf25009/websockets-17.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1c7ac77401227212dc6e849182feee50d57cf456ec6329ffd6979c94bb136c5c", size = 225451, upload-time = "2026-08-26T14:57:12.601Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/65/4d/da8d2760db53e17aae763738b6ba834b1fcf16813d3632f3edb6951e1ec8/websockets-17.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32a2a68d989d6e5b74a9d5095415c51189ebae29fceb7cf2b64a1c0318a81256", size = 223003, upload-time = "2026-08-26T14:57:13.875Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/40/ea401c141a79c5b1d0021a0dab9d0df2051c108f1620fbb39a6e7c714c3b/websockets-17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:aec00f018d34c67500ff0438dc314b40277be4a1b983cbacbf53ccf7db63e257", size = 225704, upload-time = "2026-08-26T14:57:15.091Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e1/8e/07ab3f44215d89840d5385fdcaaab1fed8caeffa67c6899e15062957c12c/websockets-17.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0014eaff8ad5b3b43feda2279f9d34bf2eaae040720b9fbbb55944b10f40b14d", size = 224192, upload-time = "2026-08-26T14:57:16.3Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/58/93/ccf1af0a23e5748d4e22292a377d78d15cf294d7e707bbb11a8990ae6bd5/websockets-17.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:db9d7ee47f3ba531e278be539af39e2c7c7d28fb94897b6cd1120d63b0ef5922", size = 225082, upload-time = "2026-08-26T14:57:17.531Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e2/db/e32200f99ce282e728d2929f2c429db353cf3282db7d0eba99eb32c9fec1/websockets-17.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:ff3e2ba7a9f0a110b0555452e9b5a03a34e11662544e01beea15f144b48ba7b7", size = 226101, upload-time = "2026-08-26T14:57:18.802Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/3d/e7a6e9777b29433620167c98f3caaff0d6b08b1239a273ef7f7fd1393349/websockets-17.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6da17fc94bd270f5987b10bee113461ac36a36a98b0481ddcc98056e5a90001a", size = 223794, upload-time = "2026-08-26T14:57:20.313Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/48/05/ac569090726dedd6656f3ee28b0c02dfb1ba76e898dceaccc2987a237cef/websockets-17.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:e8dc3fa6d6b7ead3f9de57895f41b116a28787548e066365d9d90f7356bcaad2", size = 224567, upload-time = "2026-08-26T14:57:21.634Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/14/50/4ef62941111db6b31193f4fabbb65f845a5177579040cb8fe0d774d25034/websockets-17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b65d5fe48219dc2d5e158de9e6514e75600f379cc7e37108d35f31764c155566", size = 224993, upload-time = "2026-08-26T14:57:22.86Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/42/2b95ada4ea19bf3a2072b68669ce4f4afb212690b727d31640576287fd68/websockets-17.1-cp314-cp314t-win32.whl", hash = "sha256:2cce251f3e2469b99b6802b55435bcdd07123b41870f54c87b336183af9d7e68", size = 217168, upload-time = "2026-08-26T14:57:24.466Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/32/0a/67d5ee08dd8060a37d612fd40a625b5376ad19ae48fe1c8ad428c278b817/websockets-17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:8f6c38cdcaf98a911d7acc25577f2f9e710f3a2fc2bde1563556784320196b51", size = 217508, upload-time = "2026-08-26T14:57:25.983Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/76/a3/822005d0c674451d2411027b878cdc128a2b7ea5a30d337d9e279da22eba/websockets-17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:d1e2f5fa2b6d01f0d85b4f223fea7ed1d504be282a02a81bd2be4817ef7a2f03", size = 217425, upload-time = "2026-08-26T14:57:27.324Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/d5/99a6c6a1eb5d5ae9f45f59a3c97f4e3b21f310eb404a547fb3e7d2fc054c/websockets-17.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:88381602e379165b66244b2ebc29f9b23ea0851fbe63ae157f91ca324f072d6f", size = 216970, upload-time = "2026-08-26T14:57:28.575Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a6/0e/1e7f6e833728193958d3ed3d67b5d57c3c7cfa948abf94d4bc553257c954/websockets-17.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:88bc5138e53903a85c354e59df7ba73ce306f7b09724cef74dba121e60a88ce2", size = 214699, upload-time = "2026-08-26T14:57:29.862Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/07/00/95d39549f86e34425a0412bcbe61708dd1fc46af654e2134a6c4389102ad/websockets-17.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:3546ef55b3a074494106508bc6505c73825970d2d9505f7bf53882b3e88b0d1e", size = 214927, upload-time = "2026-08-26T14:57:31.148Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4c/ff/b442415fc4f7f9943b0fc8e8eebaa13923ca73361e167c439ba634eecbd9/websockets-17.1-cp315-cp315-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9ae55d24241fc055f22aea3ac924559069848bd0ad4ea065fdd72d2194685fe8", size = 224373, upload-time = "2026-08-26T14:57:32.833Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a8/dd/b83537aae4cf61615b9d8b2dbb235c0030ba85457a6d934798273814600f/websockets-17.1-cp315-cp315-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7b349265fad6244013eecd99df8d83c12bf3013943e431f4fadd5bffc37db42", size = 224801, upload-time = "2026-08-26T14:57:34.041Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/76/83/5ab0abed58454909e8dbab45086ac68ee4556d7a8ada26735addc909b903/websockets-17.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc5789e5ea182b77a38881383ada5347202a6c66f4857d054e075290e80b604b", size = 225967, upload-time = "2026-08-26T14:57:35.292Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4b/26/e2412f2b998a8c1dfc00c0709ff6ee0c634dd0b0b4f92bdfe9667876b71c/websockets-17.1-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ce13c7d233239e739600a57d4a73c1192ad8259e655a4d55aa1a454242bc809d", size = 227664, upload-time = "2026-08-26T14:57:36.493Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/25/0dd4495df3c0e02f6db705312ba85ab9b2dd42257dc23eb0da10066e4844/websockets-17.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1036189bd34b0bc1b10a4679321e2c7968af317efe6e8e4c1c5141c4254fb5bb", size = 226447, upload-time = "2026-08-26T14:57:37.781Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/be/67/6df3f63ffc48f08126ed0cd2fd2a41092967c3e364f8ec100deae90b6d77/websockets-17.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e78fd4b7b2c5086a38671c9c882c1e643385eccea360b5b1fda4a105e590087e", size = 225343, upload-time = "2026-08-26T14:57:39.133Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/8d/a8479bbb09ff054907d141123d8f52fb6ae5ac39c6dbe39e6a02a8408309/websockets-17.1-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:46e7a10bf04318c7b0c0273791925ae5e1cbe4a11e34aa934d2ef27862058a80", size = 222748, upload-time = "2026-08-26T14:57:40.478Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/40/fb/4c3d2a3269cde3f3087916de9c3d9fc5d7196b46846d8c3a9ae59ad0a884/websockets-17.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:33e45c7ea38428e740a7f233555d71df0b875cef7fc080acebc9654475e35335", size = 225453, upload-time = "2026-08-26T14:57:41.859Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/1c/6467b401d19408f34e1c7389c222c2c7e1dfdf08c551190269b5eabc726c/websockets-17.1-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:6e63c01803be425ff062b7f7fc201a74def1d49fc94a2410dd17375df75936e9", size = 224112, upload-time = "2026-08-26T14:57:43.136Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/5f/744e032ac80e11039a7447657ebabb46e9b5c2dbcec83be571335212932f/websockets-17.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:722ec21717eec6477bce582147a28acdfe034e604239466a6a95daedb863e774", size = 224646, upload-time = "2026-08-26T14:57:44.871Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9f/47/bcb9128d9afc4d0934d9192e2a24897ca2f7a63df2654904915349c6c46d/websockets-17.1-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:e74e41f0ad12ff1e8983e349daef79d37cc8280c743ce9d134d6c74c18dab5d6", size = 225797, upload-time = "2026-08-26T14:57:46.338Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c7/e0/b058047b7cf565e1105b10ef6b6b24a6ebe3575678c7dc75a645334705a7/websockets-17.1-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:12fe8984a32dbfd084e0603f1a8d740c0180cb85b3174585c54a80d2455a8394", size = 223605, upload-time = "2026-08-26T14:57:48.175Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b9/69/fc1555bff884de363f1bf9eebf2836dbeb29fa7e4f957debb7bbcf43abba/websockets-17.1-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:01dcb47deebc40b38fd4a493b9b9f4d0a704b7bec6f35e4d34085b329abce71a", size = 224508, upload-time = "2026-08-26T14:57:49.407Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e7/f9/648d4e68621688b19093b06f7b497d520952e68cdea1c1b54371fe9491de/websockets-17.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f4c45ee2512d3757b5e6c67c5a34e435143f2ecb7df3324f9fd888688c45c0f4", size = 224767, upload-time = "2026-08-26T14:57:50.799Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/58/93/f8342b55864f71df13eb8e9ef7dce691b87a87f04f75bb8a1385b3336e7c/websockets-17.1-cp315-cp315-win32.whl", hash = "sha256:0f4f50dfe2cc810fc4e2de979b35e83bf8bb4bccdc6fe472d93762ea7b1d5927", size = 217003, upload-time = "2026-08-26T14:57:52.122Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ea/f0/7b5fdb774c245e0b6217009e2a24d2105c1a64923949f33be41aa7959302/websockets-17.1-cp315-cp315-win_amd64.whl", hash = "sha256:4af784f3e436f65b355c117c6497320f2b5cf6a559295cb1c4c7338e335d45cc", size = 217300, upload-time = "2026-08-26T14:57:53.492Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/76/33/1fe6ed1b5087516115ca451b2c240314b010647071f8fc3bd78a21e4dddb/websockets-17.1-cp315-cp315-win_arm64.whl", hash = "sha256:d58159af7835fde09c462394293c0d7aaf8fb4557d8f8e5699f5e722ccae013d", size = 217214, upload-time = "2026-08-26T14:57:54.88Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/ca/ed02e75996a266d76c5fcb5dd9b930db4cf2b388ca5fa3d2a72086f81568/websockets-17.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1a5cf4e7bbe3ca499e6a289206cb4fcb7444b09919e129bd517f57d5fa192c13", size = 217282, upload-time = "2026-08-26T14:57:56.108Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bd/7d/d536f5bc89ea5b52fd1c1727c59fabafee6bc41f5ce92c3bd2f83047908c/websockets-17.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:416b4bc8789a1865a3ff643ec4ee073a5f52402d0dbeafd27b1798d5dd6b6a51", size = 214863, upload-time = "2026-08-26T14:57:57.355Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/37/944cf17bad668e9be1247e6314f88a48b9faf7c250e383410db8b38af0b9/websockets-17.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:259f45358c76d3b18489e3e80636cdbe807e05ecf1b10fdf1a779106d23d0c8e", size = 215073, upload-time = "2026-08-26T14:57:58.719Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/74/bf/3267966cc1bbc2b8fa62fd329651b0af502df1f5d1c0eed027ff339d6aa8/websockets-17.1-cp315-cp315t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d9d01e8ede41fea4f5a847dad9d628355f74905f437a5b6856d67aa66d193800", size = 225229, upload-time = "2026-08-26T14:58:00.235Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/d8/85ea722f483510abb39fc71aafb4465d17cf9051a275ab036874ff3c300c/websockets-17.1-cp315-cp315t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a7b35181a14cbfcae163b4de545d22abfd07d06c2c41ca69cfcd99251d6888ab", size = 225500, upload-time = "2026-08-26T14:58:01.994Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/50/ce/64c7d00005bd0d15ecb5c5fcb7fb2597b6b92ddd16c4fa6bbc3d2835ad63/websockets-17.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a8e768a048c2220697477ce2e67e4345dc9f693d0ee6af53945b5e30227c6a7", size = 226829, upload-time = "2026-08-26T14:58:03.327Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b4/dc/096c67940fb957e667ca3c542818150434eb0388c6fdc90b3a502f3c3e96/websockets-17.1-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:880069d21cc33a558dcf180924a546d1ecf8ada5be3e4e70acee87019d706a24", size = 228457, upload-time = "2026-08-26T14:58:04.78Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/51/fe/f2331b6b7ccc67589891da354fa46a5cb79e95f83b9fd0e734d77f1f2140/websockets-17.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cec1bb8f22abccc8d20f8ca63df9be41600c26c190f4b97ee86c675fd4a863a6", size = 227265, upload-time = "2026-08-26T14:58:06.102Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/47/a5/fb1642302f8ec77ca922203074f155a9831a5128ad75e725059a476d1227/websockets-17.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f3a1d577e081667dda7f8e5b4796e6e32f9713c93e2a3d930669519840a3c623", size = 226143, upload-time = "2026-08-26T14:58:07.464Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d7/41/7133fcfb63f5562750b269d6a845c689dde6a2c6407286da395beea19ddd/websockets-17.1-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc053f9e95a76213c5eb7ed95779f7daf0d2bf0e4e03073629ebfa43a033f151", size = 223501, upload-time = "2026-08-26T14:58:08.766Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/64/b1/82b36bfabc79ff2d383a1fc043cee6a13f794ef4f6bf1b4810ad6988cf6f/websockets-17.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:bb0efe019480a1c93e168ce96479273aaebd672fc8c350d5eed1e507ababb1b8", size = 226330, upload-time = "2026-08-26T14:58:09.987Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/41/7d/5b511b9bf6e9ad331e6ff902fcbcc71c3794d10ef3b5efe80ccb8f0a7861/websockets-17.1-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:615746b12b26a3fd4077bc6fbeb277a1c192a45dd57b531d07ad9ed5c52a9a7a", size = 224980, upload-time = "2026-08-26T14:58:11.303Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/50/aed08f25301f8eef23be903ff9319fcf35630ca2bdec9d226f7d804dd5b3/websockets-17.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:1a20136d61f9ca3a31493732762661fafc2c20e8861930214e21afc6a8a692a2", size = 225478, upload-time = "2026-08-26T14:58:12.543Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3e/47/0d63d4168536b4682c9d19b7399443b1176f25dbb68878374fa716670230/websockets-17.1-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:2786cbd273ab69c22612db8a41229ddf2c158060b17b5928884bf388d07887f3", size = 226588, upload-time = "2026-08-26T14:58:14.457Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/dd/844bd0b6386fc81ed6a55f4b6dd26f01c6987eda205afa10175ea12b2164/websockets-17.1-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:b1c323fc3be1dc3f87f6c59458cb7d9e13dcbbf971d6c3f3e2bbaf58d3bfcdfe", size = 224336, upload-time = "2026-08-26T14:58:15.778Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/18/03709c84bc88ec4dcea68d4be4ccd07d611073dec111203a5bf45af8809d/websockets-17.1-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:12c8e2b25df59755954a04dfa09c990b96691025aaf7eafd19ed6da24b09c18d", size = 225197, upload-time = "2026-08-26T14:58:17.141Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/cf/0d1c694b6466c89e875b85b32b51312c472cf6708eee91914866f5087dde/websockets-17.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f58f58b4b29bbea2a3635e2c56eff4a3adab011fe383802a9e542e31b97085fc", size = 225493, upload-time = "2026-08-26T14:58:18.521Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4e/f5/99857c3dd9676749f33e3668665a34ad6099505fb8d75eb084f49f7807a9/websockets-17.1-cp315-cp315t-win32.whl", hash = "sha256:f78a3ffb1994304db2c0c4588e4d1a518079b557054fa3bb985a6f5e50ff49a3", size = 217130, upload-time = "2026-08-26T14:58:20.037Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2c/84/77599922ab441bfe61508f97dab2c71f8e114d31793993ea54011db16199/websockets-17.1-cp315-cp315t-win_amd64.whl", hash = "sha256:ad68c28a27246fed109a4409393d677b7e1388345cbbd2f5aee5c182d8506110", size = 217448, upload-time = "2026-08-26T14:58:21.382Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ce/3c/8b9a225b523f06a9389be81f1b0ab07c49bec6014742e6aa359c1f920f1f/websockets-17.1-cp315-cp315t-win_arm64.whl", hash = "sha256:e552e0037230ac16e5f568de7012041344d1b18c9feed30ec2891b8eba55af81", size = 217372, upload-time = "2026-08-26T14:58:22.807Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/41/63/23572870e01836a98346075b9e17a8bc24a6ddd9800a3204ceee58677f3c/websockets-17.1-py3-none-any.whl", hash = "sha256:f221081107b8c48184d99f7019604486376e7ef826037e70aad6b02540732c23", size = 211134, upload-time = "2026-08-26T17:25:31.397Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.9"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.5"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/31/33/ebe9e3d1f86c7a0b51094c0a146392045ca1631d2664889539dec8088a33/yarl-1.24.5.tar.gz", hash = "sha256:e81b83143bee16329c23db3c1b2d82b29892fcbcb849186d2f6e98a5abe9a57f", size = 228679, upload-time = "2026-07-20T02:07:45.435Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e1/63/64ef361967cc983573149dc1515d531db5da8a4c92d22bb833d59e01b313/yarl-1.24.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:79af890482fc94648e8cde4c68620378f7fef60932710fa17a66abc039244da2", size = 135075, upload-time = "2026-07-20T02:05:59.671Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bb/89/55920fd853ce43e608adbc3962456f0d649d6bb15250dc2988321da0fe1c/yarl-1.24.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:46c2f213e23a04b93a392942d782eb9e413e6ef6bf7c8c53884e599a5c174dcb", size = 97225, upload-time = "2026-07-20T02:06:01.769Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/15/f0/7688d3f2cfff7590df2af38ec46d969f4281a4dddb08a9ad2eafbcdddf98/yarl-1.24.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:92ab3e11448f2ff7bf53c5a26eff0edc086898ec8b21fb154b85839ce1d88075", size = 96751, upload-time = "2026-07-20T02:06:03.676Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/05/1a/a851a0f94aaaf379dd4f901bfc80f634280bec51eb260b47363e2a4cd62e/yarl-1.24.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ebb0ec7f17803063d5aeb982f3b1bd2b2f4e4fae6751226cbd6ba1fcfe9e63ff", size = 107960, upload-time = "2026-07-20T02:06:05.699Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6c/a8/faea066c12f9c77ca0de90641f1655f9dd7b412477bf28c76d692f3aecff/yarl-1.24.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:82632daed195dcc8ea664e8556dc9bdbd671960fb3776bd92806ce05792c2448", size = 103500, upload-time = "2026-07-20T02:06:07.556Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fb/9c/1e67084c2a6e2f2db0e3be798328cb3be42c0119b621d25461479a224d21/yarl-1.24.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:53e549287ef628fecba270045c9701b0c564563a9b0577d24a4ec75b8ab8040f", size = 115780, upload-time = "2026-07-20T02:06:09.599Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/58/86/1f94664e147474337e3359f52012cf3d02f825f694317b178bfba1078c62/yarl-1.24.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fcd3b77e2f17bbe4ca56ec7bcb07992647d19d0b9c05d84886dcd6f9eb810afd", size = 115308, upload-time = "2026-07-20T02:06:11.352Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0a/43/8e55ae7538ba5f28ccb3c845c6dd4549cf7016d5992e5326512519107cdd/yarl-1.24.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d46b86567dd4e248c6c159fcbcdcce01e0a5c8a7cd2334a0fff759d0fa075b16", size = 110574, upload-time = "2026-07-20T02:06:13.129Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ce/ba/a889ec8765cedcf2ac44dcb02d6a21e4861399b243b263c5f2dde27ee740/yarl-1.24.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7f72c74aa99359e27a2ee8d6613fefa28b5f76a983c083074dfc2aaa4ab46213", size = 109914, upload-time = "2026-07-20T02:06:15.243Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9c/c3/e45f821af67b791c2dbbe4a9f4137a1d33f8d386654a05a0c3f47bdfa25d/yarl-1.24.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3f45789ce415a7ec0820dc4f82925f9b5f7732070be1dec1f5f23ec381435a24", size = 107712, upload-time = "2026-07-20T02:06:17.443Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/02/00/2ab0f42c9857fcb490bfaa6647b14540b53d241ab209f23220b958cc5832/yarl-1.24.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:6e73e7fe93f17a7b191f52ec9da9dd8c06a8fe735a1ecbd13b97d1c723bff385", size = 104251, upload-time = "2026-07-20T02:06:19.259Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7a/70/709d9a286e98af2c7fd8e4e6cada658b5c0e30d87dd7e2a63c2fb5767217/yarl-1.24.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4a36f9becdd4c5c52a20c3e9484128b070b1dcfc8944c006f3a528295a359a9c", size = 115319, upload-time = "2026-07-20T02:06:21.207Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5c/6c/3eaa515142991fe84cfc483ff986492211f1978f90161ccefdbec919d09b/yarl-1.24.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:7bcbe0fcf850eae67b6b01749815a4f7161c560a844c769ad7b48fcd99f791c4", size = 109163, upload-time = "2026-07-20T02:06:23.006Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bb/64/711dafce66c323a3144d470547a71c5384c57623308ac8bb5e4b903ac148/yarl-1.24.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:24e861e9630e0daddcb9191fb187f60f034e17a4426f8101279f0c475cd74144", size = 115435, upload-time = "2026-07-20T02:06:24.923Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cf/f3/9b9d0e6d84bea851eb1ba99e4bdc755b86fd813e49ec86dfe42f26befdef/yarl-1.24.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9335a099ad87287c37fe5d1a982ff392fa5efe5d14b40a730b1ec1d6a41382b4", size = 110691, upload-time = "2026-07-20T02:06:26.973Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/86/e4/62a06b7e87c4246ac76b7c2da136f972eb4a3a1fc94abb07e7022d6fdb0a/yarl-1.24.5-cp313-cp313-win_amd64.whl", hash = "sha256:2dbe06fc16bc91502bca713704022182e5729861ae00277c3a23354b40929740", size = 97454, upload-time = "2026-07-20T02:06:29.163Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9e/c9/5fc8025b318ab10db413b61056bd0d95c557a70e8df4210c7511f866329c/yarl-1.24.5-cp313-cp313-win_arm64.whl", hash = "sha256:6b8536851f9f65e7f00c7a1d49ba7f2be0ffe2c11555367fc9f50d9f842410a1", size = 92813, upload-time = "2026-07-20T02:06:31.113Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/08/5f3085fef9564217074db9dd8573de1795bc82cde61a7ad10b6a7234a569/yarl-1.24.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2729fcfc4f6a596fb0c50f32090400aa9367774ac296a00387e65098c0befa76", size = 135680, upload-time = "2026-07-20T02:06:33.273Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ff330d3c30db4eb6b01d79e29d2d0b407a7ecad39cfd9ec993ece57396a2ec0d", size = 97395, upload-time = "2026-07-20T02:06:35.259Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/a9/a07f76f3c44e02b25cc743af5ef93eef27f7013eadca770451b6a6ccb5db/yarl-1.24.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e42d75862735da90e7fc5a7b23db0c976f737113a54b3c9777a9b665e9cbff75", size = 97223, upload-time = "2026-07-20T02:06:37.216Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/77/f7/a9a1d6fa7dd9e388f95b30f6ad3ec4e285f6c8f61f44ce16070c3fcfe414/yarl-1.24.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3732e66413163e72508da9eff9ce9d2846fde51fae45d3605393d3e6cd303e9", size = 108777, upload-time = "2026-07-20T02:06:39.292Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2f/44/e0b86c302471fabd6f02808ecf2ac52b8412b624787849d4bf2cdb466f6f/yarl-1.24.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5b8ee53be440a0cffc991a27be3057e0530122548dbe7c0892df08822fce5ede", size = 103119, upload-time = "2026-07-20T02:06:41.456Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/16/9c16d180bf8faaf223225eb50e1245870ff1ae0e302a27153988e65c51fd/yarl-1.24.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:af3aefa655adb5869491fa907e652290386800ae99cc50095cba71e2c6aefdca", size = 116471, upload-time = "2026-07-20T02:06:43.696Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d2/8d/b219b9df28a02ce95cfbdd41d2f7caa5669d0ff979c1c9975697145e33c5/yarl-1.24.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2120b96872df4a117cde97d270bac96aea7cc52205d305cf4611df694a487027", size = 115974, upload-time = "2026-07-20T02:06:45.874Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9b/e8/f20557aca240d88e69850ad1ee91756821d094bb1310565c04d25c6682a2/yarl-1.24.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:66410eb6345d467151934b49bfa70fb32f5b35a6140baa40ad97d6436abea2e9", size = 110830, upload-time = "2026-07-20T02:06:47.852Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/db/18/199b85109a53eeca64ee19c9cca228287e8e4ab0cc1a09b28f530e65cce0/yarl-1.24.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4af7b7e1be0a69bee8210735fe6dcfc38879adfac6d62e789d53ba432d1ffa41", size = 110054, upload-time = "2026-07-20T02:06:49.84Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/2f/ed28147f8cd7f48c49367c90713b30a555284b6105a6a56f3a05568da795/yarl-1.24.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa139875ff98ab97da323cfadfaff08900d1ad42f1b5087b0b812a55c5a06373", size = 108312, upload-time = "2026-07-20T02:06:51.835Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/c5/55e16ae0a5c227cea8df1c6871ba57d614a34243146c05729caf2a1bd9c5/yarl-1.24.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0055afc45e864b92729ac7600e2d102c17bef060647e74bca75fa84d66b9ff36", size = 103662, upload-time = "2026-07-20T02:06:54.061Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8d/ea/dbd7c2caec459c9a426f18b02688ecbfb58620d0f6a3422d24769fbaf8ab/yarl-1.24.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f0e466ed7511fe9d459a819edbc6c2585c0b6eabde9fa8a8947552468a7a6ef0", size = 116090, upload-time = "2026-07-20T02:06:56.015Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/06/84/39ce4ce3059e07fece5fbdbee8c4053406af9aca911ce9fa5f8548aab6af/yarl-1.24.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f141474e85b7e54998ec5180530a7cda99ab29e282fa50e0756d89981a9b43c5", size = 109523, upload-time = "2026-07-20T02:06:57.926Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/8b/71ff44137b405c64a7788075669c24010019f57a7464b78c3a6cbee539d9/yarl-1.24.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:e2935f8c39e3b03e83519292d78f075189978f3f4adc15a78144c7c8e2a1cba5", size = 116084, upload-time = "2026-07-20T02:06:59.868Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/62/c0/423078fdd4042e1862c11f0ffd977a0ffa393783c12bee94685923bc189e/yarl-1.24.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9d1216a7f6f77836617dba35687c5b78a4170afc3c3f18fc788f785ba26565c4", size = 111006, upload-time = "2026-07-20T02:07:01.907Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cf/52/6daa2ee9d95e5c98b8128f8df91eb692eb423ab274b8cf08db52152fad26/yarl-1.24.5-cp314-cp314-win_amd64.whl", hash = "sha256:5ba4f78df2bcc19f764a4b26a8a4f5049c110090ad5825993aacb052bf8003ad", size = 99215, upload-time = "2026-07-20T02:07:03.852Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ec/0e/464a847d7359e0da75dd9fc5c1d1aa35d0159ea31e5f8e66a3c1c29ff3d0/yarl-1.24.5-cp314-cp314-win_arm64.whl", hash = "sha256:9e4e16c73d717c5cf27626c524d0a2e261ad20e46932b2670f64ad5dde23e26f", size = 94566, upload-time = "2026-07-20T02:07:06.074Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e2/55/e03acc4446772660bc335e86e41ef31e4d0d838fd641531a11a5ee33b493/yarl-1.24.5-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e1ae548a9d901adca07899a4147a7c826bbcc06239d3ce9a59f57886a28a4c88", size = 142533, upload-time = "2026-07-20T02:07:08.284Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ae/71/4acd3a1fc7cf14345cdb302665ecd2097f62c365b4f14ca17d4f37775cf9/yarl-1.24.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ff405d91509d88e8d44129cd87b18d70acd1f0c1aeabd7bc3c46792b1fe2acba", size = 100776, upload-time = "2026-07-20T02:07:10.197Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ff/0b/cfb76b7fe99686db264bff829779a539d923e7564ffd7ef18da6c54c3774/yarl-1.24.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:47e98aab9d8d82ff682e7b0b5dded33bf138a32b817fcf7fa3b27b2d7c412928", size = 100913, upload-time = "2026-07-20T02:07:12.357Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/3f/7116e782992abbd4fb6948488aec72078895e929a23078290739e8396fce/yarl-1.24.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f0a658a6d3fafee5c6f63c58f3e785c8c43c93fbc02bf9f2b6663f8185e0971f", size = 106507, upload-time = "2026-07-20T02:07:14.173Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/33/90/d4d2d73ee78229cc889872eb8e085d8f5c6f51abdb178409fd9b23cf74fd/yarl-1.24.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4377407001ca3c057773f44d8ddd6358fa5f691407c1ba92210bd3cf8d9e4c95", size = 99219, upload-time = "2026-07-20T02:07:16.019Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3e/fa/a6df1a9bccd644eec00abee0dff4277416222cec435330fd1f2858523ec1/yarl-1.24.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7c0494a31a1ac5461a226e7947a9c9b78c44e1dc7185164fa7e9651557a5d9bc", size = 111804, upload-time = "2026-07-20T02:07:18.141Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8a/9e/7b2a1f4bcc20e9447156dd2b1c4d01f70d9df0759025ee7d09a84ffae134/yarl-1.24.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a7cff474ab7cd149765bb784cf6d78b32e18e20473fb7bda860bce98ab58e9da", size = 110943, upload-time = "2026-07-20T02:07:20.06Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/08/ff/22c92affb0f9b623ca753d27d968b5625b868f12c6378d049d55ae247643/yarl-1.24.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbb833ccacdb5519eff9b8b71ee618cc2801c878e77e288775d77c3a2ced858a", size = 108251, upload-time = "2026-07-20T02:07:22.217Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/44/5769b96298c1e195fb412997b6090af2a84105cf59c17613558a2d011d1f/yarl-1.24.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:82f75e05912e84b7a0fe57075d9c59de3cb352b928330f2eb69b2e1f54c3e1f0", size = 106025, upload-time = "2026-07-20T02:07:24.083Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4c/40/009e8e791fd9762c0e1567e69248acb4f49064597e1680874c16dd8bb798/yarl-1.24.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:16a2f5010280020e90f5330257e6944bc33e73593b136cc5a241e6c1dc292498", size = 106573, upload-time = "2026-07-20T02:07:26.248Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/20/c6/b7480578f8a0a80946f36ad6df547ecec704f9ba69d2de60f8aa6f1c1cbf/yarl-1.24.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:ffcd54362564dc1a30fb74d8b8a6e5a6b11ebd5e27266adc3b7427a21a6c9104", size = 100751, upload-time = "2026-07-20T02:07:28.098Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d4/27/4476f3360b91a48c5cf125e91f59a3bd35299d84a431a258d57f5977bb11/yarl-1.24.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0465ec8cedc2349b97a6b595ace64084a50c6e839eca40aa0626f38b8350e331", size = 111643, upload-time = "2026-07-20T02:07:30.88Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4c/4b/5cdd3e5ee944e8af31e52f6cd3d3af5fd7b937e036ccbbba2c9ffebede95/yarl-1.24.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4db9aecb141cb7a5447171b57aa1ed3a8fee06af40b992ffc31206c0b0121550", size = 106312, upload-time = "2026-07-20T02:07:33.06Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/18/86/f406b0c2a6f99575de2da671ef47aa06f89a5be83a27a46971c3b86cecdb/yarl-1.24.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:f540c013589084679a6c7fac07096b10159737918174f5dfc5e11bf5bca4dfe6", size = 110379, upload-time = "2026-07-20T02:07:35.155Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/6c/9f3adfbd3b30b4fa0f7ccb3a83eba2c1152d3fff554d535e640ba0f7ba2b/yarl-1.24.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a61834fb15d81322d872eaafd333838ae7c9cea84067f232656f75965933d047", size = 108497, upload-time = "2026-07-20T02:07:37.35Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dd/37/91eb2e5ca883a529c1b390348a74cd9fc0512171727f547ce70bfe02be5c/yarl-1.24.5-cp314-cp314t-win_amd64.whl", hash = "sha256:5c88e5815a49d289e599f3513aa7fde0bc2092ff188f99c940f007f90f53d104", size = 102450, upload-time = "2026-07-20T02:07:39.578Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/bf/f4/ed5c402ac8fde4403ed3366c2716bfddc8a6677ebd59f3d62772cc7fe468/yarl-1.24.5-cp314-cp314t-win_arm64.whl", hash = "sha256:cf139c02f5f23ef6532040a30ff662c00a318c952334f211046b8e60b7f17688", size = 97222, upload-time = "2026-07-20T02:07:41.55Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/02/962c1cbfc401a30c1d034dc67ff395f64b52302c6d62de556c1fca99acc0/yarl-1.24.5-py3-none-any.whl", hash = "sha256:a33700d13d9b7d84fd10947b09ff69fb9a792e519c8cb9764a3ca70baa6c23a7", size = 58612, upload-time = "2026-07-20T02:07:43.461Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]


### PR DESCRIPTION
## 这是什么

两轮工作的合并：**第一轮**逐项修复架构审查确认的问题（安全信任边界 → 可靠性/数据一致性 → 工程化护栏），**第二轮**对第一轮的 46 个提交做对抗性 code review（5 个独立子代理并行：安全 / 数据一致性 / 异步并发 / 测试质量 / 集成回归），再修复复查发现的真实缺陷。

共 **64 个提交**，每个提交修一个问题，遵守约定式提交，提交前跑针对性 pytest / ruff。

## ⚠️ 合入前请先看：尚未处理的复查结论

第二轮安全审查给出 **2 个 blocker + 3 个 major**，其中 blocker 已全部修复；以下 3 条 major 仍未修（需要设计决策，本次按你的要求暂停）：

| 项 | 问题 | 位置 |
|---|---|---|
| SSRF | web_search 抓取只校验不钉扎：`validate_public_url_async` 解析一次、`client.get` 再解析一次 → DNS rebinding 可绕；同仓 `agent_tools/web.py` 已有 `_pinned_url` 正确写法可参考 | `app/src/neobot_app/web_search/session.py:330-349` |
| 本地适配器 | 只比对 Authorization/`?token=`，无 Origin 校验且 `request.json()` 不校验 Content-Type → 恶意网页可用 text/plain 简单请求跨站打 `/v1/send` 等；非回环监听 + token 留空时完全可达 | `packages/adapter/src/neobot_adapter/local/server.py:120-128` |
| 非 ASCII token | `hmac.compare_digest(str, str)` 遇非 ASCII 抛 TypeError（fail-closed，但每次打 traceback） | `onebot/receiver/core.py:339`、`dashboard/security.py:118` |

另有 4 条**测试证据缺口**（helper 有测试、生产接线没有）：反向 WS `_run_server` 是否注册 `process_request`、bootstrap 是否真在迁移前备份、浏览器僵尸流是否真被后台循环回收，以及 1 条「移除整套停机机制后仍通过」的假测试。

## 第二轮修复（18 个提交）

**Blocker**
- `b5816e1` 回复结束释放执行器时不再取消在途**会话工具**（`download__url`/`parse_image` 契约就是「后台执行、完成自动通知」；私聊挂起窗 300s < 工具超时 300–1800s，原先结果与通知永不产生）
- `62d5d49` `read_archive` 的 `items` 批量模式逐项校验 `allowed_tables`（原先顶层表名合法即可读任意表全文）
- `92a2ae8` 脱敏统一：模型侧补裸 `sk-`、日志侧修 `\b` 词边界导致的 `DEEPSEEK_APIKEY=`/`client_secret=` 漏项、补 URL userinfo 与无分隔符形态、`skills/base.py` 不再写未脱敏原文、**控制台 sink 挂上 filter**

**本轮引入的回归 / major**
- `ea82602` 「回复中」标记按归属设置，拒绝启动时不再误删运行中管线的标记
- `a166919` config.toml 的 token 不再回明文（结构化/schema/原文三份副本都脱敏，只读会话连原文一起屏蔽；保存时按分区+键还原，TOML 模式仍可用）
- `9bf2615` 计数器解析缓存加 30s TTL（修「外部删除被陈旧 blob 复活」）
- `08969d9` 表数组（`[[models.registry]]` 等）元素里的未知键不再被表单保存抹掉
- `327dc5e` 原子写对 Windows 句柄占用做短退避重试，并合并重复实现
- `3b944ce` 维护周期/临时清理加进程内互斥（搬进线程池后失去事件循环隐式串行）
- `f021221` 孤儿临时文件清理移出变更门、按 mkstemp 形态精确匹配、跳过 junction
- `9e296ac` 维护/清理拿到真实 logger（此前 `.logger` 是死属性，全程 `NullLogger`，静默失败不可见）

**安全与可用性**
- `3128159` XFF 取**最右**一项：客户端不能再伪造 `X-Forwarded-For: 127.0.0.1` 抢设面板密码
- `42720f3` 反向代理下登录不再被 Origin 校验打死（+ nginx 需透传的头写进部署文档）
- `056f950` 档案提示词与工具表一致（不再宣传被隐藏的 `delete_archive`）
- `5069769` 被 `min_neobot_version` 拒绝的插件仍可在面板停用/重载，来源判定不再误判
- `1999496` 无控制台环境（pythonw/PyInstaller）`print` 不再抛 AttributeError，补 `writelines`
- `632653e` CI `--locked` + pytest `--strict-markers`，订正失效的注释
- `08f57f3` 新测试里的假密钥改为拼接构造，避免触发仓库密钥扫描

## 第一轮修复（46 个提交，摘要）

- **安全**：反向 WS access token 握手校验（OneBot 11 规范，兼容新旧 websockets 签名）、local 适配器 `local_auth_token` 贯通、面板登录/首设密码跨站防护、插件依赖安装移出事件循环并校验条目、web_search 抓取前 SSRF 校验、绘图本地图片读取加固、archive `allow_delete`/`allowed_tables` 真正生效、工具错误详情不再被销毁（且回传前脱敏）、迁移 0021 前自动快照数据库、插件 `min_neobot_version` 校验
- **数据一致性**：UoW.commit 去掉会静默丢写入的重试分支、配置解析失败不再用默认值覆盖用户配置、`.env` 备份不再与 config.toml 混池、面板保存不再删掉不认识的键/不再被既有额外键拦死、队列权重账本口径统一、图片意愿等待失败不再滞留消息、通知取消回队、工具执行器不再泄漏、插件数据库 ERROR 路径关闭
- **并发/性能**：多处「假 async」真正移出事件循环（沙箱文件操作、图片预处理、压缩、维护周期）、插件输出捕获改按任务路由（去掉进程级 stdout 重定向）
- **工程化**：ruff 配置 + 清理、CI（测试与 ruff 阻断、mypy 观察）、提交 `uv.lock`、测试状态隔离（消除顺序相关假失败）、删除 `EventPipeline` 重复订阅入口

## 验证

- `ruff check .` → **All checks passed!**
- `pytest --strict-markers -m "not browser and not network and not slow and not llm"` → **2897 passed, 10 skipped, 17 failed**
  - 17 个失败全部为**本机缺 `onnxruntime`/`ultralytics`/`playwright`** 的环境性失败（16 vision_detect + 1 chromium），与改动无关（CI 全新环境不受影响）
- 每个提交各自跑了对应模块的定向测试；新测试尽量做到「回退该修复即失败」（第二轮 review 用变异测试验证了这一点，并据此补齐了多处不足）

## Review 过程

5 个独立子代理并行只读审查（安全 / 数据一致性 / 异步并发 / 测试质量 / 集成回归），全程未改动仓库；测试质量那路用 `git clone` 到临时目录做**变异测试**（回退源码后跑新测试，确认能抓到回归），并做了 120 次重复运行排查 flake。审查产物（复现脚本、变异日志）都在系统临时目录，未进入仓库。

## 已知取舍

- 面板保持出厂默认 `host = "0.0.0.0"` + `secure_cookies = false`（已加启动告警与文档说明），未改为仅本机
- 损坏的 `config.toml` 现在**拒绝启动并保持原文件不动**（原先会用默认值静默覆盖）——行为变更，已在文档与启动错误信息中说明
- `delete_archive` 默认被拒且不注入给模型，需 `agent.memory.archive.allow_delete=true`
- 结构性债务（`ReplyOrchestrator` 3768 行、`create_application()` 约 700 行手工装配、26/40 个从未被导入的僵尸 Ports、共享默认线程池饥饿、技能层残留阻塞 IO）按约定记录未改
