### PR TITLE
fix(ci): 修复前端 job 的 pnpm 版本读取与密钥扫描误报

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,12 @@ jobs:
       - name: 检出仓库
         uses: actions/checkout@v7
 
+      # 版本取自前端的 package.json#packageManager：仓库根目录没有 package.json，
+      # 不显式指定文件时 action 会直接报 "No pnpm version is specified"。
       - name: 安装 pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package-json-file: app/src/neobot_app/builtin_plugins/dashboard/frontend/package.json
 
       - name: 安装 Node
         uses: actions/setup-node@v4

--- a/.secretsignore
+++ b/.secretsignore
@@ -17,3 +17,15 @@ sk-filetrace12345678xyz
 sk-excluded-ok
 sk-deepseek-test-1234567890
 sk-malformed-must-not-be-logged
+# 误报：Tailwind CSS v4 生成的 mask-image-* 工具类名，出现在入库产物
+# app/src/neobot_app/builtin_plugins/dashboard/web/assets/*.js 里，
+# 形态恰好匹配 sk-[A-Za-z0-9_-]{20,}，已逐个核对，不是密钥。
+sk-image-conic-from-color
+sk-image-conic-from-pos
+sk-image-conic-to-color
+sk-image-linear-from-color
+sk-image-linear-from-pos
+sk-image-linear-to-color
+sk-image-radial-from-color
+sk-image-radial-from-pos
+sk-image-radial-to-color


### PR DESCRIPTION
## 问题

PR #32 合并后 `main` 上的 CI 仍然失败，两处都不是业务代码问题：

1. **前端 job 起不来**：`pnpm/action-setup@v4` 在仓库根目录找 `package.json` 读 `packageManager`，而本仓库根目录没有 `package.json`（前端在 `dashboard/frontend/`），因此直接报 `Error: No pnpm version is specified`，后续 lint / typecheck / test / build 一步没跑。
2. **密钥扫描误报**：`app/tests/modules/security/test_repo_secrets.py` 在入库产物 `dashboard/web/assets/index-DzrGv2cX.js:257` 命中 9 处 "OpenAI/兼容平台 Key"，实际是 Tailwind CSS v4 生成的 `mask-image-*` 工具类名，形态恰好匹配 `sk-[A-Za-z0-9_-]{20,}`。

## 改动

- `.github/workflows/ci.yml`：`pnpm/action-setup@v4` 显式指定 `package-json-file` 为前端 `package.json`，从而取到 `pnpm@12.3.4`。
- `.secretsignore`：补充这 9 条已逐个核对过的类名，并注明来源，避免误报阻断 CI。

## 验证

- `python scripts/check_secrets.py`（全仓库跟踪文件）→ 0 命中。
- 前端本地：`pnpm run lint` / `typecheck` / `test`（37 项）/ `build` 均通过。

## 已知遗留（非本 PR 引入）

`app/tests/test_agent_tools_processes.py::test_process_tree_reaped_even_after_parent_exit[True]` 在 `main` 的既有运行（#31 合并后的 push run）中同样失败，属存量问题，本 PR 未触碰。
