### PR TITLE
ci: 拆分 PR 检查与合并后自动发布工作流

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,15 @@
 name: CI
 
-# 每次推送到 main / 每个 PR：先跑静态检查，再跑测试。
+# PR 代码审查；也供合并后的发布工作流复用，确保发布代码通过检查。
 # browser / network / slow / llm 四个标记用于隔离依赖外部环境的用例；当前仓库里
 # 只有 browser 有实际用例，新增真实网络/真实 LLM 用例时请务必打上对应标记，
 # 否则它们会进入 CI 默认集合（--strict-markers 会拦下拼错的标记名）。
 on:
-  push:
-    branches: [main]
   pull_request:
+  workflow_call:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -29,6 +28,9 @@ jobs:
 
       - name: 安装依赖（全部工作区包 + dev 组，严格用锁文件）
         run: uv sync --all-packages --locked
+
+      - name: 发布版本逻辑回归测试（阻断）
+        run: uv run --no-project --python 3.13 --with packaging python -m unittest discover -s scripts -p 'test_prepare_release.py' -v
 
       - name: ruff（阻断）
         run: uv run ruff check .
@@ -58,9 +60,11 @@ jobs:
 
       - name: 安装 pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: app/src/neobot_app/builtin_plugins/dashboard/frontend/package.json
 
       - name: 安装 Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -84,7 +88,7 @@ jobs:
       # web/ 是入库产物：构建后若与提交内容有差异，说明改了源码没重新构建。
       - name: 校验构建产物已同步（阻断）
         run: |
-          if ! git diff --quiet -- ../web; then
+          if [ -n "$(git status --porcelain --untracked-files=all -- ../web)" ]; then
             echo "::error::web/ 构建产物与源码不一致，请在 frontend 目录执行 pnpm run build 并提交产物。"
             git --no-pager diff --stat -- ../web
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,107 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+
+# Never cancel a release while it is uploading multiple workspace packages.
+concurrency:
+  group: pypi-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  merged-pr:
+    name: 确认 main 推送来自已合并 PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      merged: ${{ steps.pr.outputs.merged }}
+    steps:
+      # Use push rather than pull_request.closed so merged fork PRs also receive
+      # the trusted main-branch token/secrets. Direct pushes do not publish.
+      - uses: actions/github-script@v8
+        id: pr
+        with:
+          script: |
+            const prs = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+              ...context.repo,
+              commit_sha: context.sha,
+            });
+            const merged = prs.some(pr => pr.merged_at &&
+              pr.base.ref === 'main' && pr.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}` &&
+              pr.merge_commit_sha === context.sha);
+            core.setOutput('merged', String(merged));
+
+  checks:
+    name: 合并后质量门禁
+    needs: merged-pr
+    if: needs.merged-pr.outputs.merged == 'true'
+    uses: ./.github/workflows/ci.yml
+
+  publish:
+    name: 检测版本、构建并发布
+    needs: checks
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: astral-sh/setup-uv@v10.0.1
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: app/src/neobot_app/builtin_plugins/dashboard/frontend/package.json
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: app/src/neobot_app/builtin_plugins/dashboard/frontend/pnpm-lock.yaml
+
+      - name: 检查发布凭据
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
+        run: |
+          if [ -z "$UV_PUBLISH_TOKEN" ]; then
+            echo '::error::请在 pypi environment 或仓库 secrets 配置 UV_PUBLISH_TOKEN'
+            exit 1
+          fi
+
+      - name: 查询 PyPI 并同步工作区版本
+        id: version
+        run: uv run --no-project --python 3.13 --with packaging python scripts/prepare_release.py
+
+      - name: 更新 Python 锁文件
+        run: uv lock
+
+      - name: 构建与发布预检（不上传）
+        shell: pwsh
+        run: ./scripts/publish.ps1 -DryRun
+
+      # Persist the chosen version first. A protected-branch or concurrent-push
+      # rejection must fail BEFORE uploading, never force-push over newer code.
+      - name: 回写版本和锁文件
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add pyproject.toml app/pyproject.toml packages/*/pyproject.toml uv.lock
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: release ${RELEASE_VERSION}"
+          fi
+          git push origin HEAD:main
+
+      - name: 上传已验证的产物（已存在的文件由 check-url 跳过）
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
+        run: uv publish --publish-url https://upload.pypi.org/legacy/ --check-url https://pypi.org/simple/ dist/*

--- a/scripts/RELEASING.md
+++ b/scripts/RELEASING.md
@@ -1,0 +1,40 @@
+# 检查与发布
+
+## GitHub Actions
+
+- `.github/workflows/ci.yml`：PR 的 Python 静态检查/测试、发布版本逻辑测试、前端 lint/类型/测试/构建及入库产物一致性检查；同时可由发布工作流复用。
+- `.github/workflows/publish.yml`：main 推送后通过 GitHub API 确认该提交来自合并 PR（支持 merge/squash/rebase），直接推送不发布。对合并提交重新运行 CI，通过后才检测版本、构建和上传。
+- pnpm Action 显式读取前端目录的 `package.json`，不再在仓库根目录寻找 `packageManager`。Node 使用 22，setup-node 使用 v6。
+
+### 首次配置
+
+1. 创建 GitHub environment `pypi`（可配置审批、仅允许 main 部署）。
+2. 在该 environment 或仓库 Secrets 中添加 `UV_PUBLISH_TOKEN`，需有全部 7 个工作区发布包的上传权限。根项目 `neobot` 没有 build-system，不上传。
+3. 允许发布 job 的 `GITHUB_TOKEN` 写入 main：工作流会提交版本和 `uv.lock`。若分支保护不允许机器人直接提交，需要先调整发布权限/规则，否则工作流会在上传前失败；不会强推或绕过保护。
+
+### 版本策略
+
+`scripts/prepare_release.py` 查询每个可发布包的 PyPI release 历史（含预发布），统一更新根项目和所有工作区成员的 `project.version`。
+
+- 本地版本必须一致。如果本地版本高于全部已发布版本，使用本地版本。
+- 否则取本地/PyPI 最大版本并递增：如 `1.0.0a22` → `1.0.0a23`；稳定版 `1.2.3` → `1.2.4`。不自动把 alpha 转成正式版。
+- 不支持 dev/post/local 版本时直接失败，避免错误递增。PyPI 只有 404 视为新包；网络错误、鉴权/服务错误、无效响应均中止，不猜测版本。
+- 更新 `uv.lock`，完成前端和 Python 构建/发布预检后，先提交版本再上传。并发 main 更新导致非快进推送时会中止，绝不覆盖新提交。
+- 上传使用 `uv publish --check-url`，跳过已存在的文件。版本回写使用 GITHUB_TOKEN，不会递归触发新工作流。
+
+若上传部分失败，可在包含已回写版本的最新 main 上运行下面的本地发布脚本，补齐同一版本缺失文件。不要盲目重跑旧提交：旧运行的版本回写可能因 main 已前进而被拒绝。多个 main 推送的等待运行受 GitHub concurrency 队列规则影响，最新合并会包含前面合并的代码。
+
+## 本地发布
+
+要求已安装 uv、Node 22 和前端 `package.json` 指定的 pnpm。
+
+```powershell
+# 无需 token，不上传；依然执行完整构建并联网检查 PyPI 已有文件
+./scripts/publish.ps1 -DryRun
+
+# 上传当前仓库版本（本地脚本不会自动改版本）
+$env:UV_PUBLISH_TOKEN = '你的 PyPI API token'
+./scripts/publish.ps1
+```
+
+脚本可从任意目录调用；依次执行 `pnpm install --frozen-lockfile`（本仓库对应 `npm ci` 的操作）、lint、typecheck、test、build，再清理 dist、构建全部 Python 包并发布。任何步骤失败都会中止。`dist/` 是本次构建的输出目录。

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -1,0 +1,179 @@
+"""Choose one workspace release version; run with uv --no-project --with packaging.
+
+No pyproject is written until every local file and every PyPI response is valid.
+Only static project.version string values are changed, not dependency constraints.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+from dataclasses import dataclass
+from http.client import HTTPException
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import tomllib
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import urlopen
+
+from packaging.version import InvalidVersion, Version
+
+
+class ReleaseError(ValueError):
+    """Release preparation is unsafe; leave the project unchanged."""
+
+
+def parse_version(value: str, source: str) -> Version:
+    try:
+        version = Version(value)
+    except (InvalidVersion, TypeError) as exc:
+        raise ReleaseError(f"Invalid version in {source}: {value!r}") from exc
+    if version.dev is not None or version.post is not None or version.local is not None:
+        raise ReleaseError(f"Unsupported dev/post/local version in {source}: {value}")
+    return version
+
+
+@dataclass(frozen=True)
+class Project:
+    path: Path
+    text: str
+    data: dict
+    name: str
+    version: Version
+    publishable: bool
+
+
+def load_projects(root: Path) -> list[Project]:
+    paths = [root / "pyproject.toml", *sorted(root.glob("packages/*/pyproject.toml"))]
+    app = root / "app" / "pyproject.toml"
+    if app.exists():
+        paths.append(app)
+    projects = []
+    for path in paths:
+        try:
+            # Preserve CRLF and all formatting outside the version literal.
+            text = path.read_bytes().decode("utf-8")
+            data = tomllib.loads(text)
+            name = data["project"]["name"]
+            raw_version = data["project"]["version"]
+            if not isinstance(name, str) or not name.strip() or not isinstance(raw_version, str):
+                raise ReleaseError(f"Missing static project name/version in {path}")
+            if "version" in data["project"].get("dynamic", []):
+                raise ReleaseError(f"Dynamic project.version is not supported: {path}")
+            version = parse_version(raw_version, str(path))
+        except (OSError, UnicodeError, tomllib.TOMLDecodeError, KeyError, TypeError) as exc:
+            raise ReleaseError(f"Cannot load {path}: {exc}") from exc
+        projects.append(Project(path, text, data, name, version, "build-system" in data))
+    if any(project.version != projects[0].version for project in projects):
+        raise ReleaseError("Local project versions are not synchronized")
+    return projects
+
+
+def published_versions(name: str) -> list[Version]:
+    url = f"https://pypi.org/pypi/{quote(name, safe='')}/json"
+    try:
+        with urlopen(url, timeout=30) as response:
+            status = response.status
+            if status == 404:
+                return []
+            if status != 200:
+                raise ReleaseError(f"Unexpected HTTP status {status} from {url}")
+            payload = json.load(response)
+    except HTTPError as exc:
+        if exc.code == 404:
+            return []
+        raise ReleaseError(f"PyPI HTTP failure for {name}: {exc.code}") from exc
+    except (URLError, OSError, HTTPException, ValueError) as exc:
+        raise ReleaseError(f"Cannot query PyPI for {name}: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("releases"), dict):
+        raise ReleaseError(f"Invalid PyPI releases JSON for {name}")
+    versions = []
+    for value, files in payload["releases"].items():
+        if not isinstance(files, list):
+            raise ReleaseError(f"Invalid PyPI release entry for {name}: {value}")
+        # Include prereleases, yanked releases and empty release lists: never reuse a version.
+        versions.append(parse_version(value, f"PyPI {name}"))
+    return versions
+
+
+def choose_version(local: Version, published: list[Version]) -> Version:
+    if not published or local > max(published):
+        return local
+    latest = max(local, *published)
+    prefix = f"{latest.epoch}!" if latest.epoch else ""
+    if latest.pre is not None:
+        stage, number = latest.pre
+        return Version(prefix + ".".join(map(str, latest.release)) + f"{stage}{number + 1}")
+    release = list(latest.release)
+    if len(release) > 3:
+        raise ReleaseError(f"Cannot increment patch of non-standard release: {latest}")
+    release += [0] * (3 - len(release))
+    release[2] += 1
+    return Version(prefix + ".".join(map(str, release)))
+
+
+# Candidates are proved by parsing, not by assuming a regex understands TOML tables.
+_VERSION_LINE = re.compile(
+    r'''(?m)^[ \t]*(?:version|"version"|'version')[ \t]*=[ \t]*(?P<literal>"[^"\r\n]*"|'[^'\r\n]*')[ \t]*(?:\#[^\r\n]*)?\r?$'''
+)
+
+
+def replace_project_version(project: Project, version: str) -> str:
+    expected = copy.deepcopy(project.data)
+    marker = "__prepare_release_version_marker__"
+    expected["project"]["version"] = marker
+    candidates = []
+    for match in _VERSION_LINE.finditer(project.text):
+        start, end = match.span("literal")
+        probe = project.text[:start] + json.dumps(marker) + project.text[end:]
+        try:
+            if tomllib.loads(probe) == expected:
+                candidates.append((start, end))
+        except tomllib.TOMLDecodeError:
+            pass
+    if len(candidates) != 1:
+        raise ReleaseError(f"Cannot precisely locate static project.version in {project.path}")
+    start, end = candidates[0]
+    delimiter = project.text[start]
+    updated = project.text[:start] + delimiter + version + delimiter + project.text[end:]
+    expected["project"]["version"] = version
+    if tomllib.loads(updated) != expected:
+        raise ReleaseError(f"Unexpected TOML change in {project.path}")
+    return updated
+
+
+def prepare_release(root: Path) -> str:
+    projects = load_projects(Path(root))
+    published = []
+    for project in projects:
+        if project.publishable:
+            published.extend(published_versions(project.name))
+    version = str(choose_version(projects[0].version, published))
+    # Stage every edit before the first write (including precise-edit validation).
+    updates = [(project.path, replace_project_version(project, version)) for project in projects]
+    for path, text in updates:
+        path.write_bytes(text.encode("utf-8"))
+    return version
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args(argv)
+    try:
+        version = prepare_release(args.repo_root)
+        if output := os.environ.get("GITHUB_OUTPUT"):
+            with open(output, "a", encoding="utf-8") as stream:
+                stream.write(f"version={version}\n")
+        print(version)
+    except (ReleaseError, OSError) as exc:
+        print(f"prepare_release: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -1,32 +1,56 @@
 param(
     [string]$Token = $env:UV_PUBLISH_TOKEN,
-
     [string]$PublishUrl = "https://upload.pypi.org/legacy/",
-
     [string]$CheckUrl = "https://pypi.org/simple/",
-
     [switch]$DryRun
 )
 
 $ErrorActionPreference = "Stop"
-if ([string]::IsNullOrWhiteSpace($Token)) {
-    Write-Error "Missing PyPI token. Pass -Token or set UV_PUBLISH_TOKEN."
+# DryRun builds and validates without requiring a real publishing credential.
+if (-not $DryRun -and [string]::IsNullOrWhiteSpace($Token)) {
+    throw "Missing PyPI token. Pass -Token or set UV_PUBLISH_TOKEN."
 }
-$env:UV_PUBLISH_TOKEN = $Token
-
-if (Test-Path "dist") {
-    Remove-Item "dist" -Recurse -Force
+if (-not [string]::IsNullOrWhiteSpace($Token)) {
+    $env:UV_PUBLISH_TOKEN = $Token
 }
-New-Item "dist" -ItemType Directory -Force | Out-Null
 
-uv build --all-packages --out-dir "dist" --no-create-gitignore
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-$publishArgs = @("publish", "--publish-url", $PublishUrl, "--check-url", $CheckUrl)
-if ($DryRun) {
-    $publishArgs += "--dry-run"
+function Invoke-Checked {
+    param([string]$Command, [string[]]$Arguments)
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Command $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
 }
-$publishArgs += "dist/*"
 
-uv @publishArgs
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+# Resolve paths from this script, not the caller's current directory.
+Push-Location (Split-Path $PSScriptRoot -Parent)
+try {
+    Push-Location "app/src/neobot_app/builtin_plugins/dashboard/frontend"
+    try {
+        # The repository uses pnpm-lock.yaml, so this is the npm ci equivalent.
+        Invoke-Checked "pnpm" @("install", "--frozen-lockfile")
+        foreach ($task in @("lint", "typecheck", "test", "build")) {
+            Invoke-Checked "pnpm" @("run", $task)
+        }
+    }
+    finally {
+        Pop-Location
+    }
+
+    # Only clean dist after the frontend has successfully built.
+    if (Test-Path "dist") {
+        Remove-Item "dist" -Recurse -Force
+    }
+    New-Item "dist" -ItemType Directory -Force | Out-Null
+    Invoke-Checked "uv" @("build", "--all-packages", "--out-dir", "dist", "--no-create-gitignore")
+
+    $publishArgs = @("publish", "--publish-url", $PublishUrl, "--check-url", $CheckUrl)
+    if ($DryRun) {
+        $publishArgs += @("--dry-run", "--trusted-publishing", "never")
+    }
+    $publishArgs += "dist/*"
+    Invoke-Checked "uv" $publishArgs
+}
+finally {
+    Pop-Location
+}

--- a/scripts/test_prepare_release.py
+++ b/scripts/test_prepare_release.py
@@ -1,0 +1,204 @@
+"""Isolated tests: python -B -m unittest discover -s scripts -p test_prepare_release.py."""
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from http.client import IncompleteRead
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import tomllib
+import unittest
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+
+from packaging.version import Version
+
+# Also works as a directly executed file, independent of cwd or package installation.
+_SPEC = importlib.util.spec_from_file_location("prepare_release", Path(__file__).with_name("prepare_release.py"))
+release = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = release
+_SPEC.loader.exec_module(release)
+
+
+class Response(io.BytesIO):
+    status = 200
+
+
+def response(versions=()):
+    return Response(json.dumps({"releases": {version: [] for version in versions}}).encode())
+
+
+class PrepareReleaseTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.add_project("pyproject.toml", "root", build=False)
+        self.add_project("packages/one/pyproject.toml", "one")
+        self.add_project("packages/two/pyproject.toml", "two")
+        self.add_project("app/pyproject.toml", "app")
+        # All test cases block real network by default.
+        self.network = patch.object(release, "urlopen", side_effect=lambda *a, **kw: response())
+        self.urlopen = self.network.start()
+        self.addCleanup(self.network.stop)
+
+    def add_project(self, relative, name, version="1.0.0-alpha.22", build=True):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        text = f'[project]\nname = "{name}"\nversion = "{version}" # keep comment\n'
+        text += 'dependencies = ["other==1.0.0-alpha.22"]\n'
+        text += '[tool.example]\nversion = "1.0.0-alpha.22"\n'
+        if build:
+            text += '[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n'
+        path.write_bytes(text.encode())
+        return path
+
+    def snapshot(self):
+        return {path: path.read_bytes() for path in self.root.rglob("pyproject.toml")}
+
+    def assert_unchanged_failure(self):
+        before = self.snapshot()
+        with self.assertRaises(release.ReleaseError):
+            release.prepare_release(self.root)
+        self.assertEqual(self.snapshot(), before)
+
+    def assert_versions(self, expected):
+        for path in self.snapshot():
+            self.assertEqual(tomllib.loads(path.read_text())["project"]["version"], expected)
+
+    def test_first_release_404_syncs_root_without_querying_it(self):
+        self.urlopen.side_effect = HTTPError("url", 404, "Not Found", None, None)
+        self.assertEqual(release.prepare_release(self.root), "1.0.0a22")
+        self.assert_versions("1.0.0a22")
+        urls = [call.args[0] for call in self.urlopen.call_args_list]
+        self.assertEqual(urls, [f"https://pypi.org/pypi/{name}/json" for name in ("one", "two", "app")])
+        self.assertTrue(all(call.kwargs["timeout"] == 30 for call in self.urlopen.call_args_list))
+
+    def test_buildable_root_is_queried(self):
+        self.add_project("pyproject.toml", "root", build=True)
+        release.prepare_release(self.root)
+        self.assertEqual(self.urlopen.call_count, 4)
+        self.assertIn("/root/json", self.urlopen.call_args_list[0].args[0])
+
+    def test_all_histories_include_pre_releases_not_info_version(self):
+        self.urlopen.side_effect = [
+            Response(b'{"info":{"version":"0.9"},"releases":{"1.0.0a25":[]}}'),
+            response(["1.0.0b3", "1.0.0rc2"]),
+            response(["1.0.0rc10", "1.0.0rc9"]),
+        ]
+        self.assertEqual(release.prepare_release(self.root), "1.0.0rc11")
+        self.assert_versions("1.0.0rc11")
+
+    def test_local_ahead_is_kept(self):
+        self.urlopen.side_effect = lambda *a, **kw: response(["0.9", "1.0.0a21"])
+        self.assertEqual(release.prepare_release(self.root), "1.0.0a22")
+
+    def test_version_increment_cases(self):
+        cases = [
+            ("1.0.0-alpha.22", ["1.0.0a22"], "1.0.0a23"),
+            ("1.0.0", ["1.2.3-beta.9"], "1.2.3b10"),
+            ("1.0.0", ["1.2.3rc9"], "1.2.3rc10"),
+            ("1.2.3", ["1.2.3"], "1.2.4"),
+            ("1.0.0a22", ["1.0.0"], "1.0.1"),
+            ("1.0.0", ["2.4"], "2.4.1"),
+            ("1!1.0", ["1!1.0"], "1!1.0.1"),
+            ("1.0.0", [], "1.0.0"),
+        ]
+        for local, published, expected in cases:
+            with self.subTest(local=local, published=published):
+                self.assertEqual(str(release.choose_version(Version(local), list(map(Version, published)))), expected)
+
+    def test_semantically_equal_local_versions_allowed(self):
+        self.add_project("packages/two/pyproject.toml", "two", "1.0.0a22")
+        self.assertEqual(release.prepare_release(self.root), "1.0.0a22")
+
+    def test_out_of_sync_rejected_before_network(self):
+        self.add_project("packages/two/pyproject.toml", "two", "1.0.0a23")
+        self.assert_unchanged_failure()
+        self.urlopen.assert_not_called()
+
+    def test_local_unsupported_or_invalid_versions_rejected(self):
+        for version in ("1.0.dev1", "1.0.post1", "1.0+local", "not-version"):
+            with self.subTest(version=version):
+                self.add_project("packages/two/pyproject.toml", "two", version)
+                self.assert_unchanged_failure()
+        self.urlopen.assert_not_called()
+
+    def test_published_unsupported_or_invalid_versions_rejected(self):
+        for version in ("1.0.dev1", "1.0.post1", "1.0+local", "not-version"):
+            with self.subTest(version=version):
+                self.urlopen.side_effect = lambda *a, **kw: response([version])
+                self.assert_unchanged_failure()
+
+    def test_late_http_network_and_json_failures_do_not_write(self):
+        failures = [
+            HTTPError("url", 403, "Forbidden", None, None),
+            HTTPError("url", 500, "Server error", None, None),
+            URLError("connection failed"),
+            TimeoutError("timeout"),
+            IncompleteRead(b"partial"),
+        ]
+        for failure in failures:
+            with self.subTest(failure=failure):
+                self.urlopen.side_effect = [response(["2.0"]), response(), failure]
+                self.assert_unchanged_failure()
+        for payload in (b"not json", b"\xff", b"[]", b"{}", b'{"releases":[]}', b'{"releases":{"1.0":null}}'):
+            with self.subTest(payload=payload):
+                self.urlopen.side_effect = [response(["2.0"]), response(), Response(payload)]
+                self.assert_unchanged_failure()
+
+    def test_unexpected_response_status_fails_closed(self):
+        bad_response = response()
+        bad_response.status = 503
+        self.urlopen.side_effect = [bad_response]
+        self.assert_unchanged_failure()
+
+    def test_precise_edit_preserves_dependencies_comments_crlf_and_fake_keys(self):
+        path = self.root / "pyproject.toml"
+        text = (
+            '[project]\r\nname = "root"\r\n'
+            "'version'  = '1.0.0-alpha.22' # untouched comment\r\n"
+            'description = """\r\n[project]\r\nversion = "1.0.0-alpha.22"\r\n"""\r\n'
+            'dependencies = ["other==1.0.0-alpha.22"]\r\n'
+            '[tool.example]\r\nversion = "1.0.0-alpha.22"\r\n'
+        )
+        path.write_bytes(text.encode())
+        self.urlopen.side_effect = lambda *a, **kw: response(["1.0.0a22"])
+        release.prepare_release(self.root)
+        expected = text.replace("'version'  = '1.0.0-alpha.22'", "'version'  = '1.0.0a23'")
+        self.assertEqual(path.read_bytes(), expected.encode())
+
+    def test_uneditable_last_file_fails_before_any_write(self):
+        path = self.root / "app/pyproject.toml"
+        path.write_text('project = { name = "app", version = "1.0.0a22" }\n', encoding="utf-8")
+        self.assert_unchanged_failure()
+
+    def test_cli_appends_github_output(self):
+        output = self.root / "github-output"
+        output.write_text("existing=value\n", encoding="utf-8")
+        with patch.dict(os.environ, {"GITHUB_OUTPUT": str(output)}), redirect_stdout(io.StringIO()) as stdout:
+            self.assertEqual(release.main(["--repo-root", str(self.root)]), 0)
+        self.assertEqual(stdout.getvalue(), "1.0.0a22\n")
+        self.assertEqual(output.read_text(), "existing=value\nversion=1.0.0a22\n")
+
+    def test_cli_default_root_uses_script_path_not_cwd(self):
+        fake_script = self.root / "scripts" / "prepare_release.py"
+        with patch.object(release, "__file__", str(fake_script)), patch.dict(os.environ, {}, clear=True):
+            with redirect_stdout(io.StringIO()):
+                self.assertEqual(release.main([]), 0)
+        self.assert_versions("1.0.0a22")
+
+    def test_cli_failure_emits_no_github_output(self):
+        output = self.root / "github-output"
+        self.urlopen.side_effect = URLError("offline")
+        with patch.dict(os.environ, {"GITHUB_OUTPUT": str(output)}), redirect_stderr(io.StringIO()):
+            self.assertEqual(release.main(["--repo-root", str(self.root)]), 1)
+        self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

前端 job 失败于 `pnpm/action-setup@v4`：它默认在仓库根目录找 `packageManager`，而本项目的前端是子目录工程，根目录没有 `package.json`。

## 改动

### 1. 修复 pnpm 安装失败
- `pnpm/action-setup` 显式指定 `package_json_file` 指向前端 `package.json`（`pnpm@12.3.4`，与 lockfile 一致）
- `actions/setup-node` 升到 v6（Node 22），消除 Node 20 弃用告警

### 2. 工作流拆分为两套
- `.github/workflows/ci.yml`：PR 代码检查（`pull_request`），并导出 `workflow_call` 供发布流程复用
- `.github/workflows/publish.yml`：合并到 main 后触发
  1. 用 GitHub API 确认该提交确实来自已合并的 PR（兼容 merge / squash / rebase），直接推送 main 不发布
  2. 复用 ci.yml 重跑全部检查，不信任 PR 上的旧结果
  3. 查询 PyPI 版本并统一递增工作区版本
  4. 构建 + `uv publish --dry-run` 预检
  5. 回写版本与 `uv.lock` 后再上传（保证不覆盖并发的新提交）
  6. `uv publish --check-url` 上传，已存在文件自动跳过

### 3. 产物一致性检查加强
改为 `git status --porcelain --untracked-files=all`，能发现新增但未提交的产物文件。

### 4. `publish.ps1` 增加前端安装与构建
按顺序执行 `pnpm install --frozen-lockfile`（本仓库的 `npm ci` 等价操作）、`lint`、`typecheck`、`test`、`build`，随后清理 `dist`、构建全部 Python 包并发布。脚本改为按自身路径解析仓库根目录，可从任意目录调用；`-DryRun` 不再强制要求 token。

### 5. 自动版本检测
新增 `scripts/prepare_release.py`：
- 读取根与所有工作区成员的 `project.version`，要求一致
- 查询各可发布包在 PyPI 的完整 release 历史（含预发布）
- 本地版本领先则沿用，否则在最大版本上递增：`1.0.0a22 → 1.0.0a23`，稳定版 patch+1
- 拒绝 dev/post/local，PyPI 非 404 错误一律中止，绝不猜测版本
- 精确替换 `project.version`，不动依赖约束

## 验证

- 前端：lint 0 error、`tsc --noEmit`、37 项测试、构建产物与源码一致
- 版本逻辑：16 项 unittest 通过（全部 mock，不访问真实 PyPI）
- 本地 `./scripts/publish.ps1 -DryRun` 端到端通过，14 份产物检查成功，未上传

## 合并前需要配置

1. 创建 GitHub environment `pypi`，加入 secret `UV_PUBLISH_TOKEN`
2. 允许发布 job 的 `GITHUB_TOKEN` 写入 main（用于回写版本号与 `uv.lock`）；若分支保护禁止，会在上传前失败，不会强推

详见 `scripts/RELEASING.md`。
