### PR TITLE
fix(config): 修复次级管理员持久化问题

### DIFF
--- a/app/src/neobot_app/bootstrap/_commands.py
+++ b/app/src/neobot_app/bootstrap/_commands.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any
 
 from neobot_app.core import CONFIG_BACKUP_DIR, CONFIG_FILE
@@ -50,90 +49,91 @@ def build_credential_manager(*, permissions: Any) -> Any:
     return CredentialManager(permissions=permissions)
 
 
-def _make_config_save_callback(config: Any):
-    """配置保存回调:更新 chat.sub_admin_accounts 并触发热重载。"""
-
-    async def _save_sub_admins(new_list: list[int]) -> str:
-        try:
-            import tomlkit
-
-            from neobot_app.config.loader.backup import backup_config
-            from neobot_app.config.loader.converter import dict_to_dataclass
-            from neobot_app.config.schemas.bot import BotConfig
-
-            document = tomlkit.parse(CONFIG_FILE.read_text(encoding="utf-8"))
-            chat = document.get("chat", {})
-            if not isinstance(chat, dict):
-                raise TypeError("配置缺少 chat 段")
-            chat["sub_admin_accounts"] = [int(value) for value in new_list]
-            raw_config = document.unwrap()
-            validated = dict_to_dataclass(raw_config, BotConfig)
-            rendered = tomlkit.dumps(document)
-            await asyncio.to_thread(backup_config, CONFIG_FILE, CONFIG_BACKUP_DIR)
-            await asyncio.to_thread(_atomic_write, CONFIG_FILE, rendered)
-            config.reload(validated)
-        except Exception as exc:
-            return f"错误: 配置保存失败: {exc}"
-        return "ok"
-
-    return _save_sub_admins
-
-
-def _atomic_write(path: Path, text: str) -> None:
-    """原子写文件(临时文件 + replace)。"""
-    import tempfile
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(
-        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
-    )
-    try:
-        with open(fd, "w", encoding="utf-8") as handle:
-            handle.write(text)
-            handle.flush()
-            import os
-
-            os.fsync(handle.fileno())
-        tmp = Path(tmp_name)
-        tmp.replace(path)
-    except Exception:
-        Path(tmp_name).unlink(missing_ok=True)
-        raise
-
-
-# 允许 AI 工具通过回调更新的 chat 段键(白名单,防任意键注入)
+#: 允许 AI 工具通过回调更新的 chat 段键(白名单,防任意键注入)
 _CHAT_UPDATE_ALLOWED_KEYS = frozenset({
     "willing_agent_global_coefficient",
     "willing_global_coefficient",
 })
 
 
+def _reload_live_config(config: Any) -> bool:
+    """把磁盘上的 config.toml 重新加载进内存配置对象。
+
+    返回是否生效：config 不是 ConfigProxy（例如配置加载失败时的兜底对象）
+    时无法热重载，此时命令层会提示"重启后生效"，而不是把写盘成功当成失败。
+    """
+    reload = getattr(config, "reload", None)
+    if not callable(reload):
+        return False
+    try:
+        import tomlkit
+
+        from neobot_app.config.loader.converter import dict_to_dataclass
+        from neobot_app.config.schemas.bot import BotConfig
+
+        raw = tomlkit.parse(CONFIG_FILE.read_text(encoding="utf-8-sig")).unwrap()
+        reload(dict_to_dataclass(raw, BotConfig))
+    except Exception:
+        return False
+    return True
+
+
+def _make_config_save_callback(config: Any):
+    """配置保存回调:更新 chat.sub_admin_accounts 并触发热重载。
+
+    写盘走 chat_writer（缺 [chat] 段会在文档里创建、写盘前后都有校验），
+    返回 ConfigSaveResult：只有磁盘上确实写入成功才 ok=True。
+    """
+
+    async def _save_sub_admins(new_list: list[int]) -> Any:
+        from neobot_app.commands.model import ConfigSaveResult
+        from neobot_app.config.chat_writer import save_sub_admin_accounts
+
+        result = await asyncio.to_thread(
+            save_sub_admin_accounts,
+            CONFIG_FILE,
+            new_list,
+            backup_dir=CONFIG_BACKUP_DIR,
+        )
+        if not result.ok:
+            return ConfigSaveResult(ok=False, error=result.error, path=str(CONFIG_FILE))
+        accounts = tuple(
+            str(item) for item in (result.values.get("sub_admin_accounts") or ())
+        )
+        applied = await asyncio.to_thread(_reload_live_config, config)
+        return ConfigSaveResult(
+            ok=True, accounts=accounts, applied=applied, path=str(CONFIG_FILE)
+        )
+
+    return _save_sub_admins
+
+
 def _make_chat_config_update_callback(config: Any):
-    """chat 段指定键更新回调:写回 config.toml + 热重载(白名单键)。"""
+    """chat 段指定键更新回调:写回 config.toml + 热重载(白名单键)。
+
+    与次级管理员共用 chat_writer：缺 [chat] 段时同样会在文档里创建，
+    不会出现"返回 ok 但文件没变"的静默失败。
+    """
 
     async def _update_chat_config(key: str, value: Any) -> str:
         if key not in _CHAT_UPDATE_ALLOWED_KEYS:
             return f"错误: 不允许更新配置键 {key}"
+        from neobot_app.config.chat_writer import write_chat_values
+
         try:
-            import tomlkit
-
-            from neobot_app.config.loader.backup import backup_config
-            from neobot_app.config.loader.converter import dict_to_dataclass
-            from neobot_app.config.schemas.bot import BotConfig
-
-            document = tomlkit.parse(CONFIG_FILE.read_text(encoding="utf-8"))
-            chat = document.get("chat", {})
-            if not isinstance(chat, dict):
-                raise TypeError("配置缺少 chat 段")
-            chat[key] = value
-            raw_config = document.unwrap()
-            validated = dict_to_dataclass(raw_config, BotConfig)
-            rendered = tomlkit.dumps(document)
-            await asyncio.to_thread(backup_config, CONFIG_FILE, CONFIG_BACKUP_DIR)
-            await asyncio.to_thread(_atomic_write, CONFIG_FILE, rendered)
-            config.reload(validated)
+            result = await asyncio.to_thread(
+                write_chat_values,
+                CONFIG_FILE,
+                {key: value},
+                backup_dir=CONFIG_BACKUP_DIR,
+            )
         except Exception as exc:
             return f"错误: 配置保存失败: {exc}"
+        if not result.ok:
+            return f"错误: 配置保存失败: {result.error}"
+        await asyncio.to_thread(_reload_live_config, config)
         return "ok"
 
     return _update_chat_config
+
+

--- a/app/src/neobot_app/commands/builtin.py
+++ b/app/src/neobot_app/commands/builtin.py
@@ -376,9 +376,22 @@ async def _modify_admin(ctx: CommandContext, *, add: bool) -> str:
         action = "删除"
 
     result = await ctx.service.save_sub_admins(sorted(current))
-    if result.startswith("错误"):
-        return result
-    return f"已{action}次级管理员 QQ {target_qq}。\n当前次级管理员: {'、'.join(str(qq) for qq in sorted(current)) or '(无)'}"
+    if not result.ok:
+        return f"错误: 配置保存失败: {result.error or '未知原因'}"
+
+    # 以"磁盘上回读到的列表"为准回复：写盘静默失败时不能再报成功
+    persisted = list(result.accounts)
+    wanted = str(target_qq)
+    if (add and wanted not in persisted) or (not add and wanted in persisted):
+        return (
+            f"错误: 配置写入后内容不符合预期（QQ {wanted}），"
+            f"请检查配置文件权限与内容（{result.path or ctx.service.config_path_hint()}）"
+        )
+    suffix = "" if result.applied else "\n（配置已写入文件，重启 NeoBot 后生效）"
+    return (
+        f"已{action}次级管理员 QQ {target_qq}。\n"
+        f"当前次级管理员: {'、'.join(persisted) or '(无)'}{suffix}"
+    )
 
 
 async def _handle_set_password(ctx: CommandContext) -> str:

--- a/app/src/neobot_app/commands/model.py
+++ b/app/src/neobot_app/commands/model.py
@@ -36,6 +36,25 @@ class CommandHandleResult:
     background: str | None = None
 
 
+@dataclass(frozen=True)
+class ConfigSaveResult:
+    """配置写回结果。
+
+    命令层据此区分「真的写进磁盘并生效」与「看起来成功」：
+    早期实现只返回字符串，写盘静默失败时命令照样回复成功，
+    于是 /add_admin 加了管理员、重启后却没了。
+    """
+
+    ok: bool
+    error: str = ""
+    #: 写盘后回读到的次级管理员列表（规范化后的字符串）
+    accounts: tuple[str, ...] = ()
+    #: 是否已经把新配置热重载进当前进程（False 表示需重启生效）
+    applied: bool = False
+    #: 实际写入的配置文件路径（用于失败提示）
+    path: str = ""
+
+
 @dataclass
 class CommandContext:
     """命令执行上下文。"""

--- a/app/src/neobot_app/commands/service.py
+++ b/app/src/neobot_app/commands/service.py
@@ -11,12 +11,13 @@ from neobot_app.commands.builtin import build_builtin_commands
 from neobot_app.commands.model import (
     CommandContext,
     CommandHandleResult,
+    ConfigSaveResult,
 )
 from neobot_app.commands.permissions import PermissionManager
 from neobot_app.commands.registry import CommandRegistry
 
 SendCallback = Callable[[str, str, str, int | None], Awaitable[Any]]
-ConfigSaveCallback = Callable[[list[int]], Awaitable[str]]
+ConfigSaveCallback = Callable[[list[int]], Awaitable[ConfigSaveResult]]
 RestartCallback = Callable[[], Any]
 ConfigReloadCallback = Callable[[], Awaitable[Any]]
 
@@ -310,11 +311,26 @@ class CommandService:
         except Exception as exc:
             self._log(f"命令回复发送失败: {exc}")
 
-    async def save_sub_admins(self, new_list: list[int]) -> str:
-        """保存次级管理员列表(经注入的回调,含配置写回与热重载)。"""
+    async def save_sub_admins(self, new_list: list[int]) -> ConfigSaveResult:
+        """保存次级管理员列表(经注入的回调,含配置写回与热重载)。
+
+        回调返回 ConfigSaveResult：只有 ok=True 才代表磁盘上确实写成功了。
+        """
         if self._config_save_callback is None:
-            return "错误: 配置保存能力未注入"
+            return ConfigSaveResult(ok=False, error="配置保存能力未注入")
         return await self._config_save_callback(new_list)
+
+    def config_path_hint(self) -> str:
+        """配置文件路径提示（命令回复里帮助用户定位问题）。"""
+        path = getattr(self._config, "config_path", None)
+        if path:
+            return str(path)
+        try:
+            from neobot_app.core import CONFIG_FILE
+
+            return str(CONFIG_FILE)
+        except Exception:  # pragma: no cover - 导入失败时不影响命令
+            return "data/config.toml"
 
     def _log(self, message: str) -> None:
         logger = self._logger

--- a/app/src/neobot_app/config/chat_writer.py
+++ b/app/src/neobot_app/config/chat_writer.py
@@ -1,0 +1,238 @@
+"""config.toml 的定点写回（聊天段配置、次级管理员列表）。
+
+为什么不能直接在解析出的文档上赋值：tomlkit 的 document.get("chat", {}) 在
+[chat] 段不存在时返回一个**游离的 dict**，赋值不会进入文档，于是
+tomlkit.dumps(document) 写回去的还是原文件——而调用方收到的是"成功"。
+/add_admin 正好会踩中这条路径：命令回复"已添加次级管理员"，文件却没变，
+重启 NeoBot 后列表自然就空了（用户看到的现象就是"只写在内存里"）。
+
+本模块把写回收敛成三条保证：
+
+1. 缺段就在**文档里**创建（不是操作游离对象），已有内容与注释保持不动；
+2. 值与 schema 类型对齐（次级管理员是 List[str]，就写字符串，避免下次启动
+   被当成"类型不匹配的缺失项"整段重置）；
+3. 写盘前先校验"这份内容能不能被 BotConfig 加载"，写盘后**回读比对**，
+   任何一步不一致都返回失败，绝不谎报成功。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import tomlkit
+
+from neobot_app.config.loader.backup import backup_config
+from neobot_app.config.loader.converter import dict_to_dataclass
+from neobot_app.config.schemas.bot import BotConfig
+
+#: config.toml 里承载聊天/账号配置的表名
+CHAT_SECTION = "chat"
+#: 次级管理员列表的字段名（schema 里是 List[str]）
+SUB_ADMIN_FIELD = "sub_admin_accounts"
+#: QQ 号长度上限（防御性校验：不接受明显不是 QQ 号的值）
+MAX_ACCOUNT_LENGTH = 20
+
+
+@dataclass(frozen=True, slots=True)
+class ChatConfigWriteResult:
+    """一次定点写回的结果。"""
+
+    ok: bool
+    #: 写盘后回读到的该键的值（ok=False 时为空）
+    values: Mapping[str, Any] = field(default_factory=dict)
+    error: str = ""
+
+    def text_value(self, key: str) -> str:
+        return str(self.values.get(key, "") or "")
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        Path(temp_name).replace(path)
+    except BaseException:
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _canonical(value: Any) -> Any:
+    """把值归一化成可比较的形态（列表逐项转字符串，标量转字符串）。"""
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item) for item in value)
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, (int, float)):
+        return str(value)
+    return str(value)
+
+
+def read_chat_values(config_path: Path, keys: Iterable[str]) -> dict[str, Any]:
+    """读取 [chat] 段里指定键的当前值（文件不存在/无该段时返回空字典）。"""
+    path = Path(config_path)
+    if not path.is_file():
+        return {}
+    try:
+        # utf-8-sig：兼容记事本存的 BOM，否则 tomlkit 会直接抛错
+        document = tomlkit.parse(path.read_text(encoding="utf-8-sig"))
+    except Exception:
+        return {}
+    chat = document.get(CHAT_SECTION)
+    if not isinstance(chat, dict):
+        return {}
+    result: dict[str, Any] = {}
+    for key in keys:
+        if key in chat:
+            result[str(key)] = chat.get(key)
+    return result
+
+
+def write_chat_values(
+    config_path: Path,
+    values: Mapping[str, Any],
+    *,
+    backup_dir: Path | None = None,
+    max_backups: int = 15,
+) -> ChatConfigWriteResult:
+    """把若干键写进 config.toml 的 [chat] 段并回读校验。
+
+    Args:
+        config_path: 目标配置文件（通常是 data/config.toml）。
+        values: 键 -> 新值；只改这些键，其它内容（含注释与顺序）保持不变。
+        backup_dir: 备份目录；缺省为配置文件同级的 config_backup。
+        max_backups: 备份保留份数。
+
+    Returns:
+        ChatConfigWriteResult：ok=True 时才代表磁盘上确实写成功了。
+    """
+    path = Path(config_path)
+    if not values:
+        return ChatConfigWriteResult(ok=False, error="没有需要写入的配置项")
+
+    try:
+        text = path.read_text(encoding="utf-8-sig") if path.is_file() else ""
+    except OSError as exc:
+        return ChatConfigWriteResult(ok=False, error=f"读取配置失败: {exc}")
+
+    try:
+        document = tomlkit.parse(text) if text.strip() else tomlkit.document()
+    except Exception as exc:
+        return ChatConfigWriteResult(ok=False, error=f"配置解析失败: {exc}")
+
+    chat = document.get(CHAT_SECTION)
+    if chat is None:
+        # 关键修复：在文档里创建 [chat]，而不是往游离 dict 上写
+        chat = tomlkit.table()
+        document[CHAT_SECTION] = chat
+    elif not isinstance(chat, dict):
+        return ChatConfigWriteResult(
+            ok=False, error=f"配置里的 [{CHAT_SECTION}] 不是表，无法写入"
+        )
+
+    for key, value in values.items():
+        chat[str(key)] = tomlkit.item(value)
+
+    rendered = tomlkit.dumps(document)
+
+    # 写盘前先确认这份内容能被 schema 加载：写出一份加载不了的配置，
+    # 下次启动会被"补全缺失项"整段重写，用户改的东西就没了。
+    try:
+        validated = dict_to_dataclass(tomlkit.parse(rendered).unwrap(), BotConfig)
+    except Exception as exc:
+        return ChatConfigWriteResult(ok=False, error=f"配置校验失败，未写入: {exc}")
+    if validated is None:  # pragma: no cover - dict_to_dataclass 不会返回 None
+        return ChatConfigWriteResult(ok=False, error="配置校验失败，未写入")
+
+    try:
+        if path.is_file():
+            backup_config(
+                path,
+                Path(backup_dir) if backup_dir is not None else path.parent / "config_backup",
+                max_backups=max_backups,
+            )
+        _atomic_write(path, rendered if rendered.endswith("\n") else rendered + "\n")
+    except Exception as exc:
+        return ChatConfigWriteResult(ok=False, error=f"写入配置失败: {exc}")
+
+    persisted = read_chat_values(path, values.keys())
+    mismatched = [
+        key
+        for key, value in values.items()
+        if _canonical(persisted.get(key)) != _canonical(value)
+    ]
+    if mismatched:
+        return ChatConfigWriteResult(
+            ok=False,
+            error="写入后回读不一致: " + "、".join(sorted(mismatched)),
+            values=persisted,
+        )
+    return ChatConfigWriteResult(ok=True, values=persisted)
+
+
+def normalize_accounts(accounts: Iterable[Any]) -> tuple[tuple[str, ...], str]:
+    """归一化 QQ 号列表：去空白、只留数字、去重、按数值排序。
+
+    Returns:
+        (规范化后的账号元组, 错误文本)；错误文本非空时元组为空。
+    """
+    collected: dict[int, str] = {}
+    for raw in accounts:
+        text = str(raw).strip()
+        if not text:
+            continue
+        if not text.isdigit() or len(text) > MAX_ACCOUNT_LENGTH:
+            return (), f"非法的 QQ 号: {raw!r}"
+        collected[int(text)] = text
+    return tuple(collected[key] for key in sorted(collected)), ""
+
+
+def save_sub_admin_accounts(
+    config_path: Path,
+    accounts: Iterable[Any],
+    *,
+    backup_dir: Path | None = None,
+) -> ChatConfigWriteResult:
+    """写入次级管理员列表（[chat].sub_admin_accounts）。"""
+    normalized, error = normalize_accounts(accounts)
+    if error:
+        return ChatConfigWriteResult(ok=False, error=error)
+    return write_chat_values(
+        config_path,
+        {SUB_ADMIN_FIELD: list(normalized)},
+        backup_dir=backup_dir,
+    )
+
+
+def read_sub_admin_accounts(config_path: Path) -> tuple[str, ...]:
+    """读取次级管理员列表（去空白、只留数字、去重、按数值排序）。"""
+    stored = read_chat_values(config_path, [SUB_ADMIN_FIELD]).get(SUB_ADMIN_FIELD)
+    if not isinstance(stored, list):
+        return ()
+    normalized, _error = normalize_accounts(stored)
+    return normalized
+
+
+__all__ = [
+    "CHAT_SECTION",
+    "SUB_ADMIN_FIELD",
+    "ChatConfigWriteResult",
+    "normalize_accounts",
+    "read_chat_values",
+    "read_sub_admin_accounts",
+    "save_sub_admin_accounts",
+    "write_chat_values",
+]

--- a/app/tests/modules/commands/test_admin_commands.py
+++ b/app/tests/modules/commands/test_admin_commands.py
@@ -1,0 +1,271 @@
+"""内置命令 /add_admin、/del_admin：写盘持久化与失败如实汇报。
+
+回归背景：这两条命令此前会「回复成功但配置没写进去」（[chat] 段缺失时
+写进了游离 dict），重启后次级管理员列表就空了。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import tomlkit
+
+from neobot_app.bootstrap import _commands
+from neobot_app.commands.service import CommandService
+from neobot_app.config.chat_writer import read_sub_admin_accounts
+from neobot_app.config.loader.converter import dict_to_dataclass
+from neobot_app.config.proxy import ConfigProxy
+from neobot_app.config.schemas.bot import BotConfig
+
+BOT = 88888
+SUPER = 10001
+SUB = 20002
+
+BASE_CONFIG = """version = "0.6.0"
+
+[bot]
+account = 88888
+nick_name = "bot"
+
+[chat]
+admin_accounts = ["10001"]
+sub_admin_accounts = []
+"""
+
+
+class _Adapter:
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    async def send(self, conversation, segments):
+        text = "".join(
+            str((segment.get("data") or {}).get("text") or "")
+            for segment in segments
+            if isinstance(segment, dict) and segment.get("type") == "text"
+        )
+        self.sent.append(text)
+        return SimpleNamespace(status="ok")
+
+    async def send_private_msg(self, user_id, message):
+        return await self.send(SimpleNamespace(kind="private", id=str(user_id)), message)
+
+
+def _message(text: str, user_id: int):
+    return SimpleNamespace(
+        user_id=user_id,
+        message=[{"type": "text", "data": {"text": text}}],
+    )
+
+
+class _LoggerFactory:
+    def get_logger(self, name):
+        import logging
+
+        return logging.getLogger(name)
+
+
+@pytest.fixture()
+def config_file(tmp_path: Path, monkeypatch) -> Path:
+    """把 CONFIG_FILE / CONFIG_BACKUP_DIR 指向临时目录。"""
+    path = tmp_path / "config.toml"
+    path.write_text(BASE_CONFIG, encoding="utf-8")
+    monkeypatch.setattr(_commands, "CONFIG_FILE", path)
+    monkeypatch.setattr(_commands, "CONFIG_BACKUP_DIR", tmp_path / "config_backup")
+    return path
+
+
+def _service(path: Path) -> tuple[ConfigProxy, CommandService, _Adapter]:
+    """按真实装配方式构建：ConfigProxy + build_command_service 的保存回调。"""
+    config = ConfigProxy(
+        dict_to_dataclass(tomlkit.parse(path.read_text(encoding="utf-8")).unwrap(), BotConfig)
+    )
+    adapter = _Adapter()
+    service = _commands.build_command_service(
+        config=config, adapter=adapter, logger_factory=_LoggerFactory()
+    )
+    return config, service, adapter
+
+
+def _reload(path: Path):
+    """模拟重启：从磁盘重新构造配置对象。"""
+    return dict_to_dataclass(tomlkit.parse(path.read_text(encoding="utf-8")).unwrap(), BotConfig)
+
+
+async def _send(service: CommandService, text: str, user_id: int) -> str:
+    result = await service.handle_message(
+        _message(text, user_id), kind="private", queue_key=str(user_id)
+    )
+    assert result.consumed is True
+    return str(getattr(service, "_last_text", "") or "")
+
+
+async def _run(path: Path, text: str, user_id: int) -> tuple[str, ConfigProxy, CommandService]:
+    config, service, adapter = _service(path)
+    await service.handle_message(
+        _message(text, user_id), kind="private", queue_key=str(user_id)
+    )
+    return (adapter.sent[-1] if adapter.sent else ""), config, service
+
+
+# ---------------------------------------------------------------------------
+# 正常路径：写盘 + 热重载 + 重启后仍在
+# ---------------------------------------------------------------------------
+
+
+async def test_add_admin_persists_and_survives_restart(config_file: Path) -> None:
+    reply, config, service = await _run(config_file, "/add_admin 30003", SUPER)
+
+    assert "已添加次级管理员" in reply
+    assert "30003" in reply
+    # 磁盘
+    assert read_sub_admin_accounts(config_file) == ("30003",)
+    # 内存（热重载生效）
+    assert list(config.chat.sub_admin_accounts) == ["30003"]
+    assert service.permissions.is_sub_admin(30003) is True
+    # 重启
+    assert list(_reload(config_file).chat.sub_admin_accounts) == ["30003"]
+
+
+async def test_add_admin_writes_schema_correct_strings(config_file: Path) -> None:
+    await _run(config_file, "/add_admin 30003", SUPER)
+
+    text = config_file.read_text(encoding="utf-8")
+    assert 'sub_admin_accounts = ["30003"]' in text
+
+
+async def test_del_admin_removes_and_persists(config_file: Path) -> None:
+    await _run(config_file, "/add_admin 30003", SUPER)
+    reply, _config, _service_ = await _run(config_file, "/del_admin 30003", SUPER)
+
+    assert "已删除次级管理员" in reply
+    assert read_sub_admin_accounts(config_file) == ()
+
+
+async def test_sub_admin_gains_permissions_after_restart(config_file: Path) -> None:
+    await _run(config_file, "/add_admin 30003", SUPER)
+    _config, service, adapter = _service(config_file)
+
+    assert service.permissions.is_sub_admin(30003) is True
+
+    await service.handle_message(
+        _message("/add_admin 40004", 30003), kind="private", queue_key="30003"
+    )
+    assert "没有权限" in (adapter.sent[-1] if adapter.sent else "")
+
+
+async def test_add_admin_rejects_super_admin_target(config_file: Path) -> None:
+    reply, _config, _service_ = await _run(config_file, f"/add_admin {SUPER}", SUPER)
+
+    assert "超级管理员" in reply
+    assert read_sub_admin_accounts(config_file) == ()
+
+
+# ---------------------------------------------------------------------------
+# 失败路径：绝不谎报成功
+# ---------------------------------------------------------------------------
+
+
+async def test_write_failure_is_reported_as_error(config_file: Path, monkeypatch) -> None:
+    from neobot_app.config import chat_writer
+
+    def _boom(*args, **kwargs):
+        raise OSError("只读文件系统")
+
+    monkeypatch.setattr(chat_writer, "_atomic_write", _boom)
+
+    reply, _config, _service_ = await _run(config_file, "/add_admin 30003", SUPER)
+
+    assert reply.startswith("错误")
+    assert "写入配置失败" in reply
+    assert read_sub_admin_accounts(config_file) == ()
+
+
+async def test_silent_write_is_detected_and_reported(config_file: Path, monkeypatch) -> None:
+    """回读不到写入内容时必须报错（旧实现会回复"已添加"）。"""
+    from neobot_app.config import chat_writer
+
+    monkeypatch.setattr(chat_writer, "read_chat_values", lambda *args, **kwargs: {})
+
+    reply, _config, _service_ = await _run(config_file, "/add_admin 30003", SUPER)
+
+    assert reply.startswith("错误")
+    assert "回读不一致" in reply
+
+
+async def test_missing_callback_reports_error(config_file: Path) -> None:
+    config = ConfigProxy(
+        dict_to_dataclass(
+            tomlkit.parse(config_file.read_text(encoding="utf-8")).unwrap(), BotConfig
+        )
+    )
+    adapter = _Adapter()
+    service = CommandService(config=config, adapter=adapter)
+
+    await service.handle_message(
+        _message("/add_admin 30003", SUPER), kind="private", queue_key="1"
+    )
+
+    assert "配置保存能力未注入" in (adapter.sent[-1] if adapter.sent else "")
+
+
+async def test_missing_chat_section_is_created(config_file: Path) -> None:
+    """回归用例：[chat] 段不存在时也必须真的写进去。"""
+    config_file.write_text(
+        'version = "0.6.0"\n\n[bot]\naccount = 88888\nnick_name = "bot"\n',
+        encoding="utf-8",
+    )
+    config = dict_to_dataclass(
+        tomlkit.parse(config_file.read_text(encoding="utf-8")).unwrap(), BotConfig
+    )
+    config.chat.admin_accounts = [str(SUPER)]
+    proxy = ConfigProxy(config)
+    adapter = _Adapter()
+    service = _commands.build_command_service(
+        config=proxy, adapter=adapter, logger_factory=_LoggerFactory()
+    )
+
+    await service.handle_message(
+        _message("/add_admin 30003", SUPER), kind="private", queue_key="1"
+    )
+
+    assert "已添加次级管理员" in (adapter.sent[-1] if adapter.sent else "")
+    assert read_sub_admin_accounts(config_file) == ("30003",)
+
+
+# ---------------------------------------------------------------------------
+# 同一类问题的另一个回调
+# ---------------------------------------------------------------------------
+
+
+async def test_chat_update_callback_creates_missing_section(
+    config_file: Path, monkeypatch
+) -> None:
+    config_file.write_text('version = "0.6.0"\n\n[bot]\naccount = 88888\n', encoding="utf-8")
+    config = ConfigProxy(
+        dict_to_dataclass(
+            tomlkit.parse(config_file.read_text(encoding="utf-8")).unwrap(), BotConfig
+        )
+    )
+    callback = _commands._make_chat_config_update_callback(config)
+
+    result = await callback("willing_global_coefficient", 0.35)
+
+    assert result == "ok"
+    parsed = tomlkit.parse(config_file.read_text(encoding="utf-8"))
+    assert parsed["chat"]["willing_global_coefficient"] == 0.35
+
+
+async def test_chat_update_callback_rejects_unknown_key(config_file: Path) -> None:
+    config = ConfigProxy(
+        dict_to_dataclass(
+            tomlkit.parse(config_file.read_text(encoding="utf-8")).unwrap(), BotConfig
+        )
+    )
+    callback = _commands._make_chat_config_update_callback(config)
+
+    result = await callback("admin_accounts", ["1"])
+
+    assert result.startswith("错误")
+    assert "不允许更新配置键" in result

--- a/app/tests/modules/commands/test_commands.py
+++ b/app/tests/modules/commands/test_commands.py
@@ -1,4 +1,4 @@
-﻿"""命令系统单元测试:解析 / 权限树 / 内置命令 / 热重载回调。"""
+"""命令系统单元测试:解析 / 权限树 / 内置命令 / 热重载回调。"""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ from neobot_app.commands.model import (
     PERM_SUB_ADMIN,
     PERM_SUPER_ADMIN,
     Command,
+    ConfigSaveResult,
 )
 from neobot_app.commands.permissions import PermissionManager
 from neobot_app.commands.registry import CommandRegistry
@@ -148,11 +149,18 @@ async def test_permission_denied_consumes_and_replies() -> None:
 
 
 def _admin_service(save_result: str = "ok") -> tuple[CommandService, list[list[int]]]:
+    """保存回调按新契约返回 ConfigSaveResult（只有 ok=True 才算写盘成功）。"""
     saved: list[list[int]] = []
 
     async def save(new_list):
         saved.append(new_list)
-        return save_result
+        ok = save_result == "ok"
+        return ConfigSaveResult(
+            ok=ok,
+            error="" if ok else save_result,
+            accounts=tuple(str(item) for item in new_list),
+            applied=ok,
+        )
 
     service = CommandService(
         config=_config(admin_accounts=[SUPER], sub_admin_accounts=[SUB]),
@@ -191,7 +199,7 @@ async def test_add_admin_super_admin_protected() -> None:
 
     async def save(new_list):
         saved2.append(new_list)
-        return "ok"
+        return ConfigSaveResult(ok=True, accounts=tuple(str(item) for item in new_list))
 
     service = CommandService(
         config=_config(admin_accounts=[SUPER, 20000], sub_admin_accounts=[SUB]),

--- a/app/tests/modules/config/test_admin_accounts.py
+++ b/app/tests/modules/config/test_admin_accounts.py
@@ -1,0 +1,208 @@
+"""次级管理员列表的持久化（config.toml 的 [chat].sub_admin_accounts）。
+
+回归背景：旧实现直接在 tomlkit 文档上写 chat["sub_admin_accounts"]，
+[chat] 段不存在时 document.get("chat", {}) 返回的是**游离的 dict**，
+赋值进不了文档，写回去还是原文件——而调用方收到的是"成功"。
+命令因此回复"已添加次级管理员"，重启后列表却空了。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from neobot_app.config import chat_writer
+from neobot_app.config.chat_writer import (
+    ChatConfigWriteResult,
+    normalize_accounts,
+    read_sub_admin_accounts,
+    save_sub_admin_accounts,
+    write_chat_values,
+)
+
+FULL_CONFIG = """version = "0.6.0"
+
+[bot]
+account = 10001
+nick_name = "bot"
+
+[chat]
+# 保留这条注释
+admin_accounts = ["3331347593"]
+sub_admin_accounts = []
+reply_mode = "agent"
+"""
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# 回归：缺 [chat] 段不能再静默失败
+# ---------------------------------------------------------------------------
+
+
+def test_creates_chat_section_when_missing(tmp_path: Path) -> None:
+    path = _write(tmp_path / "config.toml", 'version = "0.6.0"\n\n[bot]\naccount = 10001\n')
+
+    result = save_sub_admin_accounts(path, [88888])
+
+    assert result.ok is True, result.error
+    assert read_sub_admin_accounts(path) == ("88888",)
+    text = path.read_text(encoding="utf-8")
+    assert "[chat]" in text
+    assert "sub_admin_accounts" in text
+
+
+def test_creates_chat_section_in_empty_file(tmp_path: Path) -> None:
+    path = _write(tmp_path / "config.toml", "")
+
+    result = save_sub_admin_accounts(path, [88888])
+
+    assert result.ok is True, result.error
+    assert read_sub_admin_accounts(path) == ("88888",)
+
+
+def test_writes_into_existing_file_without_touching_other_content(tmp_path: Path) -> None:
+    path = _write(tmp_path / "config.toml", FULL_CONFIG)
+
+    result = save_sub_admin_accounts(path, [88888, 77777])
+
+    assert result.ok is True, result.error
+    text = path.read_text(encoding="utf-8")
+    assert "# 保留这条注释" in text
+    assert 'admin_accounts = ["3331347593"]' in text
+    assert 'reply_mode = "agent"' in text
+    assert read_sub_admin_accounts(path) == ("77777", "88888")
+
+
+def test_handles_bom_encoded_file(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(FULL_CONFIG, encoding="utf-8-sig")
+
+    result = save_sub_admin_accounts(path, [88888])
+
+    assert result.ok is True, result.error
+    assert read_sub_admin_accounts(path) == ("88888",)
+
+
+# ---------------------------------------------------------------------------
+# 类型与规范化
+# ---------------------------------------------------------------------------
+
+
+def test_accounts_are_persisted_as_strings(tmp_path: Path) -> None:
+    """schema 是 List[str]：写 int 会被下次启动判成类型不匹配。"""
+    path = _write(tmp_path / "config.toml", FULL_CONFIG)
+
+    assert save_sub_admin_accounts(path, [88888]).ok is True
+
+    text = path.read_text(encoding="utf-8")
+    assert 'sub_admin_accounts = ["88888"]' in text
+
+
+def test_normalize_accounts_sorts_dedupes_and_rejects_garbage() -> None:
+    accounts, error = normalize_accounts(["10002", 10001, "10002", " 10003 "])
+    assert error == ""
+    assert accounts == ("10001", "10002", "10003")
+
+    for bad in ("abc", "10001; rm -rf /", "-1", "1234567890123456789012345"):
+        accounts, error = normalize_accounts([bad])
+        assert error, bad
+        assert accounts == ()
+
+
+def test_invalid_account_leaves_file_untouched(tmp_path: Path) -> None:
+    path = _write(tmp_path / "config.toml", FULL_CONFIG)
+
+    result = save_sub_admin_accounts(path, ["not-a-qq"])
+
+    assert result.ok is False
+    assert "非法" in result.error
+    assert path.read_text(encoding="utf-8") == FULL_CONFIG
+
+
+def test_read_returns_empty_for_missing_or_broken_file(tmp_path: Path) -> None:
+    assert read_sub_admin_accounts(tmp_path / "nope.toml") == ()
+    broken = _write(tmp_path / "broken.toml", "[chat\n")
+    assert read_sub_admin_accounts(broken) == ()
+
+
+# ---------------------------------------------------------------------------
+# 失败必须如实汇报（绝不谎报成功）
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_config_is_rejected_without_overwriting(tmp_path: Path) -> None:
+    path = _write(tmp_path / "config.toml", "[chat\nadmin_accounts = ")
+
+    result = save_sub_admin_accounts(path, [88888])
+
+    assert result.ok is False
+    assert "解析失败" in result.error
+    assert path.read_text(encoding="utf-8") == "[chat\nadmin_accounts = "
+
+
+def test_validation_failure_blocks_write(tmp_path: Path, monkeypatch) -> None:
+    path = _write(tmp_path / "config.toml", FULL_CONFIG)
+
+    def _boom(*args, **kwargs):
+        raise ValueError("schema 不接受这份配置")
+
+    monkeypatch.setattr(chat_writer, "dict_to_dataclass", _boom)
+
+    result = save_sub_admin_accounts(path, [88888])
+
+    assert result.ok is False
+    assert "校验失败" in result.error
+    assert path.read_text(encoding="utf-8") == FULL_CONFIG
+
+
+def test_roundtrip_mismatch_is_reported(tmp_path: Path, monkeypatch) -> None:
+    """写盘后回读不一致时必须报错：这正是旧实现静默失败的形态。"""
+    path = _write(tmp_path / "config.toml", FULL_CONFIG)
+    monkeypatch.setattr(chat_writer, "read_chat_values", lambda *args, **kwargs: {})
+
+    result = save_sub_admin_accounts(path, [88888])
+
+    assert result.ok is False
+    assert "回读不一致" in result.error
+
+
+def test_write_failure_is_reported(tmp_path: Path, monkeypatch) -> None:
+    path = _write(tmp_path / "config.toml", FULL_CONFIG)
+
+    def _boom(*args, **kwargs):
+        raise OSError("磁盘满了")
+
+    monkeypatch.setattr(chat_writer, "_atomic_write", _boom)
+
+    result = save_sub_admin_accounts(path, [88888])
+
+    assert result.ok is False
+    assert "写入配置失败" in result.error
+    assert path.read_text(encoding="utf-8") == FULL_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# 通用 chat 段写回
+# ---------------------------------------------------------------------------
+
+
+def test_write_chat_values_rejects_when_section_is_not_a_table(tmp_path: Path) -> None:
+    path = _write(tmp_path / "config.toml", 'chat = "oops"\n')
+
+    result = write_chat_values(path, {"sub_admin_accounts": ["1"]})
+
+    assert result.ok is False
+    assert "不是表" in result.error
+
+
+def test_write_chat_values_requires_values(tmp_path: Path) -> None:
+    path = _write(tmp_path / "config.toml", FULL_CONFIG)
+
+    result = write_chat_values(path, {})
+
+    assert result.ok is False
+    assert isinstance(result, ChatConfigWriteResult)

--- a/docs/05-配置参考.md
+++ b/docs/05-配置参考.md
@@ -111,8 +111,13 @@ version = "0.6.0"   # 配置文件版本
 | `group_chat_suspend_wait_seconds` | 3600 | 群聊回复后挂起等待秒数；超时无新消息则结束会话 |
 | `enable_balance_check` | false | 是否启用 DeepSeek 余额检查与低余额预警（需配置管理员账户） |
 | `balance_threshold` | 1.0 | 余额预警阈值（CNY），低于此值发送私聊通知 |
-| `admin_accounts` | [] | 管理员 QQ 号列表，用于接收余额不足等系统通知 |
+| `admin_accounts` | [] | **超级管理员** QQ 号列表，用于接收余额不足等系统通知；只能改配置增减，命令不能修改 |
+| `sub_admin_accounts` | [] | **次级管理员** QQ 号列表；超级管理员可用 `/add_admin`、`/del_admin` 增删 |
 | `balance_check_cooldown_seconds` | 300 | 余额检查冷却秒数 |
+
+> `/add_admin`、`/del_admin` 直接改写本文件（写入前备份到 `config_backup/`，写盘后回读校验），
+> 改完立即热重载进内存；若当前进程无法热重载（例如配置加载失败进入待机），命令会提示「重启 NeoBot 后生效」。
+> 写盘失败或回读不一致时命令**如实报错**，不会回复「已添加」却什么都没写进去。
 
 ### 关键词规则（`chat.key_word`）
 


### PR DESCRIPTION
## 问题

`/add_admin` / `/del_admin` 增加的次级管理员**重启 NeoBot 后就没了**，看起来像只写在内存里。

根因在写回路径：`_save_sub_admins` 用 `tomlkit` 直接改文档里的 `chat` 表——

```python
document = tomlkit.parse(CONFIG_FILE.read_text(encoding="utf-8"))
chat = document.get("chat", {})          # [chat] 不存在时是游离的 dict
chat["sub_admin_accounts"] = [...]       # 赋值进不了文档
rendered = tomlkit.dumps(document)       # 写回去还是原文件
```

`[chat]` 段不存在（精简/手写配置、早期版本落下的文件）时，赋值落在游离对象上，
落盘内容**没有任何变化**，而回调仍返回 `"ok"`、命令仍回复「已添加次级管理员」。
用户重启发现在列表是空的。

另外两处同源缺陷：

- 写入的是 `int` 列表，而 schema 是 `List[str]`，会走到「类型不匹配」分支；
- 读取用 `encoding="utf-8"`，带 BOM 的 config.toml 会直接解析失败（本体其它地方用的是 `utf-8-sig`）。

## 修复

**新增 `config/chat_writer.py`：config.toml 的定点写回**

- 缺 `[chat]` 段就在**文档里**创建（不再操作游离对象），其它内容与注释保持不动；
- 值按 schema 类型写入（次级管理员写字符串）；
- **写盘前**先校验这份内容能不能被 `BotConfig` 加载（写出一份加载不了的配置，下次启动会被「补全缺失项」整段重写）；
- **写盘后回读比对**，不一致就返回失败；
- 支持 BOM / 无该段 / 空文件等形态；不接受非数字账号。

**`bootstrap/_commands.py`：回调返回结构化结果**

`ConfigSaveResult(ok, error, accounts, applied, path)` 取代原来的 `"ok"` 字符串：只有磁盘确实写入成功才 `ok=True`；
热重载不可用（例如配置加载失败进入待机）时 `applied=False`，命令提示「重启 NeoBot 后生效」，
而不是把写盘成功报成异常。同一文件里 AI 工具用的 `chat` 系数写回也改用同一套逻辑（同一类静默失败）。

**`commands/builtin.py`：以磁盘回读结果回复**

写盘失败、回读不一致、或回读内容与预期不符时明确报错并给出配置文件路径，
不再出现「回复成功但什么都没发生」。

## 测试

- `app/tests/modules/config/test_admin_accounts.py`：写回器 16 例
  （缺 `[chat]` 段 / 空文件 / BOM / 类型 / 保留其它内容与注释 / 解析失败 / 校验失败 / 回读不一致 / 写盘失败）；
- `app/tests/modules/commands/test_admin_commands.py`：命令级 9 例
  （含「缺 `[chat]` 段」「写盘失败」「回读不一致」三个回归用例，以及重启后持久化与次级管理员权限）；
- 既有 `test_commands.py` 的保存回调适配新契约。

`app` 全量测试 **2675 passed**，`ruff check` 通过。
